### PR TITLE
Adding map-panel now clones current sync'd browser state.

### DIFF
--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -247,7 +247,6 @@ var hic = (function (hic) {
     };
 
     hic.syncBrowsers = function (browsers) {
-
         browsers.forEach(function (b1) {
             if (b1 === undefined) {
                 console.log("Attempt to sync undefined browser");
@@ -874,7 +873,9 @@ var hic = (function (hic) {
 
         function setDataset(dataset) {
 
-            var previousGenomeId = self.genome ? self.genome.id : undefined;
+            var previousGenomeId = self.genome ? self.genome.id : undefined,
+                me,
+                any_other;
 
             self.dataset = dataset;
 
@@ -885,9 +886,15 @@ var hic = (function (hic) {
 
             if (config.state) {
                 self.setState(config.state);
-            }
-            else {
-                self.setState(defaultState.clone());
+            } else {
+
+                if (1 === _.size(hic.allBrowsers)) {
+                    self.setState(defaultState.clone());
+                } else {
+                    me = [ self ];
+                    any_other = _.first(_.difference(hic.allBrowsers, me));
+                    self.setState(any_other.state.clone());
+                }
             }
             self.contactMatrixView.setDataset(dataset);
 


### PR DESCRIPTION
Adding map-panel now clones current sync'd browser state rather then resetting state of all browsers.
