### PR TITLE
Flattened nesting in hicStraw, + more informative errors

### DIFF
--- a/js/hicDataset.js
+++ b/js/hicDataset.js
@@ -236,14 +236,15 @@ var hic = (function (hic) {
         }
         else if (unit === "FRAG") {
             resolutionArray = this.fragResolutions;
+        } else {
+            throw new Error("Invalid unit: " + unit);
         }
-
-        // todo throw error if resolutionArray === undefined
 
         for (i = 0; i < resolutionArray.length; i++) {
             if (resolutionArray[i] === binSize) return i;
         }
 
+        return -1;
     }
 
     hic.Dataset.prototype.getChrIndexFromName = function(chrName) {

--- a/js/hicStraw.js
+++ b/js/hicStraw.js
@@ -93,18 +93,18 @@ var hic = (function (hic) {
             .then(function (blocks) {
                 var contactRecords = [];
 
-                for (let block of blocks) {
+                blocks.forEach(function (block) {
                     if (block === null) { // This is most likely caused by a base pair range outside the chromosome
-                        continue;
+                        return;
                     }
-                    let records = block.records;
-                    for (let rec of records) {
+                    block.records.forEach(function(rec) {
                         // TODO -- transpose?
                         if(rec.bin1 >= x1 && rec.bin1 <= x2 && rec.bin2 >= y1 && rec.bin2 <= y2) {
                             contactRecords.push(rec);
                         }
-                    }
-                }
+                    });
+                });
+                
                 return contactRecords;
             });
     }

--- a/test/testStraw.js
+++ b/test/testStraw.js
@@ -51,7 +51,7 @@ function runStrawTests() {
                 start();
             })
             .catch(function (error) {
-                console.log(error);
+                console.error(error);
                 start();
             })
     });


### PR DESCRIPTION
I've flattened the nested `then` blocks which were impairing readability.  I've also made friendlier errors when:

- a chromosome name could not be found
- the unit (not BP or FRAG) is invalid
- when a invalid bin size is passed.

Finally, base pair ranges that fall outside the chromosome will no longer cause an error, but will be ignored.
