### PR TITLE
SweepZoom magnification now passes minimum res. to browser goto.

### DIFF
--- a/js/contactMatrixView.js
+++ b/js/contactMatrixView.js
@@ -871,7 +871,7 @@ var hic = (function (hic) {
                 isSweepZooming = (true === e.altKey);
                 if (isSweepZooming) {
                     eFixed = $.event.fix(e);
-                    self.sweepZoom.reset({x: eFixed.pageX, y: eFixed.pageY});
+                    self.sweepZoom.initialize({x: eFixed.pageX, y: eFixed.pageY});
                 }
 
                 isMouseDown = true;
@@ -980,7 +980,7 @@ var hic = (function (hic) {
 
                     if (isSweepZooming) {
                         isSweepZooming = false;
-                        self.sweepZoom.dismiss();
+                        self.sweepZoom.commit();
                     }
 
                 }

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -1310,7 +1310,7 @@ var hic = (function (hic) {
 
         targetResolution = Math.max((bpXMax - bpX) / viewDimensions.width, (bpYMax - bpY) / viewDimensions.height);
 
-        if (targetResolution < minResolution) {
+        if (minResolution && targetResolution < minResolution) {
             maxExtent = viewWidth * minResolution;
             xCenter = (bpX + bpXMax) / 2;
             yCenter = (bpY + bpYMax) / 2;

--- a/js/sweepZoom.js
+++ b/js/sweepZoom.js
@@ -95,8 +95,8 @@ var hic = (function (hic) {
             width,
             height,
             xMax,
-            yMax;
-
+            yMax,
+            minimumResolution;
 
         this.$rulerSweeper.hide();
 
@@ -122,7 +122,8 @@ var hic = (function (hic) {
         xMax = x + width;
         yMax = y + height;
 
-        this.browser.goto(state.chr1, x, xMax, state.chr2, y, yMax);
+        minimumResolution = this.browser.dataset.bpResolutions[ this.browser.dataset.bpResolutions.length - 1 ];
+        this.browser.goto(state.chr1, x, xMax, state.chr2, y, yMax, minimumResolution);
 
     };
 

--- a/js/sweepZoom.js
+++ b/js/sweepZoom.js
@@ -38,7 +38,7 @@ var hic = (function (hic) {
         this.sweepRect = {};
     };
 
-    hic.SweepZoom.prototype.reset = function (pageCoords) {
+    hic.SweepZoom.prototype.initialize = function (pageCoords) {
 
         this.anchor = pageCoords;
         this.coordinateFrame = this.$rulerSweeper.parent().offset();
@@ -85,7 +85,7 @@ var hic = (function (hic) {
 
     };
 
-    hic.SweepZoom.prototype.dismiss = function () {
+    hic.SweepZoom.prototype.commit = function () {
         var state,
             resolution,
             posX,


### PR DESCRIPTION
By passing the minimum resolution to browser goto() pixel size is prevented from falling below 1 and magnification is restricted to this value.
