### PR TITLE
Bump hic-straw to v3.0.1

### DIFF
--- a/js/version.js
+++ b/js/version.js
@@ -1,2 +1,2 @@
-const version = "3.3.0"
+const version = "3.4.0"
 export {version}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@vitest/ui": "^4.0.7",
     "atob": "^2.1.2",
     "btoa": "^1.2.1",
-    "hic-straw": "github:aidenlab/hic-straw#v2.2.0",
+    "hic-straw": "github:aidenlab/hic-straw#v3.0.1",
     "igv": "^3.8.0",
     "igv-ui": "github:igvteam/igv-ui#v1.5.9",
     "igv-utils": "github:igvteam/igv-utils#v1.7.1",


### PR DESCRIPTION
## Summary
- Bumps `hic-straw` to `github:aidenlab/hic-straw#v3.0.1`, which in turn picks up `hdf5-indexed-reader@v1.0.3`.
- v1.0.3 of `hdf5-indexed-reader` ships proper `main`/`module`/`exports` metadata, so consumers can resolve the bare import directly. v3.0.1 of `hic-straw` uses that bare import in `swParser.js` instead of the prior dual-path dynamic-import workaround that was forcing Vite to bundle the Node build (and its `node-fetch` chain) into the browser build of juicebox.js.
- Also syncs `js/version.js` with the `3.4.0` bump committed in b11ba24 — the build plugin regenerates this file on every build.

## Background
Attempting to bump `hic-straw` to v3.0.0 broke `npm install` with:

```
node_modules/node-fetch/src/body.js (9:26): "promisify" is not exported by "__vite-browser-external"
```

Root cause: `hic-straw` v3.0.0 used a runtime `isBrowser ? import(esm) : import(node)` ternary because `hdf5-indexed-reader` lacked package metadata for bare resolution. Rollup statically follows both branches, dragging `node-fetch` into the browser bundle, where its `node:util` import fails. Fixed upstream by adding `exports` to `hdf5-indexed-reader` and collapsing the import in `hic-straw`.

Related releases:
- aidenlab/hdf5-indexed-reader@v1.0.3 (new repo home; was previously jrobinso/hdf5-indexed-reader)
- aidenlab/hic-straw@v3.0.1

## Test plan
- [x] `npm install` succeeds (build runs as part of `prepare`).
- [x] `vite build` produces `dist/juicebox.esm.js` and `dist/juicebox.min.js` without errors.
- [x] Smoke-test the dashboard (`npm run dev`) to confirm static `.hic` loading still works.
- [x] Smoke-test the live contact map example in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)