### PR TITLE
Tune auto color-scale threshold for live contact maps

### DIFF
--- a/js/contactMatrixView.js
+++ b/js/contactMatrixView.js
@@ -548,9 +548,14 @@ class ContactMatrixView {
                 const region2 = {chr: zd.chr2.name, start: y0bp, end: y0bp + yWidthInBp}
                 const records = await ds.getContactRecords(normalization, region1, region2, zd.zoom.unit, zd.zoom.binSize, true)
 
-                let s = computePercentile(records, 95)
+                // Live maps emit ensemble contact frequencies bounded in (0, 1];
+                // the .hic heuristics (95th percentile, ×4 for whole-genome) overshoot
+                // that ceiling and leave the +/- threshold buttons with no usable range.
+                const p = ds.isLive ? 75 : 95
+                let s = computePercentile(records, p)
                 if (!isNaN(s)) {  // Can return NaN if all blocks are empty
-                    if (0 === zd.chr1.index) s *= 4   // Heuristic for whole genome view
+                    if (!ds.isLive && 0 === zd.chr1.index) s *= 4   // Heuristic for whole genome view
+                    if (ds.isLive) s = Math.min(s, 1)               // Clamp to frequency ceiling
                     this.colorScale = new ColorScale(this.colorScale)
                     this.colorScale.setThreshold(s)
                     this.computeColorScale = false

--- a/js/hicDataset.js
+++ b/js/hicDataset.js
@@ -222,7 +222,8 @@ class HiCDataset extends Dataset {
     constructor(config) {
         super(config);
         this.straw = new Straw(config)
-        this.datasetType = 'hic';
+        this.isLive = Boolean(config.liveContactMap);
+        this.datasetType = this.isLive ? 'live' : 'hic';
     }
 
     async init() {


### PR DESCRIPTION
## Summary
- Live maps emit ensemble contact frequencies bounded in (0, 1], so the .hic auto-threshold heuristics (95th percentile + ×4 for whole-genome) overshoot the data's ceiling and leave the +/− threshold buttons with no usable range.
- When the dataset is a live contact map, use the 75th percentile, skip the whole-genome ×4 multiplier, and clamp at 1.0.
- Adds an \`isLive\` flag on \`HiCDataset\` (set from \`config.liveContactMap\`) so the rendering path can branch without sniffing record values.

## Test plan
- [x] Load a live contact map; confirm the map renders with visible gradient (not solid background or solid color).
- [x] Click +/− several times; confirm both directions produce visible contrast changes.
- [x] Switch to whole-genome view on a live map; confirm it is not washed out.
- [x] Load a standard .hic file; confirm behavior is unchanged (95th percentile, ×4 whole-genome multiplier still applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)