### PR TITLE
Give the registry a dispose() that evicts it from the container map (#496)

### DIFF
--- a/docs/adr/0003-public-api-contract.md
+++ b/docs/adr/0003-public-api-contract.md
@@ -108,6 +108,26 @@ all** — they exist solely for hosts. Deleting them would not remove a hop; it 
 promote `dataLoader` and `interactions` from internal collaborators to published
 names, freezing the browser's internal decomposition into the contract.
 
+### Browser registry — added since the measurement
+
+The measurement predates the per-container registry, so no row above names one:
+`initRegistry()` and `browser.registry` (ADR-0004, #483 and #479) hand a host an
+object this table never saw. Its declared members live in `REGISTRY_SURFACE` —
+that manifest, not this table, is the current list.
+
+**Added since the measurement:** `registry.dispose` (#496, decisions 7 and 8 of
+ADR-0005), the embed-level counterpart of `browser.dispose` above and of
+`initRegistry`. It disposes every browser the registry owns and then **evicts the
+registry from the container map**, so a host that takes its embed down and later
+calls `hic.init()` on the same element gets a clean registry rather than a dead
+one. Neither known host can be measured using it, for the same reason
+`browser.dispose` cannot: it did not exist when they were measured, and Spacewalk
+removing its Juicebox panel is exactly the case it is for.
+
+Unlike a disposed browser, a disposed *registry* is not fatal — it is simply a
+registry with no browsers, and what a host can observe is that a second `init()`
+on the same container hands back a different object. Nothing here throws.
+
 ### Sub-surfaces reached *through* those members
 
 These are contract too, and are easy to miss because they are one dot further out:

--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -136,7 +136,7 @@ class BrowserRegistry {
      * Tear a browser down and give up its slot.
      *
      * The teardown itself is the browser's -- `dispose()` is the one path, per
-     * ADR-0005 -- and it calls `evict` below on its way out. So this method is
+     * ADR-0005 -- and it calls `releaseSlot` below on its way out. So this method is
      * one line, and `deleteAll` is the same line in a loop: two delete paths
      * that used to disagree about `unsyncSelf` and about the dialog outside
      * `rootElement` now cannot.
@@ -162,6 +162,42 @@ class BrowserRegistry {
         // The postcondition, not the mechanism -- the loop above has already
         // emptied the list one slot at a time.
         this.clear()
+    }
+
+    /**
+     * Tear this embed down: dispose every browser it owns, take down the one
+     * node the registry itself installed, and evict the registry from the
+     * container map. Decisions 7 and 8 of ADR-0005.
+     *
+     * NOTE: public API function
+     *
+     * The counterpart of `initRegistry` the way `browser.dispose()` is the
+     * counterpart of the constructor: a host that is done with an embed --
+     * Spacewalk removing its Juicebox panel -- hands the container back empty.
+     *
+     * Eviction is what makes "dispose, then `hic.init()` the same element"
+     * supported rather than accidental. `registryForContainer` creates lazily,
+     * so the next call in builds a clean registry instead of finding this one.
+     * Decision 8 of ADR-0004 keyed the map by container precisely so a dropped
+     * container drops its registry; this is the explicit form of the same rule.
+     *
+     * Idempotent, for the same reason `browser.dispose()` is: a host that tears
+     * down twice is doing the right thing twice. It is deliberately *not*
+     * fatal, unlike a disposed browser -- a disposed registry is simply one
+     * with no browsers, and what a host can observe is that a second `init()`
+     * on the same container hands back a different object.
+     */
+    dispose() {
+
+        this.deleteAll()
+
+        // The registry's own contribution to the container, and the only node
+        // no browser teardown looks at: an embed whose host raised one alert
+        // would otherwise hand the container back non-empty.
+        this.alertDialog?.container.remove()
+        this.alertDialog = undefined
+
+        evict(this)
     }
 
     /**
@@ -338,6 +374,27 @@ function registryForContainer(container) {
     }
 
     return registry
+}
+
+/**
+ * Drop `registry` from the container map, so the next `registryForContainer`
+ * for the same element builds a new one.
+ *
+ * Internal, and the outbound half of `dispose()`: a registry tears itself down
+ * and evicts itself, rather than something outside reaching into the map.
+ *
+ * The identity check is what keeps `dispose()` idempotent once decision 8's
+ * sequence is taken up: dispose an embed, `init()` the same container again,
+ * and a host still holding the *first* registry can dispose it a second time.
+ * Deleting by container alone would take the live embed's entry with it, and
+ * the next `init()` would silently build a third registry over the second one's
+ * browsers. A registry built without a container -- the tests that exercise one
+ * without a document -- was never in the map, and matches nothing here.
+ */
+function evict(registry) {
+    if (registriesByContainer.get(registry.container) === registry) {
+        registriesByContainer.delete(registry.container)
+    }
 }
 
 function getMostRecentlySelectedBrowser() {

--- a/js/publicApi.js
+++ b/js/publicApi.js
@@ -189,6 +189,11 @@ export const REGISTRY_SURFACE = [
     'delete',
     'deleteAll',
     'updateAll',
+    // The embed-level teardown, new in #496, and the counterpart of
+    // `initRegistry` the way `browser.dispose` is the counterpart of the
+    // constructor. Declared for the same reason that one is. Decisions 7 and 8
+    // of ADR-0005.
+    'dispose',
 
     // The sync group's membership rule, over this registry's browsers by
     // default. Decision 6.

--- a/test/testRegistryDispose.js
+++ b/test/testRegistryDispose.js
@@ -1,0 +1,189 @@
+import {describe, it, expect} from 'vitest'
+import {JSDOM} from 'jsdom'
+
+/**
+ * igv-ui builds its DOMPurify at import time, from whatever `window` is then,
+ * and `test/setup.js` installs a hand-rolled mock. Priming a real window before
+ * the dynamic imports below is what lets one of these tests raise a real alert
+ * through a real dialog -- the same dance, and for the same reason, as
+ * `test/testEmbedScoping.js`.
+ */
+const priming = new JSDOM('<!doctype html><html><body></body></html>')
+const mockedWindow = globalThis.window
+const mockedDocument = globalThis.document
+globalThis.window = priming.window
+globalThis.document = priming.window.document
+
+const {default: BrowserRegistry, registryForContainer} = await import('../js/browserRegistry.js')
+const {initRegistry} = await import('../js/init.js')
+const {default: juicebox} = await import('../js/index.js')
+const {default: HICBrowser} = await import('../js/hicBrowser.js')
+const {withContainers} = await import('./utils/browserFixture.js')
+const {withStubbedLoads} = await import('./utils/stubbedLoads.js')
+const {REGISTRY_SURFACE} = await import('../js/publicApi.js')
+
+globalThis.window = mockedWindow
+globalThis.document = mockedDocument
+
+/**
+ * Registry teardown -- #496, decisions 7 and 8 of ADR-0005.
+ *
+ * `browser.dispose()` gives a host a way to take one panel down. This is the
+ * other half: a host that is done with the whole embed -- Spacewalk removing
+ * its Juicebox panel -- takes the container back. Two claims, and the second is
+ * the one that is easy to leave out:
+ *
+ * 1. Every browser goes, and the container is *empty* -- not "empty of roots".
+ *    The registry installs a node in the container itself, its own alert
+ *    dialog, and a teardown that counts only browsers leaves it behind.
+ * 2. The registry evicts itself from the container map, so `hic.init()` on the
+ *    same element afterwards builds into a clean registry rather than a dead
+ *    one. `registryForContainer` creates lazily, which is what makes eviction
+ *    sufficient.
+ *
+ * Every test stands up two containers where the claim is about scope: a
+ * single-embed assertion would pass against a teardown that took the page down.
+ */
+
+const config = url => ({url, queryParametersSupported: false})
+
+const session = (...urls) => ({browsers: urls.map(url => ({url})), queryParametersSupported: false})
+
+describe('BrowserRegistry.dispose', () => {
+
+    const dom = withContainers()
+    withStubbedLoads()
+
+    it('disposes every browser it owns', async () => {
+        const registry = await initRegistry(dom.container, session('https://example.com/a.hic', 'https://example.com/b.hic'))
+        const browsers = [...registry.browsers]
+
+        registry.dispose()
+
+        expect(registry.browsers).toEqual([])
+        expect(registry.currentBrowser).toBeUndefined()
+        expect(browsers.some(browser => browser.rootElement.isConnected)).toBe(false)
+        // Disposed, not merely delisted: a published call on one now throws.
+        expect(() => browsers[0].reset()).toThrow()
+    })
+
+    it('leaves its container empty', async () => {
+        const registry = await initRegistry(dom.container, session('https://example.com/a.hic', 'https://example.com/b.hic'))
+
+        registry.dispose()
+
+        expect(dom.container.children.length).toBe(0)
+    })
+
+    it('takes its own alert dialog down with it', async () => {
+        // The registry's contribution to the container, and the reason the
+        // assertion above counts children rather than browsers: nothing in the
+        // browser teardown path looks at this node.
+        const registry = await initRegistry(dom.container, config('https://example.com/a.hic'))
+        registry.presentAlert('boom')
+        const dialog = registry.alertDialog.container
+
+        expect(dialog.isConnected).toBe(true)
+
+        registry.dispose()
+
+        expect(dialog.isConnected).toBe(false)
+        expect(dom.container.children.length).toBe(0)
+    })
+
+    it('leaves an empty container empty', () => {
+        const registry = registryForContainer(dom.container)
+
+        expect(() => registry.dispose()).not.toThrow()
+        expect(dom.container.children.length).toBe(0)
+    })
+
+    it('is idempotent', async () => {
+        const registry = await initRegistry(dom.container, config('https://example.com/a.hic'))
+
+        registry.dispose()
+
+        expect(() => registry.dispose()).not.toThrow()
+        expect(registry.browsers).toEqual([])
+    })
+
+    it('leaves a second embed on the page untouched', async () => {
+        const mine = await initRegistry(dom.container, session('https://example.com/a.hic', 'https://example.com/b.hic'))
+        const theirs = await initRegistry(dom.another(), config('https://example.com/c.hic'))
+        const survivor = theirs.browsers[0]
+
+        mine.dispose()
+
+        expect(theirs.browsers).toEqual([survivor])
+        expect(theirs.currentBrowser).toBe(survivor)
+        expect(survivor.rootElement.isConnected).toBe(true)
+        expect(theirs.container.children.length).toBeGreaterThan(0)
+        // And the surviving embed still has *its* registry: eviction is keyed
+        // by container, so disposing one must not clear the map.
+        expect(registryForContainer(theirs.container)).toBe(theirs)
+    })
+})
+
+describe('a container whose registry has been disposed', () => {
+
+    const dom = withContainers()
+    withStubbedLoads()
+
+    it('resolves to a different registry instance', async () => {
+        const disposed = await initRegistry(dom.container, config('https://example.com/a.hic'))
+
+        disposed.dispose()
+
+        const fresh = registryForContainer(dom.container)
+        expect(fresh).toBeInstanceOf(BrowserRegistry)
+        expect(fresh).not.toBe(disposed)
+        expect(fresh.container).toBe(dom.container)
+        expect(fresh.browsers).toEqual([])
+    })
+
+    it('yields a working embed when init() is called on it again', async () => {
+        // The sequence decision 8 makes supported rather than accidental: a
+        // host disposes its embed, and later initializes the same element.
+        // Reached through the published namespace, because that is the door the
+        // criterion names -- a host writes `hic.init(container, config)`.
+        const disposed = await initRegistry(dom.container, config('https://example.com/a.hic'))
+        disposed.dispose()
+
+        const browser = await juicebox.init(dom.container, config('https://example.com/b.hic'))
+
+        expect(browser).toBeInstanceOf(HICBrowser)
+        expect(browser.dataset.url).toBe('https://example.com/b.hic')
+        expect(browser.rootElement.isConnected).toBe(true)
+        expect(browser.registry).not.toBe(disposed)
+        expect(browser.registry).toBe(registryForContainer(dom.container))
+        expect(browser.registry.browsers).toEqual([browser])
+        expect(browser.registry.currentBrowser).toBe(browser)
+    })
+
+    it('keeps the re-initialized embed when a stale handle is disposed again', async () => {
+        // The sequence decision 8 opens up: dispose, init the same container,
+        // and a host still holding the *first* registry tears it down twice.
+        // Eviction keyed by container alone would take the live embed's map
+        // entry with it, and the next init() would build a third registry over
+        // the second one's browsers -- silently, since nothing else reads it.
+        const stale = await initRegistry(dom.container, config('https://example.com/a.hic'))
+        stale.dispose()
+
+        const live = await initRegistry(dom.container, config('https://example.com/b.hic'))
+        stale.dispose()
+
+        expect(registryForContainer(dom.container)).toBe(live)
+        expect(live.browsers).toHaveLength(1)
+        expect(live.browsers[0].rootElement.isConnected).toBe(true)
+    })
+})
+
+describe('the declared registry surface', () => {
+
+    it('names dispose', () => {
+        // Declared deliberately rather than discovered later: per ADR-0003's
+        // "absence is not permission" a reachable member is contract the moment
+        // it ships. Decision 7 of ADR-0005.
+        expect(REGISTRY_SURFACE).toContain('dispose')
+    })
+})


### PR DESCRIPTION
Closes #496. Candidate 8, decisions 7 and 8 of `docs/adr/0005-browser-teardown-contract.md`.

## What this does

`browser.dispose()` (#493) takes one panel down. This is the other half: a host done with an embed — Spacewalk removing its Juicebox panel — calls `registry.dispose()` and gets the container back empty. Every browser it owns is disposed, and so is the registry's own alert dialog, the one node in the container no browser teardown looks at.

Then the registry **evicts itself from the container `WeakMap`**. `registryForContainer` creates lazily, so dispose-then-`hic.init()` on the same element builds into a clean registry rather than a dead one — the explicit form of the rule ADR-0004 decision 8 keyed the map by container for.

## The one non-obvious bit

Eviction is **identity-checked**. The sequence decision 8 opens up is: dispose, `init()` the same container, and a host still holding the *first* registry disposes it again. Deleting by container alone would take the live embed's map entry with it, and the next `init()` would build a third registry over the second one's browsers — silently, since nothing else reads that map. `test/testRegistryDispose.js` pins it; the test fails without the guard.

## Acceptance criteria

- [x] `registry.dispose()` disposes every browser it owns and leaves its container empty
- [x] After disposing, `hic.init()` on the same container yields a working embed backed by a different registry instance — driven through the published namespace, since that is the door the criterion names
- [x] Disposing one embed leaves a second embed on the page untouched — two containers in the test
- [x] `registry.dispose` declared in `js/publicApi.js`
- [x] `docs/adr/0003-public-api-contract.md` updated for both new members
- [x] Existing suite green — 497 tests, 32 files

## Notes for the reviewer

- **ADR-0003 gets prose, not table rows.** The table measures what hosts *use*, and no host can be measured using a method that did not exist when they were measured. `browser.dispose` set that precedent in #493; `registry.dispose` follows it, in a new "Browser registry — added since the measurement" section.
- **A disposed registry is not fatal**, unlike a disposed browser. It is simply a registry with no browsers; what a host observes is that a second `init()` hands back a different object. Nothing added throws.
- **Known duplication, deliberately left:** the JSDOM priming preamble in the new test file is a second verbatim copy of the one in `test/testEmbedScoping.js` (igv-ui builds its DOMPurify at import time). Hoisting it into `test/utils/browserFixture.js` is the right fix and is surgery on the shared fixture, so it is not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)