### PR TITLE
Enforce chr1 ≤ chr2 in the state chokepoint (#499)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,21 @@ and unambiguously specify the view: `chr1`, `chr2`, `x`, `y`, `zoom`,
 `pixelSize`, `normalization`. Everything else the user sees is derived from
 these. See `docs/state-manipulation.md`.
 
+**Axis ordering** — the invariant `chr1 ≤ chr2`, part of what makes canonical
+state *unambiguous*. A `.hic` file stores one triangle of a symmetric matrix, so
+an x-axis of chr5 against a y-axis of chr2 is the same view as its transpose,
+not a second one. A state naming the axes in the other order is a second
+spelling of a view that already has one, which is why the ordering is an
+invariant rather than a convention — see `docs/adr/0006`.
+
+Enforced in **`setView`**, the chokepoint: it receives both chromosomes and both
+origins together, so when handed an unordered pair it transposes all four
+atomically. Callers — including the translators — never order their arguments;
+they inherit the invariant by delegating. The `State` constructor transposes too,
+as belt-and-braces for states arriving from outside the chokepoint (a decoded
+session, a pasted URL); on canonical state that transposition is a no-op, which
+is what makes save → restore the identity.
+
 **Projection** — anything derived from canonical state on read rather than
 stored. The **locus** is the important one: chromosome BP coordinates computed
 via `state.getLocus(dataset, viewDimensions)`, never stored, because view

--- a/docs/state-manipulation.md
+++ b/docs/state-manipulation.md
@@ -8,7 +8,7 @@ This document catalogs every way the browser's `State` can be mutated. It exists
 
 | Field | Meaning |
 |---|---|
-| `chr1` | Chromosome index, x axis |
+| `chr1` | Chromosome index, x axis — always `≤ chr2` (see *axis ordering* below) |
 | `chr2` | Chromosome index, y axis |
 | `x` | Bin position, x axis |
 | `y` | Bin position, y axis |
@@ -32,7 +32,10 @@ async state.setView(chr1, chr2, x, y, zoom, pixelSize,
 
 `setView` is the only place that:
 
-- Detects whether `chr1`/`chr2` or `zoom` changed (against pre-mutation state).
+- Enforces **axis ordering** — `chr1 ≤ chr2`, transposing `chr1↔chr2` and `x↔y` together
+  when handed an unordered pair. See below.
+- Detects whether `chr1`/`chr2` or `zoom` changed (against pre-mutation state, and
+  against the *ordered* pair — a transposed re-set reports no change).
 - Adjusts `pixelSize` through the standard floor-and-cap pipeline (`Math.max(1, x)` → floor by `minPixelSize` → `Math.min(MAX_PIXEL_SIZE, x)`).
 - Mutates the canonical fields in a fixed order.
 - Optionally clamps `x`/`y` to chromosome bounds.
@@ -46,11 +49,17 @@ async state.setView(chr1, chr2, x, y, zoom, pixelSize,
 | `clampXY` | `true` | Whether to clamp `x`/`y` to chromosome bounds after mutation. `updateWithLoci` sets this `false` (it has historically not clamped). |
 | `adjustPixelSize` | `true` | Whether to run `pixelSize` through `_adjustPixelSize`. Pan paths set this `false`: panning never alters pixelSize, including by implicit floor. Translators that have already computed the final `pixelSize` themselves also set this `false`. |
 
-### Invariant
+### Invariants
 
-> **No code outside `js/hicState.js` should mutate state fields directly.**
+> **1. No code outside `js/hicState.js` should mutate state fields directly.**
 
 Every external caller goes through a translator (below), which itself goes through `setView`. This invariant is what makes locus-related bugs tractable to debug — there is exactly one place to look when state diverges from intent.
+
+> **2. `chr1 ≤ chr2` — axis ordering.**
+
+A `.hic` file stores one triangle of a symmetric matrix, so an x-axis of chr5 against a y-axis of chr2 is the same view as its transpose, not a second one. `setView` receives both chromosomes and both origins together and so transposes all four atomically; translators pass their pair through unordered and inherit the invariant. The `State` constructor transposes too, as belt-and-braces for states arriving from outside the chokepoint (a decoded session, a pasted URL).
+
+Where a translator's own arithmetic depends on which chromosome sits on which axis — `updateWithLoci`'s zoom fit, `setChromosomesView`'s `minZoom`/`minPixelSize` lookups, both of which weigh one axis against the view width and the other against its height — it orders locally *for that computation only*, and still hands `setView` the caller's pair. See ADR-0006 decision 3 and #499.
 
 ## Translators on `State`
 

--- a/js/hicState.js
+++ b/js/hicState.js
@@ -328,22 +328,31 @@ class State {
      * In both cases x and y are reset to 0.
      */
     async setChromosomesView(chr1Index, chr2Index, wholeChr, browser, dataset, viewDimensions) {
-        const newChr1 = Math.min(chr1Index, chr2Index)
-        const newChr2 = Math.max(chr1Index, chr2Index)
+        // State-level ordering is setView's job now (ADR-0006 decision 3) — this
+        // translator passes the caller's pair through untouched, and x/y are both 0
+        // so it has no origins of its own to keep in step.
+        //
+        // The ordered pair survives for the two lookups below, which are genuinely
+        // order-sensitive: minZoom maxes chr1 against the view width and chr2 against
+        // its height (they differ on a non-square viewport), and hic-straw caches
+        // matrices under the pre-transposition key, so an unordered call re-reads a
+        // matrix it already holds.
+        const lookupChr1 = Math.min(chr1Index, chr2Index)
+        const lookupChr2 = Math.max(chr1Index, chr2Index)
 
         let newZoom, newPixelSize
         if (wholeChr) {
-            newZoom = await browser.minZoom(newChr1, newChr2)
-            const minPS = await browser.minPixelSize(newChr1, newChr2, newZoom)
+            newZoom = await browser.minZoom(lookupChr1, lookupChr2)
+            const minPS = await browser.minPixelSize(lookupChr1, lookupChr2, newZoom)
             newPixelSize = Math.min(100, Math.max(DEFAULT_PIXEL_SIZE, minPS))
         } else {
             newZoom = 0
-            const minPS = await browser.minPixelSize(newChr1, newChr2, newZoom)
+            const minPS = await browser.minPixelSize(lookupChr1, lookupChr2, newZoom)
             newPixelSize = Math.max(this.pixelSize, minPS)
         }
 
         return await this.setView(
-            newChr1, newChr2, 0, 0, newZoom, newPixelSize,
+            chr1Index, chr2Index, 0, 0, newZoom, newPixelSize,
             browser, dataset, viewDimensions,
             { adjustPixelSize: false, clampXY: true },
         )

--- a/js/hicState.js
+++ b/js/hicState.js
@@ -48,6 +48,11 @@ import {DEFAULT_PIXEL_SIZE, MAX_PIXEL_SIZE} from "./hicBrowser.js"
  * - No code outside this file should mutate state fields directly. Everything is
  *   a translator-then-setView chain.
  * - locus reads always go through getLocus(); state.locus does not exist.
+ * - chr1 <= chr2 (axis ordering). A .hic file stores one triangle of a symmetric
+ *   matrix, so an unordered pair is a second spelling of a view that already has
+ *   one. setView enforces it, transposing chr1/chr2 and x/y together; translators
+ *   inherit it by delegating. The constructor transposes too, for states arriving
+ *   from outside the chokepoint. See ADR-0006 decision 3.
  */
 class State {
 
@@ -297,14 +302,23 @@ class State {
 
     async updateWithLoci(chr1Name, bpX, bpXMax, chr2Name, bpY, bpYMax, browser, width, height) {
         const bpResolutions = browser.getResolutions()
-        const bpPerPixelTarget = Math.max((bpXMax - bpX) / width, (bpYMax - bpY) / height)
+
+        const { index: chr1Index } = browser.genome.getChromosome(chr1Name)
+        const { index: chr2Index } = browser.genome.getChromosome(chr2Name)
+
+        // The fit weighs one BP range against the view width and the other against its
+        // height, so it must be computed against the axis assignment the state will
+        // actually end up with — and setView orders the pair. Ordering here is for this
+        // computation only; setView still receives the caller's pair and does the swap.
+        const [fitRangeX, fitRangeY] = chr1Index <= chr2Index
+            ? [bpXMax - bpX, bpYMax - bpY]
+            : [bpYMax - bpY, bpXMax - bpX]
+
+        const bpPerPixelTarget = Math.max(fitRangeX / width, fitRangeY / height)
         const zoomNew = (true === browser.resolutionLocked)
             ? this.zoom
             : browser.findMatchingZoomIndex(bpPerPixelTarget, bpResolutions)
         const { binSize: binSizeNew } = bpResolutions[zoomNew]
-
-        const { index: chr1Index } = browser.genome.getChromosome(chr1Name)
-        const { index: chr2Index } = browser.genome.getChromosome(chr2Name)
 
         return await this.setView(
             chr1Index, chr2Index,
@@ -334,9 +348,9 @@ class State {
         //
         // The ordered pair survives for the two lookups below, which are genuinely
         // order-sensitive: minZoom maxes chr1 against the view width and chr2 against
-        // its height (they differ on a non-square viewport), and hic-straw caches
-        // matrices under the pre-transposition key, so an unordered call re-reads a
-        // matrix it already holds.
+        // its height, and those differ on a non-square viewport. Since setView will
+        // order the pair anyway, fitting against the caller's order would size the view
+        // for an axis pairing the state is not going to have.
         const lookupChr1 = Math.min(chr1Index, chr2Index)
         const lookupChr2 = Math.max(chr1Index, chr2Index)
 

--- a/js/hicState.js
+++ b/js/hicState.js
@@ -141,11 +141,13 @@ class State {
      * domain-specific inputs (BP loci, dx/dy deltas, anchor pixels, peer-sync targets)
      * into these.
      *
-     * @param {number} chr1 - Chromosome 1 index. Caller is responsible for ordering
-     *                        (chr1 <= chr2) when that matters.
+     * @param {number} chr1 - Chromosome 1 index. Ordering is NOT the caller's
+     *                        responsibility: setView enforces the chr1 <= chr2
+     *                        invariant itself, transposing the pair when handed an
+     *                        unordered one.
      * @param {number} chr2 - Chromosome 2 index.
-     * @param {number} x - Bin position on x axis.
-     * @param {number} y - Bin position on y axis.
+     * @param {number} x - Bin position on the chr1 axis.
+     * @param {number} y - Bin position on the chr2 axis.
      * @param {number} zoom - Zoom level (index into bpResolutions).
      * @param {number} [pixelSize] - Target pixelSize. May be undefined when
      *                               options.useDefaultMin is true (DEFAULT_PIXEL_SIZE
@@ -168,6 +170,16 @@ class State {
      */
     async setView(chr1, chr2, x, y, zoom, pixelSize, browser, dataset, viewDimensions, options = {}) {
         const { useDefaultMin = false, minPixelSize, clampXY = true, adjustPixelSize = true } = options;
+
+        // Axis ordering (ADR-0006 decision 3). A .hic file stores one triangle of a
+        // symmetric matrix, so an unordered pair names a view that already has a
+        // canonical spelling. Transpose it here — the one place that receives both
+        // chromosomes and both origins together, and so can swap all four atomically.
+        // Every translator inherits the invariant by delegating here.
+        if (chr1 > chr2) {
+            [chr1, chr2] = [chr2, chr1];
+            [x, y] = [y, x];
+        }
 
         const chrChanged = this._detectChromosomeChange(chr1, chr2);
         const resolutionChanged = this._detectResolutionChange(zoom);

--- a/test/testState.js
+++ b/test/testState.js
@@ -976,3 +976,106 @@ describe('InteractionHandler.setChromosomes — inline-mutation path', () => {
         expect(browser.state.pixelSize).toBe(9)
     })
 })
+
+/**
+ * Axis ordering (#499, ADR-0006 decision 3).
+ *
+ * A .hic file stores one triangle of a symmetric matrix, so (chr5, chr2) is the same
+ * view as (chr2, chr5) — not a second one. chr1 <= chr2 is therefore an invariant of
+ * canonical state, enforced at the chokepoint where all four fields (both chromosomes
+ * and both origins) arrive together and can be swapped atomically.
+ */
+describe('Axis ordering — chr1 <= chr2 is enforced in setView', () => {
+    test('unordered chromosome pair is transposed, swapping x with y', async () => {
+        const browser = createMockBrowser()
+        const dataset = createMockDataset()
+        const state = createState({ chr1: 1, chr2: 1, zoom: 3, x: 0, y: 0, pixelSize: 1 })
+
+        // x-axis chr3, y-axis chr1 — the unordered spelling.
+        await state.setView(3, 1, 50, 75, 4, 6, browser, dataset, DEFAULT_VIEW_DIMENSIONS, {
+            clampXY: false,
+        })
+
+        expect(state.chr1).toBe(1)
+        expect(state.chr2).toBe(3)
+        // The origins travel with their chromosomes: chr1's origin was 75, chr3's was 50.
+        expect(state.x).toBe(75)
+        expect(state.y).toBe(50)
+    })
+
+    test('an already-ordered pair is left alone', async () => {
+        const browser = createMockBrowser()
+        const dataset = createMockDataset()
+        const state = createState({ chr1: 0, chr2: 0, zoom: 0, x: 0, y: 0, pixelSize: 1 })
+
+        await state.setView(1, 3, 50, 75, 4, 6, browser, dataset, DEFAULT_VIEW_DIMENSIONS, {
+            clampXY: false,
+        })
+
+        expect(state.chr1).toBe(1)
+        expect(state.chr2).toBe(3)
+        expect(state.x).toBe(50)
+        expect(state.y).toBe(75)
+    })
+
+    test('chrChanged compares the ordered pair, so a transposed re-set reports no change', async () => {
+        const browser = createMockBrowser()
+        const dataset = createMockDataset()
+        const state = createState({ chr1: 1, chr2: 3, zoom: 3, x: 0, y: 0, pixelSize: 1 })
+
+        const result = await state.setView(3, 1, 0, 0, 3, 1, browser, dataset, DEFAULT_VIEW_DIMENSIONS)
+
+        expect(result).toEqual({ chrChanged: false, resolutionChanged: false })
+    })
+
+    test('clamping uses the post-swap chromosomes', async () => {
+        const browser = createMockBrowser()
+        const dataset = createMockDataset()
+        const state = createState({ chr1: 1, chr2: 1 })
+
+        // Ask for x-axis chr3 (200M), y-axis chr1 (250M), both origins past the end.
+        await state.setView(3, 1, 999_999, 999_999, 3, 1, browser, dataset, DEFAULT_VIEW_DIMENSIONS)
+
+        // Post-swap: chr1=1 (250M -> 1000 bins, maxX = 1000 - 800 = 200),
+        //            chr2=3 (200M -> 800 bins,  maxY = 800 - 800 = 0).
+        expect(state.chr1).toBe(1)
+        expect(state.chr2).toBe(3)
+        expect(state.x).toBe(200)
+        expect(state.y).toBe(0)
+    })
+
+    test('translators inherit the invariant — updateWithLoci needs no fix of its own', async () => {
+        const browser = createMockBrowser({ findMatchingZoomIndex: () => 4 })
+        const dataset = createMockDataset()
+        const state = createState({ chr1: 1, chr2: 1, zoom: 3, x: 0, y: 0, pixelSize: 2 })
+
+        // goto() with the y-axis chromosome below the x-axis's: x-axis chr3, y-axis chr1.
+        await state.updateWithLoci('chr3', 1_000_000, 9_000_000, 'chr1', 2_000_000, 10_000_000, browser, 800, 800)
+
+        expect(state.chr1).toBe(1)
+        expect(state.chr2).toBe(3)
+
+        // Same view, spelled canonically: the requested chr1 locus is now the x axis.
+        const locus = state.getLocus(dataset, DEFAULT_VIEW_DIMENSIONS)
+        expect(locus.x.chr).toBe('chr1')
+        expect(locus.x.start).toBe(2_000_000)
+        expect(locus.y.chr).toBe('chr3')
+        expect(locus.y.start).toBe(1_000_000)
+    })
+
+    test('save -> restore is the identity for a view reached by an unordered goto', async () => {
+        const browser = createMockBrowser({ findMatchingZoomIndex: () => 4 })
+        const dataset = createMockDataset()
+        const state = createState({ chr1: 1, chr2: 1, zoom: 3, x: 0, y: 0, pixelSize: 2 })
+
+        await state.updateWithLoci('chr3', 1_000_000, 9_000_000, 'chr1', 2_000_000, 10_000_000, browser, 800, 800)
+
+        const restored = State.fromJSON(JSON.parse(JSON.stringify(state.toJSON())))
+
+        // The constructor's transposition is a no-op on canonical state, so the second
+        // render matches the first.
+        expect(restored.toJSON()).toEqual(state.toJSON())
+        expect(restored.getLocus(dataset, DEFAULT_VIEW_DIMENSIONS))
+            .toEqual(state.getLocus(dataset, DEFAULT_VIEW_DIMENSIONS))
+    })
+})

--- a/test/testState.js
+++ b/test/testState.js
@@ -1063,6 +1063,23 @@ describe('Axis ordering — chr1 <= chr2 is enforced in setView', () => {
         expect(locus.y.start).toBe(1_000_000)
     })
 
+    test('the zoom fit is computed against the axes the state ends up with', async () => {
+        // On a non-square viewport the fit weighs one range against the width and the
+        // other against the height, so it has to know which chromosome lands on which
+        // axis. An unordered goto must produce the same canonical state as the ordered
+        // spelling of the same view.
+        const browser = createMockBrowser()
+        const viewport = { width: 800, height: 400 }
+
+        const unordered = createState({ chr1: 1, chr2: 1, zoom: 3, x: 0, y: 0, pixelSize: 2 })
+        await unordered.updateWithLoci('chr3', 0, 8_000_000, 'chr1', 0, 40_000_000, browser, viewport.width, viewport.height)
+
+        const ordered = createState({ chr1: 1, chr2: 1, zoom: 3, x: 0, y: 0, pixelSize: 2 })
+        await ordered.updateWithLoci('chr1', 0, 40_000_000, 'chr3', 0, 8_000_000, browser, viewport.width, viewport.height)
+
+        expect(unordered.toJSON()).toEqual(ordered.toJSON())
+    })
+
     test('save -> restore is the identity for a view reached by an unordered goto', async () => {
         const browser = createMockBrowser({ findMatchingZoomIndex: () => 4 })
         const dataset = createMockDataset()


### PR DESCRIPTION
Closes #499. Implements ADR-0006 decision 3 — the first of the three fixes that precede the candidate 5 decoder collapse.

## The bug

A `.hic` file stores one triangle of a symmetric matrix, so an x-axis of chr5 against a y-axis of chr2 is the same view as its transpose, not a second one. The `State` constructor already took this literally; `setView`, the declared chokepoint, assigned whatever it was handed.

That was a live bug with no session involved. `goto()` with a y-axis chromosome index below the x-axis's left a state the constructor would have rejected: it rendered one way and reloaded transposed — same contacts, axes flipped about the diagonal, the user's view moved. The new `save -> restore is the identity` test fails on `master` with exactly that, saving `chr1: 3, chr2: 1` and restoring `chr1: 1, chr2: 3`.

## The fix

`setView` receives both chromosomes and both origins together, so it swaps all four atomically. Every translator inherits the invariant by delegating; no caller outside `js/hicState.js` learns about the ordering.

## Commits

1. **45ea251** — the chokepoint fix, seven tests, the `CONTEXT.md` entry.
2. **ec643ef** — `setChromosomesView` stops ordering the pair it hands to `setView`.
3. **418a332** — review fixes.

## Two deviations from ADR-0006 decision 3

Discussed in more detail [on the issue](https://github.com/aidenlab/juicebox.js/issues/499#issuecomment-5231617776).

**The ADR says `setChromosomesView`'s `Math.min`/`Math.max` "becomes redundant and is deleted."** It is redundant *for the state*, and that part is gone. But `browser.minZoom` computes `max(chr1.size / width, chr2.size / height)`, which is order-sensitive on a non-square viewport, so a plain deletion would have been a silent regression. The ordered pair survives, renamed `lookupChr1`/`lookupChr2`, as arguments to `minZoom`/`minPixelSize` only.

**The ADR has `updateWithLoci` swapping `x` with `y`.** It does not need to — it inherits that. It needed a different fix: its zoom fit, `max(xRange / width, yRange / height)`, ran *before* delegating, so on a non-square viewport an unordered `goto` and the ordered spelling of the same view landed on **different zoom levels**. Caught by `/code-review`, fixed, covered by a test at 800×400.

The pattern behind both: a translator orders locally when its own arithmetic weighs one axis against the view width and the other against its height, and never for the state. Written down in `docs/state-manipulation.md` under Invariants.

## Verification

- 504 tests green (8 new in `test/testState.js`), `npm run build` clean.
- The pre-existing `sorts chr1 <= chr2 even when input order is reversed` test stays green through commit 2 — it now proves `setView` does the ordering.

## Not in scope

`State.default()`'s dropped argument (`hicState.js`), which the ADR files separately. The uncommitted ADR-0006 doc work in the working tree (`CONTEXT.md` wire-format entries, the punch list, the ADR itself) is left for its own commit — this branch carries only the axis-ordering hunk of `CONTEXT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)