### PR TITLE
An empty browser leaves the session instead of corrupting it (#500)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -119,6 +119,13 @@ zero-argument getters use. The only part of a session no registry owns is the
 **caption**, a single `#hic-caption` element outside every container that two
 embeds share.
 
+**Empty browser** — a browser panel with no dataset, the normal transient state
+while a user is partway through adding a map. It serializes to `null` and the
+registry drops it, so it is absent from the session rather than present as a
+browser naming no map. **Accepted asymmetry:** browser *count* does not survive
+the round trip when one of them is empty — an embed saved with an empty panel
+open restores one panel short. ADR-0006 decision 6.
+
 **Wire format** — the serialized spelling of a session, as distinct from the
 session itself. It is a contract with *users*, not just with host apps: a link
 pasted into mail or a paper years ago must still decode. Two versions are

--- a/dev/encode-dev-proxy.html
+++ b/dev/encode-dev-proxy.html
@@ -249,8 +249,10 @@
 
             // The constraint that makes this more than a load: toJSON copies config URLs verbatim,
             // so a config-time rewrite would bake a dev-server path into every saved session.
+            // A browser with no map serializes to null (#500), which is what this reads if the
+            // probe is run before a map has loaded -- no tracks, hence no urls to check.
             const session = browser.toJSON()
-            const sessionUrls = (session.tracks || []).map(t => t.url)
+            const sessionUrls = (session?.tracks || []).map(t => t.url)
             const leaked = sessionUrls.filter(url => typeof url === 'string' && url.includes(PROXY_PREFIX))
             const bothSerialized = sessionUrls.includes(ENCODE_BIGWIG_URL) && sessionUrls.includes(ENCODE_BEDPE_URL)
 

--- a/docs/architecture-review.html
+++ b/docs/architecture-review.html
@@ -1103,6 +1103,7 @@ flowchart TB
           <div class="rounded-lg border border-red-300 bg-red-50 p-4 text-sm space-y-1">
             <div class="font-semibold text-red-900"><span class="font-mono">browser.toJSON()</span> returns the string <span class="font-mono">"{}"</span>, not an object</div>
             <p class="text-slate-700"><span class="font-mono">hicBrowser.js:903</span> — when a browser has no dataset. <span class="font-mono">session.js:11</span> pushes it into the <span class="font-mono">browsers</span> array, and on restore <span class="font-mono">setDefaults</span> assigns properties to a string primitive. Saving a session while any browser is empty produces a session that cannot be reloaded.</p>
+            <p class="text-slate-700"><strong>Fixed — #500</strong>, per ADR-0006 decision 6. An empty browser serializes to <span class="font-mono">null</span> and the registry filters it out. Accepted asymmetry: browser <em>count</em> does not survive the round trip when one of them is empty.</p>
           </div>
           <div class="rounded-lg border border-red-300 bg-red-50 p-4 text-sm space-y-1">
             <div class="font-semibold text-red-900"><span class="font-mono">expandURL</span> repairs only the first brace pair — candidate cause of #283</div>

--- a/docs/juicebox-punch-list.md
+++ b/docs/juicebox-punch-list.md
@@ -60,7 +60,7 @@ carries a Consumer impact block; read it before filing anything.
 
 | Candidate | Status |
 |---|---|
-| **5 · One decoder for session and URL** | **ADR-0006 + tickets #499–#509 filed** — start at #499, #500, #501, #502 |
+| **5 · One decoder for session and URL** | **ADR-0006 + tickets #499–#509 filed** — #499 and #500 landed; next up #501, #502 |
 | **11 · Give the track tile one owner** | ⚠️ breaking |
 | **6 · Fold StateManager into State, and make restore use the chokepoint** | watch |
 | **7 · Move the gesture state machines behind InteractionHandler** | watch |
@@ -79,7 +79,7 @@ rather than a reading exercise — a ticket is startable exactly when `blocked_b
 
 | | Ticket | Gated on |
 |---|---|---|
-| **Start here** | #499 axis ordering · #500 empty browsers · #501 versioned url.md + delete `stringify` · #502 fixture corpus | nothing |
+| **Start here** | ~~#499 axis ordering~~ **landed** · ~~#500 empty browsers~~ **landed** · #501 versioned url.md + delete `stringify` · #502 fixture corpus | nothing |
 | **The gate** | #503 golden-file snapshot — **no decoder code moves until it is green** | #499, #500, #502 |
 | Collapse | #504 pure `sniffFormat`/`decodeState` → #505 `decodeSession` + injected loader → #506 drop bit.ly | linear |
 | Payoff | #507 `encodeSession` + round-trip property test → #508 version field | #500, #505 |

--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -282,10 +282,20 @@ class BrowserRegistry {
      * container to resolve from and so follows the page-wide selection, but
      * what it resolves to is *a registry*, and everything in the document comes
      * from that one registry.
+     *
+     * A browser with no dataset serializes to `null` and is dropped here rather
+     * than written into the session: it names no map, and restoring it would
+     * rebuild an empty panel. **Accepted asymmetry:** browser *count* does not
+     * survive the round trip when one of them is empty -- an embed saved with
+     * an empty panel open restores one panel short. ADR-0006 decision 6, #500.
      */
     toJSON() {
 
-        const json = {browsers: this.browsers.map(browser => browser.toJSON())}
+        const json = {
+            browsers: this.browsers
+                .map(browser => browser.toJSON())
+                .filter(browserJson => null !== browserJson)
+        }
 
         if (this.selectedGene) {
             json.selectedGene = this.selectedGene

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -1054,9 +1054,18 @@ class HICBrowser {
         return this.dataset.bpResolutions[this.state.zoom]
     };
 
+    /**
+     * Serialize this browser as a session entry, or `null` when it has no map.
+     *
+     * A browser with no dataset names nothing a session can restore, and `null`
+     * is what says so to the registry, which drops it. It used to be the string
+     * `"{}"`, which was neither a browser nor distinguishable from one: the
+     * defaults pass on restore assigned properties to a string primitive and
+     * the whole session failed to reload. ADR-0006 decision 6, #500.
+     */
     toJSON() {
 
-        if (!(this.dataset && this.dataset.url)) return "{}"   // URL is required
+        if (!(this.dataset && this.dataset.url)) return null   // URL is required
 
         const jsonOBJ = {}
 

--- a/test/testRegistrySession.js
+++ b/test/testRegistrySession.js
@@ -2,6 +2,7 @@ import {describe, it, expect} from 'vitest'
 import BrowserRegistry, {registryForContainer} from '../js/browserRegistry.js'
 import {toJSON, compressedSession, restoreSession} from '../js/session.js'
 import {init} from '../js/init.js'
+import HICBrowser from '../js/hicBrowser.js'
 import {withContainers} from './utils/browserFixture.js'
 import {withStubbedLoads} from './utils/stubbedLoads.js'
 import {BGZip} from 'igv-utils'
@@ -76,6 +77,75 @@ describe('registry.toJSON', () => {
 
     it('writes an empty browser list for an empty registry', () => {
         expect(new BrowserRegistry().toJSON().browsers).toEqual([])
+    })
+})
+
+/**
+ * A browser with no dataset names no map, so it is left out of the session
+ * rather than written into it -- ADR-0006 decision 6, #500.
+ *
+ * An empty panel is a normal transient state while a user is partway through
+ * adding a map, so saving then is not an error. What it costs is stated in the
+ * accepted asymmetry: browser *count* does not survive the round trip when one
+ * of them is empty.
+ */
+describe('a browser with no dataset', () => {
+
+    const dom = withContainers()
+    withStubbedLoads()
+
+    /** An empty panel: constructed, registered, never given a map. */
+    function emptyBrowser(registry) {
+        const browser = new HICBrowser(registry.container, {})
+        registry.add(browser)
+        return browser
+    }
+
+    it('serializes to null, which a consumer can tell from a real browser', () => {
+        const registry = registryForContainer(dom.container)
+
+        expect(emptyBrowser(registry).toJSON()).toBeNull()
+    })
+
+    it('is left out of a session that also holds a loaded browser', async () => {
+        const registry = registryForContainer(dom.container)
+        await registry.restoreSession({browsers: [{url: 'https://example.com/a.hic'}]})
+        emptyBrowser(registry)
+
+        const session = registry.toJSON()
+
+        expect(session.browsers).toHaveLength(1)
+        expect(session.browsers[0].url).toBe('https://example.com/a.hic')
+    })
+
+    it('leaves a session with no browsers when every browser is empty', () => {
+        const registry = registryForContainer(dom.container)
+        emptyBrowser(registry)
+        emptyBrowser(registry)
+
+        expect(registry.toJSON().browsers).toEqual([])
+    })
+
+    it('restores from a session it was saved into, one panel short', async () => {
+        const first = registryForContainer(dom.container)
+        await first.restoreSession({browsers: [{url: 'https://example.com/a.hic'}]})
+        emptyBrowser(first)
+
+        const second = registryForContainer(dom.another())
+        await second.restoreSession(first.toJSON())
+
+        expect(second.browsers).toHaveLength(1)
+        expect(second.browsers[0].dataset.url).toBe('https://example.com/a.hic')
+    })
+
+    it('restores an all-empty registry\'s session as an embed with no browsers', async () => {
+        const first = registryForContainer(dom.container)
+        emptyBrowser(first)
+
+        const second = registryForContainer(dom.another())
+        await second.restoreSession(first.toJSON())
+
+        expect(second.browsers).toEqual([])
     })
 })
 


### PR DESCRIPTION
Closes #500. ADR-0006 decision 6; sequencing item 2 of candidate 5.

## The bug

A browser with no dataset serialized itself as the *string* `"{}"`, and `registry.toJSON()` mapped over its browsers with nothing filtering that out. The string landed in the session's `browsers` array, and on restore the defaults pass assigned properties to a string primitive:

```
TypeError: Cannot create property 'showLocusGoto' on string '{}'
```

So saving a session while any panel was empty produced a session that could not be reloaded.

## The fix

`browser.toJSON()` returns `null`; `registry.toJSON()` drops those. An empty browser names no map, and restoring it would only rebuild an empty panel — round-tripping "nothing" as a browser is not an identity worth having. Throwing was rejected: an empty panel is a normal transient state while a user is partway through adding a map, and saving then is not an error.

**Accepted asymmetry:** browser *count* does not survive the round trip when one of them is empty — an embed saved with an empty panel open restores one panel short. Written down in `CONTEXT.md` (new **Empty browser** glossary entry), in the doc comments at both code sites, and on the review card, rather than left as folklore.

## Also

`dev/encode-dev-proxy.html` was the one consumer that read the old string — under the old contract `session.tracks` was `undefined` and its `|| []` guard held. It now guards against `null`.

## Acceptance criteria

- [x] Saving a session with one empty browser and one loaded browser produces a session that restores successfully
- [x] The restored session contains only the loaded browser
- [x] Saving a session where *every* browser is empty produces a valid, restorable session with no browsers
- [x] A browser with no dataset serializes to something a consumer can distinguish from a real browser
- [x] The count asymmetry is written down

## Testing

Five new cases in `test/testRegistrySession.js`, written red first — they reproduced the exact `showLocusGoto` failure above. Full suite green: 509 passed, 32 files. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)