### PR TITLE
Snapshot today's decoder before anything in it moves (#503)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -134,6 +134,13 @@ accepted. **v0** is the older query form documented in `docs/url.md` — a
 4-token track string, and the session JSON that `compressedSession` writes.
 Juicebox reads both and writes only v1. See `docs/adr/0006`.
 
+The accepted set is pinned, not described: `test/data/wireFormatCorpus.js` holds
+one fixture per format and per decoder branch, and `test/testDecoderGolden.js`
+snapshots what today's decoder makes of each. Those snapshots *are* the
+compatibility contract in executable form, so a snapshot that moves is a change
+to the wire format until shown otherwise. That file's header carries the
+convention for updating one.
+
 **Decode** vs **normalize** — two stages, not one. *Decoding* turns a wire
 format into a session document and is the only stage that knows a format exists.
 *Normalizing* turns a session document into one every loader can consume —

--- a/test/__snapshots__/testDecoderGolden.js.snap
+++ b/test/__snapshots__/testDecoderGolden.js.snap
@@ -1,0 +1,1315 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`decoder golden file — inputs the decoder takes as a string > harvested-juicebox-encoded-braces 1`] = `
+{
+  "config": {
+    "browsers": [
+      {
+        "cycle": undefined,
+        "name": "HFFc6 DpnII",
+        "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+      },
+      {
+        "cycle": undefined,
+        "name": "H1-hESC DpnII",
+        "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/a0859349-5f06-4ad3-b56f-b1166b34a9eb/4DNFIIMZB6Y9.hic",
+      },
+    ],
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > harvested-juicebox-literal-braces 1`] = `
+{
+  "config": {
+    "browsers": [
+      {
+        "colorScale": ColorScale {
+          "b": 0,
+          "binsize": 0.07210918707440236,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 144.21837414880474,
+        },
+        "cycle": undefined,
+        "name": "ADAC_30.hic",
+        "nvi": "7989194045,18679",
+        "state": State {
+          "chr1": 2,
+          "chr2": 2,
+          "normalization": "KR",
+          "pixelSize": 1.5423280423280423,
+          "x": 1896.1562537317725,
+          "y": 1916.657181523778,
+          "zoom": 6,
+        },
+        "tracks": [
+          {
+            "color": "rgb(255,255,0)",
+            "displayMode": "COLLAPSED",
+            "name": "5000_blocks",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC/inter_30_contact_domains/5000_blocks",
+          },
+          {
+            "color": "rgb(0,36,255)",
+            "displayMode": "COLLAPSED",
+            "name": "merged_loops.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_loops/merged_loops.bedpe",
+          },
+          {
+            "color": "rgb(0,255,36)",
+            "displayMode": "COLLAPSED",
+            "name": "differential_loops1.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_vs_EndoC/differential_loops1.bedpe",
+          },
+        ],
+        "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC/ADAC_30.hic",
+      },
+      {
+        "colorScale": ColorScale {
+          "b": 0,
+          "binsize": 0.07138719710904917,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 142.77439421809834,
+        },
+        "cycle": undefined,
+        "name": "EndoC_30.hic",
+        "nvi": "6818528104,18679",
+        "state": State {
+          "chr1": 2,
+          "chr2": 2,
+          "normalization": "KR",
+          "pixelSize": 1.5423280423280423,
+          "x": 1896.1562537317725,
+          "y": 1916.657181523778,
+          "zoom": 6,
+        },
+        "tracks": [
+          {
+            "color": "rgb(18,0,255)",
+            "displayMode": "COLLAPSED",
+            "name": "merged_loops.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC_loops/merged_loops.bedpe",
+          },
+          {
+            "color": "rgb(255,255,0)",
+            "displayMode": "COLLAPSED",
+            "name": "5000_blocks",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC/inter_30_contact_domains/5000_blocks",
+          },
+          {
+            "color": "rgb(18,255,0)",
+            "displayMode": "COLLAPSED",
+            "name": "differential_loops2.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_vs_EndoC/differential_loops2.bedpe",
+          },
+        ],
+        "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC/EndoC_30.hic",
+      },
+    ],
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > harvested-query-4dn-control-map 1`] = `
+{
+  "config": {
+    "controlName": "H1-hESC DpnII",
+    "controlUrl": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/a0859349-5f06-4ad3-b56f-b1166b34a9eb/4DNFIIMZB6Y9.hic",
+    "cycle": undefined,
+    "name": "HFFc6 DpnII",
+    "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > harvested-query-4dn-state-colorscale-track 1`] = `
+{
+  "config": {
+    "colorScale": ColorScale {
+      "b": 0,
+      "binsize": 0.05,
+      "cache": [],
+      "g": 0,
+      "nbins": 2000,
+      "r": 255,
+      "threshold": 100,
+    },
+    "cycle": undefined,
+    "name": "HFFc6 DpnII",
+    "state": State {
+      "chr1": 1,
+      "chr2": 1,
+      "normalization": "NONE",
+      "pixelSize": 1,
+      "x": 0,
+      "y": 0,
+      "zoom": 4,
+    },
+    "tracks": [
+      {
+        "displayMode": "COLLAPSED",
+        "name": "RefSeq genes",
+        "url": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/refGene.txt.gz",
+      },
+    ],
+    "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > harvested-query-degron-fully-encoded 1`] = `
+{
+  "config": {
+    "colorScale": ColorScale {
+      "b": undefined,
+      "binsize": 0.036,
+      "cache": [],
+      "g": undefined,
+      "nbins": 2000,
+      "r": undefined,
+      "threshold": 72,
+    },
+    "cycle": undefined,
+    "name": "Rao et al. | Biorxiv 2017 Combined Untreated",
+    "state": State {
+      "chr1": 3,
+      "chr2": 3,
+      "normalization": "KR",
+      "pixelSize": 1.55,
+      "x": 19215,
+      "y": 19215,
+      "zoom": 7,
+    },
+    "tracks": [
+      {
+        "color": "rgb(0,150,0)",
+        "displayMode": "COLLAPSED",
+        "max": 3,
+        "min": 0,
+        "name": "Untreated H3K36me3",
+        "url": "https://s3.amazonaws.com/hicfiles/hiseq/degron/chipseq_data/untreated/H3K36me3_FE.bw",
+      },
+      {
+        "color": "rgb(0,150,0)",
+        "displayMode": "COLLAPSED",
+        "max": 7,
+        "min": 0,
+        "name": "Untreated H3K4me1",
+        "url": "https://s3.amazonaws.com/hicfiles/hiseq/degron/chipseq_data/untreated/H3K4me1_FE.bw",
+      },
+    ],
+    "url": "https://s3.amazonaws.com/hicfiles/hiseq/degron/untreated/unsynchronized/combined.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > harvested-query-dnazoo-no-state 1`] = `
+{
+  "config": {
+    "colorScale": ColorScale {
+      "b": 0,
+      "binsize": 9.778,
+      "cache": [],
+      "g": 0,
+      "nbins": 2000,
+      "r": 255,
+      "threshold": 19556,
+    },
+    "cycle": undefined,
+    "name": "Draft assembly",
+    "nvi": "2592278165,834",
+    "url": "https://dnazoo.s3.amazonaws.com/Ailurus_fulgens/ASM200746v1.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > harvested-query-gm12878-nvi 1`] = `
+{
+  "config": {
+    "colorScale": ColorScale {
+      "b": undefined,
+      "binsize": 0.0145,
+      "cache": [],
+      "g": undefined,
+      "nbins": 2000,
+      "r": undefined,
+      "threshold": 29,
+    },
+    "cycle": undefined,
+    "name": "Rao and Huntley et al. | Cell 2014 GM12878 (human) in situ MboI HIC009 (95M)",
+    "nvi": "2851728310,36479",
+    "state": State {
+      "chr1": 1,
+      "chr2": 1,
+      "normalization": "NONE",
+      "pixelSize": 1,
+      "x": 1115.253105,
+      "y": 1149.253105,
+      "zoom": 4,
+    },
+    "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > harvested-query-wapl-ko 1`] = `
+{
+  "config": {
+    "colorScale": ColorScale {
+      "b": undefined,
+      "binsize": 0.009448099314069635,
+      "cache": [],
+      "g": undefined,
+      "nbins": 2000,
+      "r": undefined,
+      "threshold": 18.89619862813927,
+    },
+    "cycle": undefined,
+    "name": "Haarhuis et al. | Cell 2017 Hap1 knockout WAPL clone 1",
+    "state": State {
+      "chr1": 3,
+      "chr2": 3,
+      "normalization": "KR",
+      "pixelSize": 1,
+      "x": 5537.98746,
+      "y": 5537.749239047619,
+      "zoom": 6,
+    },
+    "tracks": [
+      {
+        "displayMode": "COLLAPSED",
+        "name": "GM12878_CTCF_orientation.bed",
+        "url": "http://hicfiles.s3.amazonaws.com/external/GM12878_CTCF_orientation.bed",
+      },
+      {
+        "displayMode": "COLLAPSED",
+        "name": "gencode.v18.collapsed.bed.gz",
+        "url": "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/gencode.v18.collapsed.bed.gz",
+      },
+    ],
+    "url": "https://s3.amazonaws.com/hicfiles/external/wapl_hic/WaplKO_1.14.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > harvested-query-wapl-wt 1`] = `
+{
+  "config": {
+    "colorScale": ColorScale {
+      "b": undefined,
+      "binsize": 0.009448099314069635,
+      "cache": [],
+      "g": undefined,
+      "nbins": 2000,
+      "r": undefined,
+      "threshold": 18.89619862813927,
+    },
+    "cycle": undefined,
+    "name": "Haarhuis et al. | Cell 2017 Hap1 control",
+    "state": State {
+      "chr1": 3,
+      "chr2": 3,
+      "normalization": "KR",
+      "pixelSize": 1,
+      "x": 5537.98746,
+      "y": 5537.749239047619,
+      "zoom": 6,
+    },
+    "tracks": [
+      {
+        "displayMode": "COLLAPSED",
+        "name": "GM12878_CTCF_orientation.bed",
+        "url": "http://hicfiles.s3.amazonaws.com/external/GM12878_CTCF_orientation.bed",
+      },
+      {
+        "displayMode": "COLLAPSED",
+        "name": "gencode.v18.collapsed.bed.gz",
+        "url": "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/gencode.v18.collapsed.bed.gz",
+      },
+    ],
+    "url": "https://s3.amazonaws.com/hicfiles/external/wapl_hic/WT.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > harvested-session-blob-adac-endoc 1`] = `
+{
+  "config": {
+    "browsers": [
+      {
+        "colorScale": "144.21837414880474,255,0,0",
+        "name": "ADAC_30.hic",
+        "nvi": "7989194045,18679",
+        "state": "2,2,6,1896.1562537317725,1916.657181523778,1.5423280423280423,KR",
+        "tracks": [
+          {
+            "color": "rgb(255,255,0)",
+            "displayMode": "COLLAPSED",
+            "name": "5000_blocks",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC/inter_30_contact_domains/5000_blocks",
+          },
+          {
+            "color": "rgb(0,36,255)",
+            "displayMode": "COLLAPSED",
+            "name": "merged_loops.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_loops/merged_loops.bedpe",
+          },
+          {
+            "color": "rgb(0,255,36)",
+            "displayMode": "COLLAPSED",
+            "name": "differential_loops1.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_vs_EndoC/differential_loops1.bedpe",
+          },
+        ],
+        "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC/ADAC_30.hic",
+      },
+      {
+        "colorScale": "142.77439421809834,255,0,0",
+        "name": "EndoC_30.hic",
+        "nvi": "6818528104,18679",
+        "state": "2,2,6,1896.1562537317725,1916.657181523778,1.5423280423280423,KR",
+        "tracks": [
+          {
+            "color": "rgb(18,0,255)",
+            "displayMode": "COLLAPSED",
+            "name": "merged_loops.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC_loops/merged_loops.bedpe",
+          },
+          {
+            "color": "rgb(255,255,0)",
+            "displayMode": "COLLAPSED",
+            "name": "5000_blocks",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC/inter_30_contact_domains/5000_blocks",
+          },
+          {
+            "color": "rgb(18,255,0)",
+            "displayMode": "COLLAPSED",
+            "name": "differential_loops2.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_vs_EndoC/differential_loops2.bedpe",
+          },
+        ],
+        "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC/EndoC_30.hic",
+      },
+    ],
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > reject-query-empty 1`] = `
+{
+  "outcome": "no-config",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > reject-query-no-recognized-parameters 1`] = `
+{
+  "outcome": "no-config",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > reject-query-selected-gene-alone 1`] = `
+{
+  "outcome": "no-config",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > reject-session-blob-corrupt 1`] = `
+{
+  "error": {
+    "message": undefined,
+    "name": undefined,
+    "thrown": "string: invalid block type",
+  },
+  "outcome": "throws",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > reject-session-gzip-data-uri 1`] = `
+{
+  "error": {
+    "message": undefined,
+    "name": undefined,
+    "thrown": "string: invalid distance too far back",
+  },
+  "outcome": "throws",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-juicebox-browser-carrying-selected-gene 1`] = `
+{
+  "config": {
+    "browsers": [
+      {
+        "cycle": undefined,
+        "name": "A",
+        "selectedGene": "MYC",
+        "url": "https://example.org/a.hic",
+      },
+      {
+        "cycle": undefined,
+        "name": "B",
+        "selectedGene": "ACE",
+        "url": "https://example.org/b.hic",
+      },
+    ],
+    "selectedGene": "ACE",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-juiceboxData-compressed 1`] = `
+{
+  "config": {
+    "browsers": [
+      {
+        "cycle": undefined,
+        "name": "HFFc6 DpnII",
+        "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+      },
+      {
+        "cycle": undefined,
+        "name": "H1-hESC DpnII",
+        "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/a0859349-5f06-4ad3-b56f-b1166b34a9eb/4DNFIIMZB6Y9.hic",
+      },
+    ],
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-colorscale-bare-threshold 1`] = `
+{
+  "config": {
+    "colorScale": ColorScale {
+      "b": undefined,
+      "binsize": 0.009448099314069635,
+      "cache": [],
+      "g": undefined,
+      "nbins": 2000,
+      "r": undefined,
+      "threshold": 18.89619862813927,
+    },
+    "cycle": undefined,
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-colorscale-diff 1`] = `
+{
+  "config": {
+    "colorScale": DiffColorScale {
+      "negativeScale": ColorScale {
+        "b": 255,
+        "binsize": 0.0025,
+        "cache": [],
+        "g": 0,
+        "nbins": 2000,
+        "r": 0,
+        "threshold": 5,
+      },
+      "positiveScale": ColorScale {
+        "b": 0,
+        "binsize": 0.0025,
+        "cache": [],
+        "g": 0,
+        "nbins": 2000,
+        "r": 255,
+        "threshold": 5,
+      },
+      "threshold": 2,
+    },
+    "controlUrl": "https://example.org/b.hic",
+    "cycle": undefined,
+    "displayMode": "AMB",
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-colorscale-four-token 1`] = `
+{
+  "config": {
+    "colorScale": ColorScale {
+      "b": 0,
+      "binsize": 0.05,
+      "cache": [],
+      "g": 0,
+      "nbins": 2000,
+      "r": 255,
+      "threshold": 100,
+    },
+    "cycle": undefined,
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-colorscale-ratio 1`] = `
+{
+  "config": {
+    "colorScale": RatioColorScale {
+      "negativeScale": ColorScale {
+        "b": 255,
+        "binsize": 0.0025,
+        "cache": [],
+        "g": 0,
+        "nbins": 2000,
+        "r": 0,
+        "threshold": 5,
+      },
+      "positiveScale": ColorScale {
+        "b": 0,
+        "binsize": 0.0025,
+        "cache": [],
+        "g": 0,
+        "nbins": 2000,
+        "r": 255,
+        "threshold": 5,
+      },
+      "threshold": 2,
+    },
+    "controlUrl": "https://example.org/b.hic",
+    "cycle": undefined,
+    "displayMode": "AOB",
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-every-parameter 1`] = `
+{
+  "config": {
+    "colorScale": ColorScale {
+      "b": 0,
+      "binsize": 0.05,
+      "cache": [],
+      "g": 0,
+      "nbins": 2000,
+      "r": 255,
+      "threshold": 100,
+    },
+    "controlName": "B",
+    "controlNvi": "789,10",
+    "controlUrl": "https://example.org/b.hic",
+    "cycle": "true",
+    "displayMode": "AOB",
+    "name": "A",
+    "nvi": "123,456",
+    "selectedGene": "MYC",
+    "state": State {
+      "chr1": 1,
+      "chr2": 1,
+      "normalization": "KR",
+      "pixelSize": 1,
+      "x": 0,
+      "y": 0,
+      "zoom": 4,
+    },
+    "tracks": [
+      {
+        "color": "rgb(255,0,0)",
+        "displayMode": "COLLAPSED",
+        "max": 50,
+        "min": 0,
+        "name": "A",
+        "url": "https://example.org/a.bed",
+      },
+    ],
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-state-too-few-tokens 1`] = `
+{
+  "config": {
+    "cycle": undefined,
+    "state": State {
+      "chr1": 1,
+      "chr2": 2,
+      "normalization": "NONE",
+      "pixelSize": 1,
+      "x": NaN,
+      "y": NaN,
+      "zoom": NaN,
+    },
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-state-transposed 1`] = `
+{
+  "config": {
+    "cycle": undefined,
+    "state": State {
+      "chr1": 3,
+      "chr2": 5,
+      "normalization": "KR",
+      "pixelSize": 2,
+      "x": 200,
+      "y": 100,
+      "zoom": 6,
+    },
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-state-v0-six-token 1`] = `
+{
+  "config": {
+    "cycle": undefined,
+    "state": State {
+      "chr1": 1,
+      "chr2": 2,
+      "normalization": "NONE",
+      "pixelSize": 3,
+      "x": 10,
+      "y": 20,
+      "zoom": 4,
+    },
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-state-v1-eight-token 1`] = `
+{
+  "config": {
+    "cycle": undefined,
+    "state": State {
+      "chr1": 3,
+      "chr2": 5,
+      "normalization": "NONE",
+      "pixelSize": 2,
+      "x": 100,
+      "y": 200,
+      "zoom": 6,
+    },
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-state-v1-legacy-viewport 1`] = `
+{
+  "config": {
+    "cycle": undefined,
+    "state": State {
+      "chr1": 3,
+      "chr2": 5,
+      "normalization": "KR",
+      "pixelSize": 2,
+      "x": 100,
+      "y": 200,
+      "zoom": 6,
+    },
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-state-v1-nine-token 1`] = `
+{
+  "config": {
+    "cycle": undefined,
+    "state": State {
+      "chr1": 3,
+      "chr2": 5,
+      "normalization": "KR",
+      "pixelSize": 2,
+      "x": 100,
+      "y": 200,
+      "zoom": 6,
+    },
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-tracks-bare-url 1`] = `
+{
+  "config": {
+    "cycle": undefined,
+    "tracks": [
+      {
+        "color": "https://example.org/a.bed",
+        "displayMode": "COLLAPSED",
+        "url": "https://example.org/a.bed",
+      },
+    ],
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-tracks-default-color-stripped 1`] = `
+{
+  "config": {
+    "cycle": undefined,
+    "tracks": [
+      {
+        "displayMode": "COLLAPSED",
+        "max": 50,
+        "min": 0,
+        "name": "A",
+        "url": "https://example.org/a.bed",
+      },
+    ],
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-tracks-empty-range 1`] = `
+{
+  "config": {
+    "cycle": undefined,
+    "tracks": [
+      {
+        "color": "rgb(255,0,0)",
+        "displayMode": "COLLAPSED",
+        "name": "A",
+        "url": "https://example.org/a.bed",
+      },
+    ],
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-tracks-four-field 1`] = `
+{
+  "config": {
+    "cycle": undefined,
+    "tracks": [
+      {
+        "color": "rgb(255,0,0)",
+        "displayMode": "COLLAPSED",
+        "max": 50,
+        "min": 0,
+        "name": "A",
+        "url": "https://example.org/a.bed",
+      },
+    ],
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-tracks-name-with-bar 1`] = `
+{
+  "config": {
+    "cycle": undefined,
+    "tracks": [
+      {
+        "color": "rgb(255,0,0)",
+        "displayMode": "COLLAPSED",
+        "max": 50,
+        "min": 0,
+        "name": "A|B",
+        "url": "https://example.org/a.bed",
+      },
+    ],
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-tracks-negative-range 1`] = `
+{
+  "config": {
+    "cycle": undefined,
+    "tracks": [
+      {
+        "color": "rgb(255,0,0)",
+        "displayMode": "COLLAPSED",
+        "max": 5,
+        "min": -5,
+        "name": "A",
+        "url": "https://example.org/a.bed",
+      },
+    ],
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-tracks-three-field 1`] = `
+{
+  "config": {
+    "cycle": undefined,
+    "tracks": [
+      {
+        "color": "rgb(255,0,0)",
+        "displayMode": "COLLAPSED",
+        "name": "A",
+        "url": "https://example.org/a.bed",
+      },
+    ],
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-tracks-two-field 1`] = `
+{
+  "config": {
+    "cycle": undefined,
+    "tracks": [
+      {
+        "color": "rgb(255,0,0)",
+        "displayMode": "COLLAPSED",
+        "url": "https://example.org/a.bed|rgb(255,0,0)",
+      },
+    ],
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-tracks-undefined-url 1`] = `
+{
+  "config": {
+    "cycle": undefined,
+    "tracks": [],
+    "url": "https://example.org/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-url-shortcuts-http 1`] = `
+{
+  "config": {
+    "controlUrl": "http://hicfiles.s3.amazonaws.com/external/b.hic",
+    "cycle": undefined,
+    "url": "http://hicfiles.s3.amazonaws.com/hiseq/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-query-url-shortcuts-https 1`] = `
+{
+  "config": {
+    "controlUrl": "https://www.encodeproject.org/files/ENCFF000.hic",
+    "cycle": undefined,
+    "tracks": [
+      {
+        "color": "rgb(255,0,0)",
+        "displayMode": "COLLAPSED",
+        "max": 50,
+        "min": 0,
+        "name": "B",
+        "url": "https://hicfiles.s3.amazonaws.com/external/b.bed",
+      },
+    ],
+    "url": "https://hicfiles.s3.amazonaws.com/hiseq/a.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-session-and-hic-url-together 1`] = `
+{
+  "config": {
+    "cycle": undefined,
+    "url": "https://example.org/wins.hic",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-session-data-prefix 1`] = `
+{
+  "config": {
+    "browsers": [
+      {
+        "colorScale": "100,255,0,0",
+        "name": "HFFc6 DpnII",
+        "state": {
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": 0,
+          "y": 0,
+          "zoom": 4,
+        },
+        "tracks": [],
+        "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+      },
+    ],
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — inputs the decoder takes as a string > synth-session-with-selected-gene 1`] = `
+{
+  "config": {
+    "browsers": [
+      {
+        "colorScale": "100,255,0,0",
+        "name": "HFFc6 DpnII",
+        "state": {
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": 0,
+          "y": 0,
+          "zoom": 4,
+        },
+        "tracks": [],
+        "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+      },
+    ],
+    "selectedGene": "MYC",
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — session URLs, driven from their loader response > reject-session-url-invalid-json 1`] = `
+{
+  "error": {
+    "message": "Failed to load session from URL/file: Failed to parse session from URL/file: Unexpected token '<', "<!doctype "... is not valid JSON",
+    "name": "Error",
+  },
+  "outcome": "throws",
+}
+`;
+
+exports[`decoder golden file — session URLs, driven from their loader response > reject-session-url-unreachable 1`] = `
+{
+  "error": {
+    "message": "Failed to load session from URL/file: simulated fetch failure",
+    "name": "Error",
+  },
+  "outcome": "throws",
+}
+`;
+
+exports[`decoder golden file — session URLs, driven from their loader response > synth-session-url-blob-prefixed 1`] = `
+{
+  "config": {
+    "browsers": [
+      {
+        "colorScale": "100,255,0,0",
+        "name": "HFFc6 DpnII",
+        "state": {
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": 0,
+          "y": 0,
+          "zoom": 4,
+        },
+        "tracks": [],
+        "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+      },
+    ],
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — session URLs, driven from their loader response > synth-session-url-plain-json 1`] = `
+{
+  "config": {
+    "browsers": [
+      {
+        "name": "A",
+        "state": {
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": 0,
+          "y": 0,
+          "zoom": 4,
+        },
+        "url": "https://example.org/a.hic",
+      },
+    ],
+  },
+  "outcome": "decodes",
+}
+`;
+
+exports[`decoder golden file — state strings > state-truncated 1`] = `
+State {
+  "chr1": 1,
+  "chr2": 2,
+  "normalization": "NONE",
+  "pixelSize": 1,
+  "x": NaN,
+  "y": NaN,
+  "zoom": NaN,
+}
+`;
+
+exports[`decoder golden file — state strings > state-v0-seven-token 1`] = `
+State {
+  "chr1": 3,
+  "chr2": 3,
+  "normalization": "KR",
+  "pixelSize": 1,
+  "x": 5537.98746,
+  "y": 5537.749239047619,
+  "zoom": 6,
+}
+`;
+
+exports[`decoder golden file — state strings > state-v0-seven-token-encoded-origin 1`] = `
+State {
+  "chr1": 3,
+  "chr2": 3,
+  "normalization": "KR",
+  "pixelSize": 1.55,
+  "x": 19215,
+  "y": 19215,
+  "zoom": 7,
+}
+`;
+
+exports[`decoder golden file — state strings > state-v0-six-token-no-normalization 1`] = `
+State {
+  "chr1": 1,
+  "chr2": 2,
+  "normalization": "NONE",
+  "pixelSize": 3,
+  "x": 10,
+  "y": 20,
+  "zoom": 4,
+}
+`;
+
+exports[`decoder golden file — state strings > state-v0-transposed-pair 1`] = `
+State {
+  "chr1": 3,
+  "chr2": 5,
+  "normalization": "KR",
+  "pixelSize": 2,
+  "x": 200,
+  "y": 100,
+  "zoom": 6,
+}
+`;
+
+exports[`decoder golden file — state strings > state-v1-eight-token-no-normalization 1`] = `
+State {
+  "chr1": 3,
+  "chr2": 5,
+  "normalization": "NONE",
+  "pixelSize": 2,
+  "x": 100,
+  "y": 200,
+  "zoom": 6,
+}
+`;
+
+exports[`decoder golden file — state strings > state-v1-nine-token 1`] = `
+State {
+  "chr1": 3,
+  "chr2": 5,
+  "normalization": "KR",
+  "pixelSize": 2,
+  "x": 100,
+  "y": 200,
+  "zoom": 6,
+}
+`;
+
+exports[`decoder golden file — state strings > state-v1-nine-token-legacy-viewport 1`] = `
+State {
+  "chr1": 3,
+  "chr2": 5,
+  "normalization": "KR",
+  "pixelSize": 2,
+  "x": 100,
+  "y": 200,
+  "zoom": 6,
+}
+`;
+
+exports[`decoder golden file — state strings > state-v1-transposed-pair 1`] = `
+State {
+  "chr1": 3,
+  "chr2": 5,
+  "normalization": "KR",
+  "pixelSize": 2,
+  "x": 200,
+  "y": 100,
+  "zoom": 6,
+}
+`;
+
+exports[`decoder golden file — the File arm is not reachable > reject-session-file-invalid-json 1`] = `
+{
+  "error": {
+    "message": "uri.indexOf is not a function",
+    "name": "TypeError",
+  },
+  "outcome": "throws",
+}
+`;
+
+exports[`decoder golden file — the File arm is not reachable > synth-session-file-blob-prefixed 1`] = `
+{
+  "error": {
+    "message": "uri.indexOf is not a function",
+    "name": "TypeError",
+  },
+  "outcome": "throws",
+}
+`;
+
+exports[`decoder golden file — the File arm is not reachable > synth-session-file-plain-json 1`] = `
+{
+  "error": {
+    "message": "uri.indexOf is not a function",
+    "name": "TypeError",
+  },
+  "outcome": "throws",
+}
+`;
+
+exports[`decoder golden file — the legacy bit.ly form > harvested-juiceboxURL-bitly 1`] = `
+{
+  "config": {
+    "browsers": [
+      {
+        "colorScale": ColorScale {
+          "b": 0,
+          "binsize": 0.07210918707440236,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 144.21837414880474,
+        },
+        "cycle": undefined,
+        "name": "ADAC_30.hic",
+        "nvi": "7989194045,18679",
+        "state": State {
+          "chr1": 2,
+          "chr2": 2,
+          "normalization": "KR",
+          "pixelSize": 1.5423280423280423,
+          "x": 1896.1562537317725,
+          "y": 1916.657181523778,
+          "zoom": 6,
+        },
+        "tracks": [
+          {
+            "color": "rgb(255,255,0)",
+            "displayMode": "COLLAPSED",
+            "name": "5000_blocks",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC/inter_30_contact_domains/5000_blocks",
+          },
+          {
+            "color": "rgb(0,36,255)",
+            "displayMode": "COLLAPSED",
+            "name": "merged_loops.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_loops/merged_loops.bedpe",
+          },
+          {
+            "color": "rgb(0,255,36)",
+            "displayMode": "COLLAPSED",
+            "name": "differential_loops1.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_vs_EndoC/differential_loops1.bedpe",
+          },
+        ],
+        "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC/ADAC_30.hic",
+      },
+      {
+        "colorScale": ColorScale {
+          "b": 0,
+          "binsize": 0.07138719710904917,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 142.77439421809834,
+        },
+        "cycle": undefined,
+        "name": "EndoC_30.hic",
+        "nvi": "6818528104,18679",
+        "state": State {
+          "chr1": 2,
+          "chr2": 2,
+          "normalization": "KR",
+          "pixelSize": 1.5423280423280423,
+          "x": 1896.1562537317725,
+          "y": 1916.657181523778,
+          "zoom": 6,
+        },
+        "tracks": [
+          {
+            "color": "rgb(18,0,255)",
+            "displayMode": "COLLAPSED",
+            "name": "merged_loops.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC_loops/merged_loops.bedpe",
+          },
+          {
+            "color": "rgb(255,255,0)",
+            "displayMode": "COLLAPSED",
+            "name": "5000_blocks",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC/inter_30_contact_domains/5000_blocks",
+          },
+          {
+            "color": "rgb(18,255,0)",
+            "displayMode": "COLLAPSED",
+            "name": "differential_loops2.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_vs_EndoC/differential_loops2.bedpe",
+          },
+        ],
+        "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC/EndoC_30.hic",
+      },
+    ],
+  },
+  "outcome": "decodes",
+}
+`;

--- a/test/data/wireFormatCorpus.js
+++ b/test/data/wireFormatCorpus.js
@@ -674,6 +674,35 @@ export const wireFormatCorpus = [
 ]
 
 /**
+ * The corpus partitioned by *what a test has to supply* before the fixture can
+ * be decoded. Every consuming test needs this split and there is only one right
+ * answer, so it lives beside the fixtures rather than being re-derived — two
+ * copies that disagreed would silently stop covering whichever group fell
+ * through the gap.
+ *
+ * The four groups are disjoint and exhaustive, which `testDecoderGolden.js`
+ * asserts. Adding a fixture that belongs to none of them fails that assertion
+ * rather than being quietly skipped.
+ *
+ * `selfContained` — hand it `input` and nothing else.
+ * `viaLoader`     — stub `igvxhr.loadString` with `loaderResponse` first; a
+ *                   `loaderResponse` of null means the loader itself rejects.
+ * `viaBitly`      — stub `fetch` with `expandedUrl` first.
+ * `viaFile`       — needs a File where `extractQuery` can only put a string.
+ *                   See the golden test's note on this group.
+ */
+export const selfContained = wireFormatCorpus.filter(f =>
+    f.input !== undefined &&
+    f.loaderResponse === undefined &&
+    f.format !== 'juiceboxURL')
+
+export const viaLoader = wireFormatCorpus.filter(f => f.loaderResponse !== undefined)
+
+export const viaBitly = wireFormatCorpus.filter(f => f.format === 'juiceboxURL')
+
+export const viaFile = wireFormatCorpus.filter(f => f.format === 'sessionFile')
+
+/**
  * Fixtures for `State.parse` (`js/hicState.js`), the `state` query parameter on
  * its own.
  *

--- a/test/testDecoderGolden.js
+++ b/test/testDecoderGolden.js
@@ -1,0 +1,272 @@
+/**
+ * The golden-file characterization test for the session decoder. #503.
+ *
+ * Every fixture in `test/data/wireFormatCorpus.js` is run through the decoder as
+ * it exists today and the result is snapshotted verbatim into
+ * `test/__snapshots__/testDecoderGolden.js.snap`. ADR-0006, "How we know the
+ * decoder did not change": the refactor that collapses eight encodings and seven
+ * decoders behind `decodeSession` passes when — and only when — these snapshots
+ * come back byte-identical.
+ *
+ * **Nothing in the decoder moves until this file is green.** That is the whole
+ * job of the ticket. Hand-written per-fixture assertions were considered and
+ * rejected: they re-encode one reader's understanding of the code, and would
+ * bless a misreading as spec. A snapshot is indifferent to whether anyone
+ * understood it — which matters here, because this decoder has already drifted
+ * from its own documentation in three places.
+ *
+ * Two consequences to keep in view:
+ *
+ * 1. **The snapshots capture bugs as well as behaviour, deliberately.** The
+ *    brace-repair mangling at `urlUtils.js:417`, the `NaN` origins of a
+ *    truncated state string, the bare `TypeError` a corrupt share link throws —
+ *    all of it is pinned. Pinning a bug is not blessing it; it is refusing to
+ *    let a refactor change it by accident.
+ * 2. **Rejections are contract.** An input the decoder refuses, and *how* it
+ *    refuses, is snapshotted alongside the ones it accepts. `capture()` below
+ *    returns a throw as data for exactly this reason.
+ *
+ * ## Updating a snapshot — the convention
+ *
+ * A snapshot never gets re-baselined silently. `vitest -u` across the suite is
+ * how a deliberate change and an accidental one become indistinguishable, and
+ * this file exists to keep them distinguishable.
+ *
+ * When a change to the decoder legitimately moves output:
+ *
+ * 1. Read the snapshot diff first, fixture by fixture. Every moved fixture must
+ *    be one you can explain. A fixture you did not expect to move is a bug
+ *    report, not a snapshot to accept.
+ * 2. Update only the affected snapshots — `vitest -u -t '<fixture id>'`, not a
+ *    bare `-u` over the file.
+ * 3. Add a line to the log below saying which decision authorised it. The log,
+ *    not the git history, is where the next person looks: a `.snap` diff is
+ *    unreadable without it.
+ *
+ * ### Authorised snapshot movements
+ *
+ * | Date | Fixtures | Authorised by |
+ * |------|----------|---------------|
+ * | 2026-08-09 | all — baseline taken | #503, after #499 (axis ordering) and #500 (empty browsers), both of which move decoded output and so had to land first |
+ *
+ * @see docs/adr/0006-session-wire-format-and-one-decoder.md
+ * @see test/data/wireFormatCorpus.js — the inputs
+ * @see test/testWireFormatCorpus.js — guards the corpus, not the decoder
+ */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+import {igvxhr} from 'igv-utils'
+import {extractConfig} from '../js/urlUtils.js'
+import State from '../js/hicState.js'
+import {
+    selfContained,
+    stateStringCorpus,
+    viaBitly,
+    viaFile,
+    viaLoader,
+    wireFormatCorpus,
+} from './data/wireFormatCorpus.js'
+
+/**
+ * Describe a rejection well enough that its snapshot means something.
+ *
+ * Not everything the decoder throws is an `Error`: the `blob:`/`data:` arm has
+ * no try/catch of its own, so a corrupt share link rejects with whatever the
+ * decompressor threw, `name` and `message` both undefined. `{name, message}`
+ * alone would snapshot that as two blanks and pin nothing at all, so the raw
+ * value is stringified alongside for those.
+ */
+function describeThrow(e) {
+    const described = {name: e?.name, message: e?.message}
+    if (described.name === undefined && described.message === undefined) {
+        described.thrown = `${typeof e}: ${String(e)}`
+    }
+    return described
+}
+
+/**
+ * Run one input through the decoder and return the result *as data* — a decoded
+ * config, the absence of one, or the rejection — so that all three snapshot the
+ * same way. `outcome` mirrors the corpus's own vocabulary so the snapshot and
+ * the fixture can be compared without reading either closely.
+ */
+async function capture(input) {
+    try {
+        const config = await extractConfig(input)
+        return config === undefined
+            ? {outcome: 'no-config'}
+            : {outcome: 'decodes', config}
+    } catch (e) {
+        return {outcome: 'throws', error: describeThrow(e)}
+    }
+}
+
+/**
+ * Snapshot class instances as their own properties under their class name.
+ *
+ * Without this the default serializer calls `toJSON()` where one exists, which
+ * would show `State` as its seven-field wire projection and hide both the class
+ * identity and any field the projection drops. Both matter here: a `state` that
+ * arrives as a `State` from `decodeQuery` and one that arrives as a plain object
+ * from `JSON.parse` are different values, and the collapse could silently turn
+ * one into the other.
+ */
+expect.addSnapshotSerializer({
+    test: v => v !== null && typeof v === 'object' && typeof v.toJSON === 'function',
+    serialize: (v, config, indentation, depth, refs, printer) =>
+        `${v.constructor.name} ${printer({...v}, config, indentation, depth, refs)}`,
+})
+
+/**
+ * "Every fixture in the corpus has a committed snapshot" has to hold by
+ * construction, not by having been true the day it was written. The four suites
+ * below run the four partitions the corpus exports; a fixture belonging to none
+ * of them would otherwise be skipped in silence, which is the one failure mode a
+ * golden file cannot survive.
+ */
+test('every fixture falls into exactly one of the four suites', () => {
+    const partitioned = [...selfContained, ...viaLoader, ...viaBitly, ...viaFile]
+    expect(partitioned.length, 'a fixture in two partitions is snapshotted twice')
+        .toBe(wireFormatCorpus.length)
+    expect(new Set(partitioned.map(f => f.id)).size, 'a fixture in none is never snapshotted')
+        .toBe(wireFormatCorpus.length)
+})
+
+/**
+ * "Runs without network, DOM or file I/O" is enforced here rather than asserted
+ * in a comment: both I/O sites are replaced with a throw by default, so a
+ * fixture that reaches one fails loudly instead of quietly going to the wire.
+ * The two suites that legitimately need them re-stub them with a canned answer.
+ *
+ * `console.error` is silenced because the decoder logs every rejection before
+ * rethrowing it — behaviour worth keeping, noise worth not printing forty times
+ * a run. The message itself comes off the thrown error, so nothing is lost.
+ */
+beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {
+    })
+    vi.spyOn(igvxhr, 'loadString').mockImplementation(async () => {
+        throw new Error('unexpected network access from the golden-file suite')
+    })
+    vi.stubGlobal('fetch', async () => {
+        throw new Error('unexpected network access from the golden-file suite')
+    })
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+})
+
+describe('decoder golden file — inputs the decoder takes as a string', () => {
+
+    for (const fixture of selfContained) {
+        test(fixture.id, async () => {
+            const captured = await capture(fixture.input)
+            expect(captured.outcome, fixture.id).toBe(fixture.outcome)
+            expect(captured).toMatchSnapshot()
+        })
+    }
+})
+
+describe('decoder golden file — session URLs, driven from their loader response', () => {
+
+    for (const fixture of viaLoader) {
+        test(fixture.id, async () => {
+            vi.spyOn(igvxhr, 'loadString').mockImplementation(async () => {
+                if (fixture.loaderResponse === null) throw new Error('simulated fetch failure')
+                return fixture.loaderResponse
+            })
+
+            const captured = await capture(fixture.input)
+            expect(captured.outcome, fixture.id).toBe(fixture.outcome)
+            expect(captured).toMatchSnapshot()
+        })
+    }
+})
+
+/**
+ * The bit.ly path, driven from the `long_url` the real service returned on
+ * 2026-08-09. ADR-0006 decision 1 drops this format, and #506 is where it goes;
+ * until then it is live behaviour and gets a snapshot like everything else.
+ *
+ * Stubbing `fetch` rather than the network is what makes it snapshottable at
+ * all — the corpus integrity test skips this fixture precisely because its
+ * unstubbed outcome depends on a third party.
+ */
+describe('decoder golden file — the legacy bit.ly form', () => {
+
+    for (const fixture of viaBitly) {
+        test(fixture.id, async () => {
+            vi.stubGlobal('fetch', async () => ({
+                ok: true,
+                json: async () => ({long_url: fixture.expandedUrl}),
+            }))
+
+            const captured = await capture(fixture.input)
+            expect(captured.outcome, fixture.id).toBe(fixture.outcome)
+            expect(captured).toMatchSnapshot()
+        })
+    }
+})
+
+/**
+ * The `isFile` arm of `extractConfig` (`urlUtils.js:90-104`).
+ *
+ * What is snapshotted here is **the arm's unreachability**, which is the real
+ * behaviour and not a stand-in for it. `extractConfig` parses its argument with
+ * `extractQuery`, which calls `indexOf` on it and can only ever produce string
+ * values; the sole caller (`init.js:50`) hands it `window.location.href`. There
+ * is no input — File or otherwise — that reaches line 92. Handing the decoder
+ * the query object the arm was written for does not enter the arm, it throws out
+ * of the parser one line earlier, and that throw is what the snapshot records.
+ *
+ * The three `sessionFile` fixtures still get a snapshot each, so that "every
+ * fixture in the corpus has one" stays literally true and so that this arm
+ * becoming reachable — which the ADR-0006 collapse could easily do by accident —
+ * shows up as a snapshot movement rather than as silence.
+ *
+ * **These three are the one place the suite does not assert `fixture.outcome`,
+ * and the divergence is deliberate.** The corpus records what the *arm* would do
+ * with `fileText` — two `decodes` and one `throws`, measured by reading the code
+ * because nothing can run it. What is measured here is what the *decoder* does,
+ * which is to reject at the parser without ever looking at the file. Asserting
+ * the parser's message rather than the coarse outcome is what keeps the two
+ * claims apart: the day that assertion fails, the arm has become reachable and
+ * the corpus's declared outcome is the thing to check against instead.
+ */
+describe('decoder golden file — the File arm is not reachable', () => {
+
+    for (const fixture of viaFile) {
+        test(fixture.id, async () => {
+            // The mock File (test/utils/File.js) takes a Buffer, not the array
+            // of parts the DOM constructor wants. Deliberate — `.text()` reads
+            // `buffer.toString()`.
+            const file = new File(Buffer.from(fixture.fileText), 'session.json')
+
+            const captured = await capture({session: file})
+
+            expect(captured.error.message, 'the File arm became reachable — see the note above')
+                .toBe('uri.indexOf is not a function')
+            expect(captured).toMatchSnapshot()
+        })
+    }
+})
+
+/**
+ * `State.parse` on its own. The state string is a wire format in its own right —
+ * the one piece of the query form that also appears inside session JSON, and the
+ * one with two live versions — so it is pinned directly as well as through the
+ * decoder.
+ *
+ * The instance, not `toJSON()`: the serializer above prints its own properties,
+ * which is a superset of the wire projection and so pins the fields `toJSON`
+ * drops as well as the ones it keeps.
+ */
+describe('decoder golden file — state strings', () => {
+
+    for (const fixture of stateStringCorpus) {
+        test(fixture.id, () => {
+            expect(State.parse(fixture.input)).toMatchSnapshot()
+        })
+    }
+})

--- a/test/testWireFormatCorpus.js
+++ b/test/testWireFormatCorpus.js
@@ -19,20 +19,11 @@ import State from '../js/hicState.js'
 import {
     FORMATS,
     OUTCOMES,
-    wireFormatCorpus,
+    selfContained,
     stateStringCorpus,
+    viaLoader,
+    wireFormatCorpus,
 } from './data/wireFormatCorpus.js'
-
-/**
- * Fixtures whose input is a plain string and whose decode needs nothing else.
- * The rest need something a string literal cannot supply — a network fetch, an
- * injected loader, or a File object — and are exercised by whatever test
- * supplies it.
- */
-const selfContained = wireFormatCorpus.filter(f =>
-    f.input !== undefined &&
-    f.loaderResponse === undefined &&
-    f.format !== 'juiceboxURL')
 
 const stateStringById = Object.fromEntries(stateStringCorpus.map(f => [f.id, f.input]))
 
@@ -131,7 +122,7 @@ describe('wire-format corpus — session URLs decode from their loader response'
 
     afterEach(() => vi.restoreAllMocks())
 
-    for (const fixture of wireFormatCorpus.filter(f => f.loaderResponse !== undefined)) {
+    for (const fixture of viaLoader) {
         test(fixture.id, async () => {
             vi.spyOn(igvxhr, 'loadString').mockImplementation(async () => {
                 if (fixture.loaderResponse === null) throw new Error('simulated fetch failure')


### PR DESCRIPTION
Closes #503.

ADR-0006's "How we know the decoder did not change" asks for a golden-file characterization test as the first ticket in candidate 5, and this is it. All 59 corpus fixtures — 50 wire-format, 9 state strings — are run through `extractConfig` as it stands and the result is snapshotted verbatim. **Nothing in the decoder moves until this is green;** the collapse into `decodeSession` passes when the snapshots come back byte-identical, and not before.

## Acceptance criteria

- [x] Every fixture in the corpus has a committed snapshot of today's decoded output
- [x] Inputs the decoder rejects have their failure mode snapshotted, not just their success
- [x] The suite runs without network, DOM or file I/O
- [x] A deliberate change to decoder behaviour fails the suite until its snapshot is updated
- [x] The commented-update convention is written down where the next person will find it

The fourth was measured rather than assumed: flipping `displayMode` to `"EXPANDED"` in `fixDefaults` broke 17 of the 59 snapshots; reverting restored green.

The third is enforced rather than asserted. `igvxhr.loadString` and `fetch` both throw by default in `beforeEach`, so a fixture that reaches either fails loudly instead of quietly going to the wire; the two suites that legitimately need them re-stub with the canned response the corpus already carries. Whole run is 400ms.

## Three notes on the snapshots

**A local serializer prints class instances as their own properties under their class name.** The default serializer calls `toJSON()` where one exists, which would show `State` as its seven-field wire projection and hide both the class identity and any field the projection drops. Both matter: a `state` that arrived as a `State` from `decodeQuery` and one that arrived as a plain object from `JSON.parse` are different values, and the collapse could turn one into the other without anyone noticing.

**The `sessionFile` arm is unreachable, and the snapshot says so.** `extractQuery` calls `indexOf` on its argument and can only ever produce string values; the sole caller hands it `window.location.href`. Nothing reaches the `File` branch. Those three fixtures pin the parser's `TypeError` one line earlier — real behaviour, not a stand-in — and the assertion is on that specific message, so the day the arm becomes reachable the test fails and points at the corpus's declared outcome instead. This is the one place the suite does not assert `fixture.outcome`: the corpus records what the *arm* would do with `fileText` (two `decodes`, hand-measured by reading code), which is not what the *decoder* does with a File.

**The bit.ly path decodes in full, offline.** Driven from the `long_url` captured on 2026-08-09. The single-brace-repair bug at `urlUtils.js:417` turns out not to mangle this link: `decodeURIComponent` runs before the `},{` split and restores what the lone `replace` escaped, so both browsers come through. Now pinned, which matters when #506 removes the path.

## Also here

`test/data/wireFormatCorpus.js` exports the four partitions (`selfContained`, `viaLoader`, `viaBitly`, `viaFile`) rather than each test re-deriving them — `testWireFormatCorpus.js` had its own copy of two of them. A guard asserts the partitions stay disjoint and exhaustive: "every fixture has a snapshot" has to hold by construction, not by having been true the day it was written.

`CONTEXT.md` gains a paragraph saying the snapshots *are* the compatibility contract in executable form, pointing at the test header for the update convention. The convention itself — read the diff fixture by fixture, update only what you can explain, log the authorising decision, never `vitest -u` the file wholesale — stays in one place.

## Testing

640 passing across 34 files. No snapshots written or obsolete on a clean run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)