### PR TITLE
Lift format sniffing and the state-decode ladder out as pure functions (#504)

### DIFF
--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -35,7 +35,19 @@ import {getLayoutDimensions} from './layoutController.js'
 import Track2D from './track2D.js'
 
 import {DEFAULT_ANNOTATION_COLOR} from "./urlUtils.js"
+import {decodeState} from "./sessionCodec.js"
 import {mapTrackConfig} from "./urlMapper.js"
+
+/**
+ * How this module reports a `config.state` that is neither a state token nor a
+ * state object. `decodeState` returns the default view either way; saying so is
+ * kept out of the codec, which is pure by design and has no business raising an
+ * `alert`.
+ */
+function reportUnknownStateType() {
+    alert('config.state is of unknown type');
+    console.error('config.state is of unknown type');
+}
 
 /**
  * DataLoader handles all data loading responsibilities for HICBrowser.
@@ -109,15 +121,7 @@ class DataLoader {
                 this.browser.setActiveDataset(dataset, state);
                 await this.browser.parseGotoInput(config.locus);
             } else if (config.state) {
-                if (typeof config.state === 'string') {
-                    state = State.parse(config.state);
-                } else if (typeof config.state === 'object') {
-                    state = State.fromJSON(config.state);
-                } else {
-                    alert('config.state is of unknown type');
-                    console.error('config.state is of unknown type');
-                    state = State.default(config);
-                }
+                state = decodeState(config.state, config, reportUnknownStateType);
 
                 this.browser.setActiveDataset(dataset, state);
                 await this.browser.setState(state);
@@ -240,14 +244,11 @@ class DataLoader {
                 EventBus.globalBus.post(HICEvent("GenomeChange", this.browser.genome.id));
             }
 
-            let state;
-            if (config.state) {
-                state = typeof config.state === 'object'
-                    ? State.fromJSON(config.state)
-                    : State.parse(config.state);
-            } else {
-                state = State.default(config);
-            }
+            // The same ladder the file path walks. It used to be spelled
+            // differently here and had lost the unknown-type rung, so a numeric
+            // `state` crashed in `State.parse` on this path and opened the
+            // default view on the other. #504.
+            const state = decodeState(config.state, config, reportUnknownStateType);
 
             this.browser.setActiveDataset(dataset, state);
             await this.browser.setState(state);

--- a/js/sessionCodec.js
+++ b/js/sessionCodec.js
@@ -1,0 +1,203 @@
+/**
+ * The session wire format, decoded — the pure half.
+ *
+ * Everything here takes a string (or a plain object) and returns a value. No
+ * network, no DOM, no async, no `State` mutation. That is the point: the decode
+ * decisions this module owns were previously written two and three times each,
+ * inside async wrappers that could only be exercised through `extractConfig`
+ * with a stubbed loader, and so were reachable from no test at all.
+ *
+ * ADR-0006 decision 9. `js/urlUtils.js` keeps only URL-shortcut and
+ * query-string concerns, which is the one job its name describes.
+ *
+ * ## The error contract
+ *
+ * One condition, one error: anything this module cannot decode raises a
+ * `SessionDecodeError` carrying the underlying failure as `cause`. Previously
+ * the same malformed input produced a different message depending on which of
+ * three call sites reached it, which made a user's bug report ambiguous about
+ * where their link actually failed.
+ *
+ * **The three call sites in `urlUtils.js` still rethrow `cause` in the shape
+ * each has always thrown**, because ADR-0006's golden file (#503) pins those
+ * outward messages and this ticket changes no behaviour. Unifying what the
+ * *caller* reports is a deliberate, snapshot-moving change and belongs to a
+ * later ticket in the candidate; unifying what the *decoder* raises is this one.
+ *
+ * @see docs/adr/0006-session-wire-format-and-one-decoder.md
+ * @see docs/url.md — the format specification
+ */
+import {BGZip} from 'igv-utils'
+import State from './hicState.js'
+
+/**
+ * The shapes a session string can arrive in.
+ *
+ * `BLOB` and `DATA_URI` are told apart because the sniff is the one place that
+ * can still see the difference — they are handled identically downstream (both
+ * prefixes are five characters and both carry the same compressed payload), and
+ * naming them separately keeps that an observation rather than a coincidence.
+ *
+ * There is no `STATE_TOKEN` member. A bare state token (`3,3,6,…`) is a wire
+ * format in its own right, but it never arrives as a *session* string — it
+ * arrives as the `state=` query parameter, already discriminated by position,
+ * and is decoded by {@link decodeState}. Adding a branch here for it would
+ * invent a form nothing writes and nothing reads.
+ */
+export const SessionFormat = {
+    BLOB: 'blob',
+    DATA_URI: 'data-uri',
+    JSON: 'json',
+}
+
+const COMPRESSED_PREFIXES = {
+    'blob:': SessionFormat.BLOB,
+    'data:': SessionFormat.DATA_URI,
+}
+
+/**
+ * Raised for every input this module refuses.
+ *
+ * `cause` is the failure underneath — a `SyntaxError` from `JSON.parse`, or
+ * whatever the decompressor threw, which is not always an `Error`: `BGZip`
+ * rejects a corrupt payload with a bare string.
+ */
+export class SessionDecodeError extends Error {
+    constructor(message, cause) {
+        super(message)
+        this.name = 'SessionDecodeError'
+        this.cause = cause
+    }
+}
+
+/**
+ * Decide what a session string is, and split off the part that carries the
+ * payload.
+ *
+ * @param {string} text - a session string, from a URL parameter, a fetched
+ *   document or a file's contents
+ * @returns {{format: string, payload: string}} `format` is a
+ *   {@link SessionFormat} member; `payload` is the compressed body for the two
+ *   compressed forms, and the whole string for `JSON`
+ * @throws {SessionDecodeError} if `text` is not a string
+ */
+export function sniffSessionFormat(text) {
+
+    if (typeof text !== 'string') {
+        throw new SessionDecodeError(`Session must be a string, got ${typeof text}`)
+    }
+
+    for (const [prefix, format] of Object.entries(COMPRESSED_PREFIXES)) {
+        if (text.startsWith(prefix)) {
+            return {format, payload: text.substring(prefix.length)}
+        }
+    }
+
+    return {format: SessionFormat.JSON, payload: text}
+}
+
+/**
+ * Is this session string one of the compressed forms?
+ *
+ * The predicate behind the sniff, exported because `extractConfig` needs the
+ * same question answered before it knows which of its arms to enter — and
+ * answering it with a fourth copy of the prefix literals is exactly what this
+ * module exists to stop.
+ *
+ * Deliberately no type check: a non-string raises the same `TypeError` here
+ * that the inline literals raised, on a path the golden file records as
+ * unreachable.
+ *
+ * @param {string} text
+ * @returns {boolean}
+ */
+export function isCompressedSession(text) {
+    return Object.keys(COMPRESSED_PREFIXES).some(prefix => text.startsWith(prefix))
+}
+
+/**
+ * Decode a session string to the session config it encodes.
+ *
+ * The whole ladder: sniff, decompress if compressed, parse. Every failure —
+ * a corrupt compressed payload, a body that is not JSON, a non-string argument
+ * — comes back as a {@link SessionDecodeError}.
+ *
+ * The message names the form that failed to read, so it varies with the *input*
+ * and never with which caller reached it. That is the distinction the single
+ * error contract is about: today the same malformed string produced a different
+ * message depending on the path, which made a bug report ambiguous about where
+ * the link actually failed.
+ *
+ * @param {string} text
+ * @returns {object} the decoded session config
+ * @throws {SessionDecodeError}
+ */
+export function decodeSessionString(text) {
+
+    const {format, payload} = sniffSessionFormat(text)
+
+    let json
+    if (format === SessionFormat.JSON) {
+        json = payload
+    } else {
+        try {
+            json = BGZip.uncompressString(payload)
+        } catch (e) {
+            throw new SessionDecodeError(`Session is not a readable ${format}`, e)
+        }
+    }
+
+    try {
+        return JSON.parse(json)
+    } catch (e) {
+        throw new SessionDecodeError('Session is not valid JSON', e)
+    }
+}
+
+/**
+ * Decode the `state` a config carries, whichever of its two spellings it uses.
+ *
+ * A state reaches a config either as the token string from a `state=` query
+ * parameter or as the object `State.toJSON()` writes into a session. Both are
+ * live, and a config carrying neither falls back to the default view.
+ *
+ * This ladder was written twice — `dataLoader.loadHicFile` and
+ * `dataLoader.loadLiveContactMap` — and the two copies had drifted: only the
+ * first had the unknown-type rung, so a `state` that was neither string nor
+ * object reached `State.parse` on the live path and crashed there instead of
+ * falling back. The rung is restored here for both.
+ *
+ * Reporting the unknown type is the caller's job, not this module's — the
+ * original copy raised an `alert`, which is exactly the kind of thing that
+ * makes a decoder untestable.
+ *
+ * @param {string|object|undefined} value - `config.state`. Absent or empty
+ *   yields the default view, which is the truthiness guard both call sites
+ *   wrote around the ladder; delegating it here keeps `''` and `0` out of
+ *   `State.parse`, where they decode to a view of `NaN`.
+ * @param {object} [config] - passed through to `State.default`, which **ignores
+ *   it** — a known defect (`hicState.js`, `State.default(configOrUndefined)`),
+ *   filed separately per ADR-0006's consequences. Threaded anyway so that
+ *   fixing it there fixes it for both call sites at once.
+ * @param {function(*): void} [onUnknownType] - called with `value` when it is
+ *   neither a string nor an object; the default view is returned either way
+ * @returns {State}
+ */
+export function decodeState(value, config, onUnknownType = () => {}) {
+
+    if (!value) {
+        return State.default(config)
+    }
+
+    if (typeof value === 'string') {
+        return State.parse(value)
+    }
+
+    if (typeof value === 'object') {
+        return State.fromJSON(value)
+    }
+
+    onUnknownType(value)
+
+    return State.default(config)
+}

--- a/js/urlUtils.js
+++ b/js/urlUtils.js
@@ -25,6 +25,7 @@ import {parseColorScale} from "./colorScaleParser.js"
 import {StringUtils, BGZip} from 'igv-utils'
 import {isFile} from './fileUtils.js'
 import {igvxhr} from 'igv-utils'
+import {decodeSessionString, isCompressedSession} from './sessionCodec.js'
 
 const DEFAULT_ANNOTATION_COLOR = "rgb(22, 129, 198)";
 
@@ -78,6 +79,20 @@ function expandSessionUrlShortcuts(session) {
     }
 }
 
+/**
+ * Report a session that would not decode, in the shape the arm naming `origin`
+ * has always reported it. Two arms, one shape, one noun apart.
+ *
+ * `cause` is the failure underneath the codec's single `SessionDecodeError`, and
+ * is not always an `Error` -- `BGZip` rejects a corrupt payload with a bare
+ * string, whose `message` is `undefined`. That `undefined` reaches the user
+ * today; #521 is where it stops.
+ */
+function parseFailure(origin, e) {
+    console.error(`Error parsing session ${origin}:`, e.cause);
+    return new Error(`Failed to parse session ${origin}: ${e.cause?.message}`);
+}
+
 async function extractConfig(queryString) {
 
     let query = extractQuery(queryString);
@@ -85,38 +100,40 @@ async function extractConfig(queryString) {
 
     if (query.hasOwnProperty("session")) {
         const sessionValue = query.session;
-        if (sessionValue.startsWith("blob:") || sessionValue.startsWith("data:")) {
-            sessionConfig = JSON.parse(BGZip.uncompressString(sessionValue.substr(5)));
+
+        // Three arms, one decoder. The arms differ only in where the session
+        // text comes from -- the parameter itself, a File, or a fetched
+        // document -- and in how they report a failure. The reporting is
+        // preserved verbatim: `decodeSessionString` raises one error for every
+        // malformed session (ADR-0006 decision 9), and each arm rethrows its
+        // `cause` in the shape it has always thrown, because #503's golden file
+        // pins those messages and this ticket changes no behaviour. Collapsing
+        // the three outward messages into one moves those snapshots and is #521.
+        if (isCompressedSession(sessionValue)) {
+            // No wrapping here, and never has been: a corrupt share link
+            // rejects with whatever the decompressor threw, which is a bare
+            // string rather than an Error.
+            try {
+                sessionConfig = decodeSessionString(sessionValue);
+            } catch (e) {
+                throw e.cause ?? e;
+            }
         } else if (isFile(sessionValue)) {
             // Handle File object
             const sessionText = await sessionValue.text();
             try {
-                // Try to parse as compressed blob first
-                if (sessionText.startsWith("blob:") || sessionText.startsWith("data:")) {
-                    sessionConfig = JSON.parse(BGZip.uncompressString(sessionText.substr(5)));
-                } else {
-                    // Parse as plain JSON
-                    sessionConfig = JSON.parse(sessionText);
-                }
+                sessionConfig = decodeSessionString(sessionText);
             } catch (e) {
-                console.error("Error parsing session file:", e);
-                throw new Error(`Failed to parse session file: ${e.message}`);
+                throw parseFailure("file", e);
             }
         } else if (typeof sessionValue === 'string') {
             // Handle session URL or local file path
             try {
                 const sessionText = await igvxhr.loadString(sessionValue);
                 try {
-                    // Try to parse as compressed blob first
-                    if (sessionText.startsWith("blob:") || sessionText.startsWith("data:")) {
-                        sessionConfig = JSON.parse(BGZip.uncompressString(sessionText.substr(5)));
-                    } else {
-                        // Parse as plain JSON
-                        sessionConfig = JSON.parse(sessionText);
-                    }
+                    sessionConfig = decodeSessionString(sessionText);
                 } catch (e) {
-                    console.error("Error parsing session from URL/file:", e);
-                    throw new Error(`Failed to parse session from URL/file: ${e.message}`);
+                    throw parseFailure("from URL/file", e);
                 }
             } catch (e) {
                 console.error("Error loading session from URL/file:", e);

--- a/test/testSessionCodec.js
+++ b/test/testSessionCodec.js
@@ -1,0 +1,232 @@
+/**
+ * `js/sessionCodec.js` — the pure half of the session decoder. #504, ADR-0006
+ * decision 9.
+ *
+ * The whole reason this module exists is that it can be driven from string
+ * literals: no network, no DOM, no async, no browser. Nothing in this file
+ * stubs anything, and if that ever stops being true the extraction has leaked.
+ *
+ * The golden file (`test/testDecoderGolden.js`) still owns the question "does
+ * the decoder as a whole behave as it did?". This file owns "does each decision
+ * inside it behave as described?" — including the branches the golden corpus
+ * cannot reach, such as the unknown-`state`-type rung that no URL can express.
+ *
+ * @see js/sessionCodec.js
+ * @see docs/adr/0006-session-wire-format-and-one-decoder.md
+ */
+import {describe, expect, test} from 'vitest'
+import {BGZip} from 'igv-utils'
+import {
+    SessionDecodeError,
+    SessionFormat,
+    decodeSessionString,
+    decodeState,
+    isCompressedSession,
+    sniffSessionFormat,
+} from '../js/sessionCodec.js'
+import State from '../js/hicState.js'
+
+/**
+ * The share link juicebox-web writes is `?session=blob:<compressed JSON>`, so a
+ * compressed fixture is built the way one is written rather than pasted as an
+ * opaque literal — a pasted blob would pin this suite to one compressor build.
+ */
+function compress(object) {
+    return BGZip.compressString(JSON.stringify(object))
+}
+
+describe('sniffSessionFormat', () => {
+
+    test('a share link is a compressed blob, and the prefix is not part of the payload', () => {
+        expect(sniffSessionFormat('blob:H4sIAAAA')).toEqual({
+            format: SessionFormat.BLOB,
+            payload: 'H4sIAAAA',
+        })
+    })
+
+    test('a data URI is told apart from a blob, and carries the same payload shape', () => {
+        expect(sniffSessionFormat('data:H4sIAAAA')).toEqual({
+            format: SessionFormat.DATA_URI,
+            payload: 'H4sIAAAA',
+        })
+    })
+
+    test('anything else is JSON, payload and all', () => {
+        expect(sniffSessionFormat('{"browsers":[]}')).toEqual({
+            format: SessionFormat.JSON,
+            payload: '{"browsers":[]}',
+        })
+    })
+
+    test('the prefix must be at the front — a blob named inside a document is not one', () => {
+        const {format} = sniffSessionFormat('{"url":"blob:something"}')
+        expect(format).toBe(SessionFormat.JSON)
+    })
+
+    test('the empty string sniffs as JSON rather than throwing; decoding is what refuses it', () => {
+        expect(sniffSessionFormat('').format).toBe(SessionFormat.JSON)
+    })
+
+    test('a non-string is the one thing the sniff itself refuses', () => {
+        expect(() => sniffSessionFormat(undefined)).toThrow(SessionDecodeError)
+        expect(() => sniffSessionFormat({session: 'x'}))
+            .toThrow('Session must be a string, got object')
+    })
+})
+
+/**
+ * `extractConfig` asks this question before it knows which of its three arms to
+ * enter, so it has to be answerable without decoding. It must stay the same
+ * question `sniffSessionFormat` answers — a fourth copy of the prefix literals
+ * in `urlUtils.js` is what the extraction was for.
+ */
+describe('isCompressedSession', () => {
+
+    test.each([
+        ['blob:H4sIAAAA', true],
+        ['data:H4sIAAAA', true],
+        ['{"browsers":[]}', false],
+        ['https://example.org/session.json', false],
+        ['', false],
+    ])('%s -> %s', (text, expected) => {
+        expect(isCompressedSession(text)).toBe(expected)
+    })
+
+    test('agrees with the sniff on every input', () => {
+        for (const text of ['blob:x', 'data:x', '{}', 'session.json', '']) {
+            const compressed = sniffSessionFormat(text).format !== SessionFormat.JSON
+            expect(isCompressedSession(text), text).toBe(compressed)
+        }
+    })
+})
+
+describe('decodeSessionString', () => {
+
+    test('plain JSON decodes to the object it spells', () => {
+        expect(decodeSessionString('{"browsers":[{"url":"a.hic"}]}'))
+            .toEqual({browsers: [{url: 'a.hic'}]})
+    })
+
+    test('a compressed blob decodes to the same object', () => {
+        const session = {browsers: [{url: 'a.hic', name: 'A'}]}
+        expect(decodeSessionString(`blob:${compress(session)}`)).toEqual(session)
+    })
+
+    test('a data URI decodes by the same path as a blob', () => {
+        const session = {browsers: [{url: 'a.hic'}]}
+        expect(decodeSessionString(`data:${compress(session)}`)).toEqual(session)
+    })
+
+    /**
+     * The single error contract, stated three ways. Each of these produced a
+     * different message at each of the three former call sites; here the same
+     * condition raises the same error whatever reached it, with the underlying
+     * failure kept as `cause` so the caller can still say what went wrong.
+     */
+    describe('one error contract', () => {
+
+        test('a document that is not JSON', () => {
+            expect(() => decodeSessionString('<!doctype html>')).toThrow(SessionDecodeError)
+            expect(() => decodeSessionString('<!doctype html>')).toThrow('Session is not valid JSON')
+        })
+
+        test('the parse failure survives as `cause`', () => {
+            try {
+                decodeSessionString('<!doctype html>')
+                expect.unreachable('malformed JSON must not decode')
+            } catch (e) {
+                expect(e.cause).toBeInstanceOf(SyntaxError)
+            }
+        })
+
+        test('a corrupt compressed payload names the form it failed to read', () => {
+            expect(() => decodeSessionString('blob:not-a-compressed-payload'))
+                .toThrow('Session is not a readable blob')
+            expect(() => decodeSessionString('data:not-a-compressed-payload'))
+                .toThrow('Session is not a readable data-uri')
+        })
+
+        /**
+         * `BGZip` rejects a corrupt payload with a bare string, not an `Error`.
+         * Pinned because the wrapper is what makes that survivable for callers,
+         * and because the golden file records the raw string reaching a user.
+         */
+        test('a decompression failure survives as `cause` even when it is not an Error', () => {
+            try {
+                decodeSessionString('blob:not-a-compressed-payload')
+                expect.unreachable('a corrupt payload must not decode')
+            } catch (e) {
+                expect(e).toBeInstanceOf(SessionDecodeError)
+                expect(e.cause).toBeDefined()
+            }
+        })
+
+        test('compressed JSON that decompresses to something unparseable is a JSON failure', () => {
+            expect(() => decodeSessionString(`blob:${BGZip.compressString('not json')}`))
+                .toThrow('Session is not valid JSON')
+        })
+    })
+})
+
+describe('decodeState', () => {
+
+    /**
+     * The v0 seven-token form, from the published Haarhuis et al. link — the
+     * same literal the golden corpus carries as load-bearing.
+     */
+    test('a state token decodes through State.parse', () => {
+        const state = decodeState('3,3,6,5537.98746,5537.749239047619,1,KR')
+        expect(state).toBeInstanceOf(State)
+        expect(state.chr1).toBe(3)
+        expect(state.zoom).toBe(6)
+        expect(state.normalization).toBe('KR')
+    })
+
+    test('a state object decodes through State.fromJSON', () => {
+        const state = decodeState({chr1: 1, chr2: 2, zoom: 3, x: 10, y: 20, pixelSize: 2, normalization: 'VC'})
+        expect(state).toBeInstanceOf(State)
+        expect(state.chr2).toBe(2)
+        expect(state.pixelSize).toBe(2)
+        expect(state.normalization).toBe('VC')
+    })
+
+    test('no state at all is the default view', () => {
+        expect(decodeState(undefined)).toEqual(State.default())
+    })
+
+    /**
+     * Both call sites guarded the ladder with `if (config.state)`. Delegating
+     * that guard is what keeps an empty string out of `State.parse`, where it
+     * would decode to a view of `NaN` rather than to the default.
+     */
+    test('an empty state is the default view, not a view of NaN', () => {
+        expect(decodeState('')).toEqual(State.default())
+        expect(decodeState(null)).toEqual(State.default())
+    })
+
+    /**
+     * The rung the live-map copy had lost. `State.parse` on a number throws;
+     * before this extraction, a live contact map handed a numeric `state` died
+     * there while a `.hic` file handed the same value opened the default view.
+     */
+    describe('the unknown-type rung', () => {
+
+        test('an unknown type falls back to the default view rather than throwing', () => {
+            expect(decodeState(42)).toEqual(State.default())
+        })
+
+        test('the caller is told, and is handed the offending value', () => {
+            const seen = []
+            decodeState(42, undefined, value => seen.push(value))
+            expect(seen).toEqual([42])
+        })
+
+        test('the reporter is not called for the types the ladder handles', () => {
+            const seen = []
+            decodeState('1,2,4,10,20,3', undefined, v => seen.push(v))
+            decodeState({chr1: 0, chr2: 0}, undefined, v => seen.push(v))
+            decodeState(undefined, undefined, v => seen.push(v))
+            expect(seen).toEqual([])
+        })
+    })
+})


### PR DESCRIPTION
Closes #504. ADR-0006 decision 9 — the first extraction in candidate 5, and the one that must not change a single snapshot.

New `js/sessionCodec.js`. Two decisions that were written two and three times each, inside async wrappers reachable only through `extractConfig` with a stubbed loader, are now pure functions testable with string literals — no network, no DOM, no async.

## Format sniffing

`sniffSessionFormat` and `isCompressedSession` replace three copies of `startsWith("blob:") || startsWith("data:")` and the `substr(5)` that followed each. `decodeSessionString` owns the ladder from there: sniff, decompress if compressed, parse.

## One error contract

Every input the codec refuses raises a `SessionDecodeError` carrying the underlying failure as `cause`. The message names the form that failed to read, so it varies with the *input* and never with which caller reached it — which was the point of the ticket: the same malformed string used to produce a different message depending on the path, making a user's bug report ambiguous about where their link actually failed.

**The three arms in `urlUtils.js` still rethrow `cause` in the shape each has always thrown.** #503's golden file pins those outward messages and this ticket changes no behaviour, so #504's two criteria — "one error contract" and "byte-identical snapshots" — genuinely conflict at the boundary. Resolved in favour of the snapshots: the contract is single inside the codec, and collapsing the outward messages is **#521**, filed with the per-fixture snapshot-update convention spelled out.

## The state-decode ladder

`decodeState` replaces the two copies in `dataLoader.js`, which had drifted: only the `.hic` path had the unknown-type rung, so a numeric `state` crashed in `State.parse` on the live-map path and opened the default view on the other. **The rung is restored for both** — the one behaviour change in the PR, and the one #504 asks for.

Reporting the unknown type stays with the caller; the original copy raised an `alert`, which is exactly what made the decoder untestable. The truthiness guard both call sites wrote around the ladder moves into it, keeping `''` and `0` out of `State.parse`, where they decode to a view of `NaN`.

## Verification

- `test/__snapshots__/testDecoderGolden.js.snap` **unmodified** — the acceptance criterion, and the whole reason #503 landed first
- 667 tests pass (640 before, +27 in `test/testSessionCodec.js`), build clean
- The new suite stubs nothing. If that ever stops being true, the extraction has leaked.

## Scope note

"`js/urlUtils.js` no longer contains session-decoding logic" is met for the `session=` arms. Still there: `BGZip.uncompressString(query["juiceboxData"])` and `State.parse(stateString)` inside `decodeQuery` — the legacy *query* formats rather than session strings, and #506's territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)