### PR TITLE
Drop the legacy bit.ly juiceboxURL= form (#506)

### DIFF
--- a/docs/url.md
+++ b/docs/url.md
@@ -185,7 +185,27 @@ follow the same rules as above.
 | `session=` | **v1 session JSON**. A `blob:` or `data:` prefix means the rest is compressed and base64-encoded — the only form juicebox writes, as juicebox-web's share link. Anything else is loaded as a URL or file and may be either compressed or plain JSON. |
 | `juicebox={…},{…}` | one brace-wrapped query string per browser, comma-separated. Read-only legacy. |
 | `juiceboxData=` | the `juicebox=` value above, compressed. **Not** session JSON — the two share one code path, and the only difference is that this one is decompressed first. Read-only legacy. |
-| `juiceboxURL=` | a bit.ly short link to expand and re-decode. **Deprecated, and the one format deliberately dropped** — see ADR-0006 decision 1. The decoder still takes this path today; #506 removes it. ADR-0006 expected it to be dead already, on the grounds that the bit.ly endpoint wants a credential we no longer hold; measured 2026-08-09 (#502) it is **not** dead — a link expands and its session decodes in full. #506 therefore removes working behaviour. |
 
 Session JSON has no `version` field today; its absence means v1. When one is
 added (#508) it will be written but never required.
+
+A fourth whole-session parameter, `juiceboxURL=`, was accepted until 2026-08-09
+— see [Removed forms](#removed-forms).
+
+## Removed forms
+
+The accepted set is frozen (ADR-0006 decision 1): a form listed anywhere above
+stays readable. This section is the exception list — forms that were accepted
+once and are not any more. It exists so that someone holding an old link can
+find out what happened to it, which is the only reason a removal is
+discoverable at all.
+
+| Parameter | Removed | What it was, and what to do with one |
+| --------- | ------- | ------------------------------------ |
+| `juiceboxURL=` | **2026-08-09**, in #506 — ADR-0006 decision 1 | A bit.ly short link standing for a whole juicebox href: juicebox expanded it through bit.ly's API and re-decoded the href that came back. It is now **refused**, with an error naming the parameter — not a timeout and not a parse failure. **To recover a link:** open the bit.ly URL in a browser and use the juicebox URL it redirects to; that URL is in one of the forms above and still decodes. |
+
+The grounds are in
+[ADR-0006](adr/0006-session-wire-format-and-one-decoder.md) decision 1 and are
+not restated here. One thing that page records and this one should not hide:
+the removal took **working** behaviour. The ADR predicted the format was already
+dead; measured on the day it went, it was not.

--- a/js/sessionCodec.js
+++ b/js/sessionCodec.js
@@ -8,9 +8,9 @@
  * reachable from a test**. That, more than the duplication, is the defect this
  * module exists to fix. ADR-0006 decisions 9 and 10.
  *
- * `js/urlUtils.js` keeps only the two I/O sites the decode path may need — the
- * session-URL fetch and the legacy bit.ly expansion — and the internal entry
- * point that injects them.
+ * `js/urlUtils.js` keeps only the one I/O site the decode path may need — the
+ * session-URL fetch — and the internal entry point that injects it. There were
+ * two until #506 retired the legacy bit.ly expansion.
  *
  * ## The decode path
  *
@@ -20,18 +20,20 @@
  * is the one place a wire format is named: four formats, one adapter each,
  * folded in order over a shared decode context. **A fifth format is an entry in
  * that array and nothing else** — which is the acceptance criterion of #505 and
- * the reason the fold takes a context rather than four bespoke arms.
+ * the reason the fold takes a context rather than four bespoke arms. Retiring
+ * one is an entry there too: `juiceboxURL` was dropped by #506 and its adapter
+ * stayed, now refusing rather than expanding, so a retired link fails saying so
+ * instead of falling through to `query` and decoding to nothing.
  *
- * The order is not decoration. `juiceboxURL` rewrites the query the later
- * adapters read, `juicebox` overwrites a config the `session` adapter may have
- * produced, and `query` overwrites both when it names a map. That precedence is
- * exactly what the previous straight-line function expressed by statement order,
- * and the golden file (#503) pins it.
+ * The order is not decoration. `juicebox` overwrites a config the `session`
+ * adapter may have produced, and `query` overwrites both when it names a map.
+ * That precedence is exactly what the previous straight-line function expressed
+ * by statement order, and the golden file (#503) pins it.
  *
  * ## No I/O
  *
- * `decodeSession` fetches nothing. The two loaders it may need arrive as
- * arguments, so the whole path is drivable from a test with string literals.
+ * `decodeSession` fetches nothing. The loader it may need arrives as an
+ * argument, so the whole path is drivable from a test with string literals.
  * Hoisting the fetching into the caller was considered and rejected in decision
  * 10: a session parameter may name a URL whose *contents* then need sniffing, so
  * a caller deciding whether more I/O is needed would need to know the format.
@@ -514,8 +516,9 @@ function parseFailure(origin, e) {
 /**
  * @typedef {object} DecodeContext
  * @property {object} query - the query parameters, as `extractQuery` read them.
- *   `juiceboxURL` replaces this wholesale, which is why it is context and not an
- *   argument.
+ *   Context rather than an argument because an adapter may rewrite it for the
+ *   ones below: `juiceboxURL` did exactly that until #506 retired it, and it is
+ *   the shape the fold is built for rather than a quirk of that one format.
  * @property {object|undefined} config - the session config decoded so far. A
  *   later adapter that owns the input overwrites an earlier one's answer.
  * @property {object|undefined} queryConfig - what the query parameters alone
@@ -527,9 +530,8 @@ function parseFailure(origin, e) {
 /**
  * @typedef {object} SessionLoaders
  * @property {function(string): Promise<string>} [loadString] - fetches the
- *   document a `session=<url>` names
- * @property {function(string): Promise<string>} [expandUrl] - expands a legacy
- *   bit.ly link to the href it stands for
+ *   document a `session=<url>` names. The only loader: `expandUrl` went with the
+ *   bit.ly expansion in #506.
  */
 
 /**
@@ -600,16 +602,29 @@ export const WIRE_FORMATS = [
     },
 
     /**
-     * `?juiceboxURL=` — a bit.ly link standing for a whole juicebox href. It
-     * decodes to no config of its own: it replaces the query the adapters below
-     * read. ADR-0006 decision 1 drops this format and #506 is where it goes.
+     * `?juiceboxURL=` — **retired**. A bit.ly link standing for a whole juicebox
+     * href; expanding it replaced the query the adapters below read. ADR-0006
+     * decision 1 named this the one deliberate exception to the frozen
+     * compatibility contract, and #506 removed the expansion.
+     *
+     * The entry stays, and what it does now is refuse. Deleting it would leave
+     * `?juiceboxURL=…` matching no adapter, so it would fall through to `query`,
+     * decode to no config, and the host would silently show whatever it was
+     * configured with — a link that does nothing, with nothing said. A retired
+     * format is still a format the decoder has an answer for; this is the
+     * answer.
+     *
+     * The grounds for the removal are ADR-0006 decision 1's, and are recorded
+     * there rather than repeated here.
      */
     {
         format: 'juiceboxURL',
         appliesTo: ({query}) => query.hasOwnProperty('juiceboxURL'),
-        decode: async ctx => {
-            const expandUrl = requireLoader(ctx, 'expandUrl', 'a legacy bit.ly link')
-            ctx.query = extractQuery(await expandUrl(ctx.query['juiceboxURL']))
+        decode: async () => {
+            throw new SessionDecodeError(
+                'juiceboxURL= links are no longer supported: the bit.ly expansion was ' +
+                'removed in #506 (ADR-0006 decision 1). Open the link in a browser to ' +
+                'read the juicebox URL it stands for, and use that. See docs/url.md.')
         },
     },
 

--- a/js/urlUtils.js
+++ b/js/urlUtils.js
@@ -25,9 +25,12 @@
  * The I/O edge of the session decoder, and nothing else.
  *
  * Every decision about what a session URL *means* lives in `js/sessionCodec.js`,
- * which fetches nothing. What is left here is the two reads that path may need —
- * a `session=<url>` document and a legacy bit.ly expansion — and `extractConfig`,
- * which injects them. ADR-0006 decisions 9 and 10.
+ * which fetches nothing. What is left here is the one read that path may need —
+ * a `session=<url>` document — and `extractConfig`, which injects it. ADR-0006
+ * decisions 9 and 10.
+ *
+ * There were two reads until #506 retired the legacy bit.ly expansion, taking
+ * the module's only `fetch` and its embedded bearer credential with it.
  *
  * **`extractConfig` stays internal.** It has one caller (`init.js`) and is not
  * exported from `js/index.js`: the public contract here is the wire format, not
@@ -51,49 +54,7 @@ import {decodeSession} from './sessionCodec.js'
 async function extractConfig(queryString) {
     return decodeSession(queryString, {
         loadString: url => igvxhr.loadString(url),
-        expandUrl: expandURL,
     })
-}
-
-/**
- * Expand legacy bitly URLs
- *
- * **The bearer literal below is byte-fragile.** It is mojibake carrying three
- * unprintable characters (0x7f, 0x1a, 0x1d); an editor that normalizes them away
- * leaves a token bit.ly answers 403 to, and `test/testURL.js` is the only thing
- * that notices. ADR-0006 decision 1 drops this format and #506 deletes this
- * function; until then, move these bytes, never retype them.
- *
- * @param url
- * @returns {Promise<*>}
- */
-async function expandURL(url) {
-
-    const endpoint = `https://api-ssl.bitly.com/v4/expand`;
-    const id = url.startsWith("http://") ? url.substring(7) : url.substring(8);
-    const message = {
-        "bitlink_id": id
-    }
-
-    const response = await fetch(endpoint, {
-        method: 'POST', // or 'PUT'
-        headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${btoa("ëtá¾´ãÎtsßéÆºÙçµóf¸í¿9snéÝz")}`
-        },
-        body: JSON.stringify(message),
-    })
-
-    if (!response.ok) {
-        throw new Error(`Network error (${response.status}): ${response.statusText}`)
-    }
-    const json = await response.json();
-    let longUrl = json.long_url;
-
-    // Fix some Bitly "normalization"
-    longUrl = longUrl.replace("{", "%7B").replace("}", "%7D");
-    return longUrl;
-
 }
 
 export {extractConfig}

--- a/test/__snapshots__/testDecoderGolden.js.snap
+++ b/test/__snapshots__/testDecoderGolden.js.snap
@@ -118,6 +118,16 @@ exports[`decoder golden file — inputs the decoder takes as a string > harveste
 }
 `;
 
+exports[`decoder golden file — inputs the decoder takes as a string > harvested-juiceboxURL-bitly 1`] = `
+{
+  "error": {
+    "message": "juiceboxURL= links are no longer supported: the bit.ly expansion was removed in #506 (ADR-0006 decision 1). Open the link in a browser to read the juicebox URL it stands for, and use that. See docs/url.md.",
+    "name": "SessionDecodeError",
+  },
+  "outcome": "throws",
+}
+`;
+
 exports[`decoder golden file — inputs the decoder takes as a string > harvested-query-4dn-control-map 1`] = `
 {
   "config": {
@@ -1213,103 +1223,5 @@ exports[`decoder golden file — the File arm is not reachable > synth-session-f
     "name": "TypeError",
   },
   "outcome": "throws",
-}
-`;
-
-exports[`decoder golden file — the legacy bit.ly form > harvested-juiceboxURL-bitly 1`] = `
-{
-  "config": {
-    "browsers": [
-      {
-        "colorScale": ColorScale {
-          "b": 0,
-          "binsize": 0.07210918707440236,
-          "cache": [],
-          "g": 0,
-          "nbins": 2000,
-          "r": 255,
-          "threshold": 144.21837414880474,
-        },
-        "cycle": undefined,
-        "name": "ADAC_30.hic",
-        "nvi": "7989194045,18679",
-        "state": State {
-          "chr1": 2,
-          "chr2": 2,
-          "normalization": "KR",
-          "pixelSize": 1.5423280423280423,
-          "x": 1896.1562537317725,
-          "y": 1916.657181523778,
-          "zoom": 6,
-        },
-        "tracks": [
-          {
-            "color": "rgb(255,255,0)",
-            "displayMode": "COLLAPSED",
-            "name": "5000_blocks",
-            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC/inter_30_contact_domains/5000_blocks",
-          },
-          {
-            "color": "rgb(0,36,255)",
-            "displayMode": "COLLAPSED",
-            "name": "merged_loops.bedpe",
-            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_loops/merged_loops.bedpe",
-          },
-          {
-            "color": "rgb(0,255,36)",
-            "displayMode": "COLLAPSED",
-            "name": "differential_loops1.bedpe",
-            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_vs_EndoC/differential_loops1.bedpe",
-          },
-        ],
-        "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC/ADAC_30.hic",
-      },
-      {
-        "colorScale": ColorScale {
-          "b": 0,
-          "binsize": 0.07138719710904917,
-          "cache": [],
-          "g": 0,
-          "nbins": 2000,
-          "r": 255,
-          "threshold": 142.77439421809834,
-        },
-        "cycle": undefined,
-        "name": "EndoC_30.hic",
-        "nvi": "6818528104,18679",
-        "state": State {
-          "chr1": 2,
-          "chr2": 2,
-          "normalization": "KR",
-          "pixelSize": 1.5423280423280423,
-          "x": 1896.1562537317725,
-          "y": 1916.657181523778,
-          "zoom": 6,
-        },
-        "tracks": [
-          {
-            "color": "rgb(18,0,255)",
-            "displayMode": "COLLAPSED",
-            "name": "merged_loops.bedpe",
-            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC_loops/merged_loops.bedpe",
-          },
-          {
-            "color": "rgb(255,255,0)",
-            "displayMode": "COLLAPSED",
-            "name": "5000_blocks",
-            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC/inter_30_contact_domains/5000_blocks",
-          },
-          {
-            "color": "rgb(18,255,0)",
-            "displayMode": "COLLAPSED",
-            "name": "differential_loops2.bedpe",
-            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_vs_EndoC/differential_loops2.bedpe",
-          },
-        ],
-        "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC/EndoC_30.hic",
-      },
-    ],
-  },
-  "outcome": "decodes",
 }
 `;

--- a/test/data/wireFormatCorpus.js
+++ b/test/data/wireFormatCorpus.js
@@ -27,17 +27,19 @@
  * Every `outcome` was measured against `extractConfig` at `b92b602` rather than
  * inferred from reading the code. `test/testWireFormatCorpus.js` re-measures on
  * every run everything drivable from literals, including the `sessionUrl`
- * fixtures via a stubbed loader. Four are left out and were measured by hand:
- * the three `sessionFile` fixtures, which the sole caller cannot reach at all
- * (see their notes), and `harvested-juiceboxURL-bitly`, whose outcome depends on
- * a third party. Distrust those four first if the corpus and the decoder ever
+ * fixtures via a stubbed loader. Three are left out and were measured by hand:
+ * the `sessionFile` fixtures, which the sole caller cannot reach at all (see
+ * their notes). Distrust those three first if the corpus and the decoder ever
  * disagree.
+ *
+ * There was a fourth — `harvested-juiceboxURL-bitly`, whose outcome depended on
+ * a third party. #506 retired that format, so the fixture now measures a
+ * rejection off its own literal like everything else.
  *
  * Nothing here does I/O. Every fixture whose decode path would reach the network
  * or a file carries the *text* that path would have returned as a further string
- * literal — `loaderResponse`, `fileText`, `expandedUrl` — so the whole decode
- * path is drivable from literals, which is the point of ADR-0006 decision 10's
- * injected loader.
+ * literal — `loaderResponse`, `fileText` — so the whole decode path is drivable
+ * from literals, which is the point of ADR-0006 decision 10's injected loader.
  *
  * **Harvest scope.** ADR-0006 names three repos and the published docs. All
  * three were searched: juicebox.js (`git log`, `test/test_urls.md`,
@@ -82,7 +84,10 @@
  * `juicebox`        — `juicebox={…},{…}`, one braced query string per browser.
  * `juiceboxData`    — `juiceboxData=`, the *braced* form compressed. Not session
  *                     JSON — see the fixture note.
- * `juiceboxURL`     — `juiceboxURL=`, a bit.ly link. Dropped by decision 1.
+ * `juiceboxURL`     — `juiceboxURL=`, a bit.ly link. **Retired** by decision 1,
+ *                     removed in #506. Its fixture stays: what the decoder does
+ *                     with a format it no longer accepts is part of the
+ *                     contract, and this is the corpus that records it.
  */
 export const FORMATS = [
     'sessionBlob',
@@ -229,11 +234,10 @@ export const wireFormatCorpus = [
         format: 'juiceboxURL',
         provenance: 'harvested',
         role: 'load-bearing',
-        outcome: 'decodes',
+        outcome: 'throws',
         source: 'test/test_urls.md and juicebox-web js/initializationHelper.js:490',
         input: 'http://localhost/juicebox-web/index.html?juiceboxURL=http://bit.ly/2C1VSHy',
-        expandedUrl: 'http://aidenlab.org/juicebox/?juicebox={hicUrl%253Dhttps%253A%252F%252Fs3.amazonaws.com%252Fhicfiles%252Fhiseq%252FnSxhJZHdDRQ0kGDR%252F12.31.17%252FADAC%252FADAC_30.hic%2526name%253DADAC_30.hic%2526state%253D2%252C2%252C6%252C1896.1562537317725%252C1916.657181523778%252C1.5423280423280423%252CKR%2526colorScale%253D144.21837414880474%252C255%252C0%252C0%2526nvi%253D7989194045%252C18679%2526tracks%253Dhttps%253A%252F%252Fs3.amazonaws.com%252Fhicfiles%252Fhiseq%252FnSxhJZHdDRQ0kGDR%252F12.31.17%252FADAC%252Finter_30_contact_domains%252F5000_blocks%257C5000_blocks%257C%257Crgb(255%252C255%252C0)%257C%257C%257Chttps%253A%252F%252Fs3.amazonaws.com%252Fhicfiles%252Fhiseq%252FnSxhJZHdDRQ0kGDR%252F12.31.17%252FADAC_loops%252Fmerged_loops.bedpe%257Cmerged_loops.bedpe%257C%257Crgb(0%252C36%252C255)%257C%257C%257Chttps%253A%252F%252Fs3.amazonaws.com%252Fhicfiles%252Fhiseq%252FnSxhJZHdDRQ0kGDR%252F12.31.17%252FADAC_vs_EndoC%252Fdifferential_loops1.bedpe%257Cdifferential_loops1.bedpe%257C%257Crgb(0%252C255%252C36)},{hicUrl%253Dhttps%253A%252F%252Fs3.amazonaws.com%252Fhicfiles%252Fhiseq%252FnSxhJZHdDRQ0kGDR%252F12.31.17%252FEndoC%252FEndoC_30.hic%2526name%253DEndoC_30.hic%2526state%253D2%252C2%252C6%252C1896.1562537317725%252C1916.657181523778%252C1.5423280423280423%252CKR%2526colorScale%253D142.77439421809834%252C255%252C0%252C0%2526nvi%253D6818528104%252C18679%2526tracks%253Dhttps%253A%252F%252Fs3.amazonaws.com%252Fhicfiles%252Fhiseq%252FnSxhJZHdDRQ0kGDR%252F12.31.17%252FEndoC_loops%252Fmerged_loops.bedpe%257Cmerged_loops.bedpe%257C%257Crgb(18%252C0%252C255)%257C%257C%257Chttps%253A%252F%252Fs3.amazonaws.com%252Fhicfiles%252Fhiseq%252FnSxhJZHdDRQ0kGDR%252F12.31.17%252FEndoC%252Finter_30_contact_domains%252F5000_blocks%257C5000_blocks%257C%257Crgb(255%252C255%252C0)%257C%257C%257Chttps%253A%252F%252Fs3.amazonaws.com%252Fhicfiles%252Fhiseq%252FnSxhJZHdDRQ0kGDR%252F12.31.17%252FADAC_vs_EndoC%252Fdifferential_loops2.bedpe%257Cdifferential_loops2.bedpe%257C%257Crgb(18%252C255%252C0)}',
-        note: 'The one format ADR-0006 decision 1 drops deliberately — and, measured 2026-08-09, **it still works**: bit.ly expands the link and the two-browser session decodes in full. ADR-0006 and docs/url.md both predicted a 401 from the mojibake bearer token at urlUtils.js:405; v4/expand accepts it for a public link. So #506 removes live behaviour rather than tidying a dead path, and this fixture is the evidence. `expandedUrl` is bit.ly\'s `long_url` field captured verbatim on the same date, so the fixture is drivable offline by stubbing the fetch with it — note it arrives **double**-encoded (`%253D` for `=`) with the braces literal, which is what the brace repair at urlUtils.js:417 exists to undo. The corpus integrity test still skips this fixture: it is the one input whose measured outcome depends on a third party.',
+        note: 'The one format ADR-0006 decision 1 dropped deliberately, removed in #506 — and it was **not** a dead path when it went. Measured 2026-08-09, bit.ly expanded this link and the two-browser session decoded in full; both ADR-0006 and docs/url.md had predicted a 401 from the mojibake bearer token, and v4/expand accepted it for a public link. What the fixture pins now is the refusal that replaced the expansion: a SessionDecodeError naming the format and the ticket, raised before the rest of the URL is read. It no longer depends on a third party, so the corpus integrity test no longer skips it. The captured `long_url` went with the expansion rather than being kept as inert evidence — it described a decode path that no longer exists, and the removal it was evidence for is recorded in the ADR and in the golden file\'s snapshot-movement log.',
     },
 
     // ---------------------------------------------------------------------
@@ -680,25 +684,25 @@ export const wireFormatCorpus = [
  * copies that disagreed would silently stop covering whichever group fell
  * through the gap.
  *
- * The four groups are disjoint and exhaustive, which `testDecoderGolden.js`
+ * The three groups are disjoint and exhaustive, which `testDecoderGolden.js`
  * asserts. Adding a fixture that belongs to none of them fails that assertion
  * rather than being quietly skipped.
  *
  * `selfContained` — hand it `input` and nothing else.
  * `viaLoader`     — stub `igvxhr.loadString` with `loaderResponse` first; a
  *                   `loaderResponse` of null means the loader itself rejects.
- * `viaBitly`      — stub `fetch` with `expandedUrl` first.
  * `viaFile`       — needs a File where `extractQuery` can only put a string.
  *                   See the golden test's note on this group.
+ *
+ * There was a fourth, `viaBitly`, which stubbed `fetch` with a captured
+ * `long_url`. #506 removed the expansion, so its one fixture needs nothing
+ * stubbed and is self-contained like the rest.
  */
 export const selfContained = wireFormatCorpus.filter(f =>
     f.input !== undefined &&
-    f.loaderResponse === undefined &&
-    f.format !== 'juiceboxURL')
+    f.loaderResponse === undefined)
 
 export const viaLoader = wireFormatCorpus.filter(f => f.loaderResponse !== undefined)
-
-export const viaBitly = wireFormatCorpus.filter(f => f.format === 'juiceboxURL')
 
 export const viaFile = wireFormatCorpus.filter(f => f.format === 'sessionFile')
 

--- a/test/testDecoderGolden.js
+++ b/test/testDecoderGolden.js
@@ -48,6 +48,7 @@
  * | Date | Fixtures | Authorised by |
  * |------|----------|---------------|
  * | 2026-08-09 | all — baseline taken | #503, after #499 (axis ordering) and #500 (empty browsers), both of which move decoded output and so had to land first |
+ * | 2026-08-09 | `harvested-juiceboxURL-bitly` — `decodes` became `throws` | **#506**, ADR-0006 decision 1: the named exception to the frozen contract. The bit.ly expansion and its embedded credential are gone, so the fixture that decoded a two-browser session through a live third-party endpoint now records the refusal that replaced it. **This is the first deliberate deviation from the baseline** — the whole point of the log is that it is written down rather than absorbed by a bare `-u`. No other fixture moved, which is the other half of the claim. |
  *
  * @see docs/adr/0006-session-wire-format-and-one-decoder.md
  * @see test/data/wireFormatCorpus.js — the inputs
@@ -60,7 +61,6 @@ import State from '../js/hicState.js'
 import {
     selfContained,
     stateStringCorpus,
-    viaBitly,
     viaFile,
     viaLoader,
     wireFormatCorpus,
@@ -118,13 +118,13 @@ expect.addSnapshotSerializer({
 
 /**
  * "Every fixture in the corpus has a committed snapshot" has to hold by
- * construction, not by having been true the day it was written. The four suites
- * below run the four partitions the corpus exports; a fixture belonging to none
+ * construction, not by having been true the day it was written. The three suites
+ * below run the three partitions the corpus exports; a fixture belonging to none
  * of them would otherwise be skipped in silence, which is the one failure mode a
  * golden file cannot survive.
  */
-test('every fixture falls into exactly one of the four suites', () => {
-    const partitioned = [...selfContained, ...viaLoader, ...viaBitly, ...viaFile]
+test('every fixture falls into exactly one of the three suites', () => {
+    const partitioned = [...selfContained, ...viaLoader, ...viaFile]
     expect(partitioned.length, 'a fixture in two partitions is snapshotted twice')
         .toBe(wireFormatCorpus.length)
     expect(new Set(partitioned.map(f => f.id)).size, 'a fixture in none is never snapshotted')
@@ -133,9 +133,11 @@ test('every fixture falls into exactly one of the four suites', () => {
 
 /**
  * "Runs without network, DOM or file I/O" is enforced here rather than asserted
- * in a comment: both I/O sites are replaced with a throw by default, so a
- * fixture that reaches one fails loudly instead of quietly going to the wire.
- * The two suites that legitimately need them re-stub them with a canned answer.
+ * in a comment: `igvxhr.loadString` and `fetch` are both replaced with a throw,
+ * so a fixture that reaches either fails loudly instead of quietly going to the
+ * wire. One suite — the session URLs — re-stubs `loadString` with a canned
+ * answer. Nothing re-stubs `fetch` any more: the bit.ly expansion was the only
+ * caller and #506 removed it, so the stub is now purely a tripwire.
  *
  * `console.error` is silenced because the decoder logs every rejection before
  * rethrowing it — behaviour worth keeping, noise worth not printing forty times
@@ -176,31 +178,6 @@ describe('decoder golden file — session URLs, driven from their loader respons
                 if (fixture.loaderResponse === null) throw new Error('simulated fetch failure')
                 return fixture.loaderResponse
             })
-
-            const captured = await capture(fixture.input)
-            expect(captured.outcome, fixture.id).toBe(fixture.outcome)
-            expect(captured).toMatchSnapshot()
-        })
-    }
-})
-
-/**
- * The bit.ly path, driven from the `long_url` the real service returned on
- * 2026-08-09. ADR-0006 decision 1 drops this format, and #506 is where it goes;
- * until then it is live behaviour and gets a snapshot like everything else.
- *
- * Stubbing `fetch` rather than the network is what makes it snapshottable at
- * all — the corpus integrity test skips this fixture precisely because its
- * unstubbed outcome depends on a third party.
- */
-describe('decoder golden file — the legacy bit.ly form', () => {
-
-    for (const fixture of viaBitly) {
-        test(fixture.id, async () => {
-            vi.stubGlobal('fetch', async () => ({
-                ok: true,
-                json: async () => ({long_url: fixture.expandedUrl}),
-            }))
 
             const captured = await capture(fixture.input)
             expect(captured.outcome, fixture.id).toBe(fixture.outcome)

--- a/test/testSessionDecode.js
+++ b/test/testSessionDecode.js
@@ -9,10 +9,11 @@
  * is exercised here without network, without a DOM and without a file, by
  * handing `decodeSession` a fake loader and a string.
  *
- * The two I/O sites — the session-URL fetch and the legacy bit.ly expansion —
- * arrive as injected functions. The suite passes loaders that *throw* wherever a
- * fixture should not need one, so a format that quietly starts doing I/O fails
- * loudly rather than reaching for the wire.
+ * The one I/O site — the session-URL fetch — arrives as an injected function.
+ * The suite passes a loader that *throws* wherever a fixture should not need
+ * one, so a format that quietly starts doing I/O fails loudly rather than
+ * reaching for the wire. (There were two until #506 removed the bit.ly
+ * expansion.)
  *
  * Division of labour with the neighbouring suites:
  *
@@ -27,9 +28,9 @@
  * @see js/sessionCodec.js
  * @see docs/adr/0006-session-wire-format-and-one-decoder.md
  */
-import {describe, expect, test} from 'vitest'
+import {afterEach, describe, expect, test, vi} from 'vitest'
 import {BGZip} from 'igv-utils'
-import {WIRE_FORMATS, decodeSession} from '../js/sessionCodec.js'
+import {SessionDecodeError, WIRE_FORMATS, decodeSession} from '../js/sessionCodec.js'
 import State from '../js/hicState.js'
 
 /**
@@ -39,9 +40,6 @@ import State from '../js/hicState.js'
 const noIO = {
     loadString: async url => {
         throw new Error(`unexpected load of ${url}`)
-    },
-    expandUrl: async url => {
-        throw new Error(`unexpected expansion of ${url}`)
     },
 }
 
@@ -53,6 +51,10 @@ function compress(object) {
 const oneBrowserSession = {
     browsers: [{url: 'https://example.org/one.hic', name: 'one'}],
 }
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+})
 
 describe('decodeSession — the query-parameter form', () => {
 
@@ -160,18 +162,45 @@ describe('decodeSession — the legacy braced forms', () => {
         expect(config.browsers[0].url).toBe('https://example.org/one.hic')
     })
 
-    test('juiceboxURL= expands through the injected expander, never through fetch', async () => {
-        const expanded = []
-        const config = await decodeSession('?juiceboxURL=http://bit.ly/2C1VSHy', {
-            ...noIO,
-            expandUrl: async url => {
-                expanded.push(url)
-                return 'https://host/?hicUrl=https://example.org/one.hic'
-            },
+})
+
+/**
+ * `juiceboxURL=` — the one deliberate deviation from ADR-0006's frozen
+ * compatibility contract, dropped by decision 1 in #506.
+ *
+ * The adapter stays in {@link WIRE_FORMATS} rather than being deleted outright,
+ * and these tests are why: a URL naming a retired format has to *say so*. Delete
+ * the entry and the parameter falls through to the `query` adapter, which finds
+ * no `hicUrl`, returns no config, and leaves the host silently showing whatever
+ * it was configured with — the confusing failure the ticket rules out.
+ */
+describe('decodeSession — the retired bit.ly form', () => {
+
+    test('juiceboxURL= is refused, and never reaches the network', async () => {
+        vi.stubGlobal('fetch', async () => {
+            throw new Error('the bit.ly expansion is gone; nothing here may fetch')
         })
 
-        expect(expanded).toEqual(['http://bit.ly/2C1VSHy'])
-        expect(config.url).toBe('https://example.org/one.hic')
+        await expect(decodeSession('?juiceboxURL=http://bit.ly/2C1VSHy', noIO))
+            .rejects.toThrow(SessionDecodeError)
+    })
+
+    test('the refusal names the format, the ticket and where to read about it', async () => {
+        const error = await decodeSession('?juiceboxURL=http://bit.ly/2C1VSHy', noIO)
+            .catch(e => e)
+
+        expect(error.message).toMatch(/juiceboxURL/)
+        expect(error.message).toMatch(/#506/)
+        expect(error.message).toMatch(/docs\/url\.md/)
+    })
+
+    test('it is refused before the rest of the URL is decoded, not after', async () => {
+        // The expansion used to *replace* the query, so anything beside it was
+        // read from the expanded href rather than from the URL as pasted.
+        // Decoding the remainder would answer a link that was never written.
+        await expect(decodeSession(
+            '?juiceboxURL=http://bit.ly/2C1VSHy&hicUrl=https://example.org/one.hic', noIO))
+            .rejects.toThrow(SessionDecodeError)
     })
 })
 
@@ -219,7 +248,10 @@ describe('the format registry', () => {
         }
     })
 
-    test('the four wire formats are the four the ADR names', () => {
+    test('the registry names four formats, one of them retired', () => {
+        // `juiceboxURL` is still named here after #506, and still in the same
+        // position in the fold: the array is where a format's *disposition* is
+        // recorded, and "retired, refuse it loudly" is a disposition.
         expect(WIRE_FORMATS.map(a => a.format))
             .toEqual(['session', 'juiceboxURL', 'juicebox', 'query'])
     })

--- a/test/testURL.js
+++ b/test/testURL.js
@@ -54,17 +54,19 @@ describe("testURLs", function () {
 
     })
 
-    test("juiceboxURL'", async function () {
+    /**
+     * `juiceboxURL=` was the one test in this file that went to the network on
+     * every `npm test`, expanding a bit.ly link through a live third-party
+     * endpoint. #506 retired the format (ADR-0006 decision 1), so what is left to
+     * check is that the refusal is a refusal — the rejection itself, and every
+     * message it carries, is pinned in `testSessionDecode.js` and in the golden
+     * file.
+     */
+    test("juiceboxURL= is refused rather than expanded", async function () {
 
         const url = "http://localhost/juicebox-web/index.html?juiceboxURL=http://bit.ly/2C1VSHy";
 
-        const sessionJSON = await extractConfig(url);
-
-        assert.equal(sessionJSON.browsers.length, 2);
-
-        const browser1 = sessionJSON.browsers[0];
-        assert.equal(browser1.name, "ADAC_30.hic");
-        assert.equal(browser1.tracks.length, 3);
+        await expect(extractConfig(url)).rejects.toThrow(/juiceboxURL/);
 
     })
 

--- a/test/test_urls.md
+++ b/test/test_urls.md
@@ -15,7 +15,15 @@
 * http://localhost/juicebox.js/dev/juicebox-blank.html?juicebox={hicUrl%3Dhttps%3A%2F%2Fs3.amazonaws.com%2Fhicfiles%2Fhiseq%2FnSxhJZHdDRQ0kGDR%2F12.31.17%2FADAC%2FADAC_30.hic%26name%3DADAC_30.hic%26state%3D2%2C2%2C6%2C1896.1562537317725%2C1916.657181523778%2C1.5423280423280423%2CKR%26colorScale%3D144.21837414880474%2C255%2C0%2C0%26nvi%3D7989194045%2C18679%26tracks%3Dhttps%3A%2F%2Fs3.amazonaws.com%2Fhicfiles%2Fhiseq%2FnSxhJZHdDRQ0kGDR%2F12.31.17%2FADAC%2Finter_30_contact_domains%2F5000_blocks%7C5000_blocks%7C%7Crgb(255%2C255%2C0)%7C%7C%7Chttps%3A%2F%2Fs3.amazonaws.com%2Fhicfiles%2Fhiseq%2FnSxhJZHdDRQ0kGDR%2F12.31.17%2FADAC_loops%2Fmerged_loops.bedpe%7Cmerged_loops.bedpe%7C%7Crgb(0%2C36%2C255)%7C%7C%7Chttps%3A%2F%2Fs3.amazonaws.com%2Fhicfiles%2Fhiseq%2FnSxhJZHdDRQ0kGDR%2F12.31.17%2FADAC_vs_EndoC%2Fdifferential_loops1.bedpe%7Cdifferential_loops1.bedpe%7C%7Crgb(0%2C255%2C36)},{hicUrl%3Dhttps%3A%2F%2Fs3.amazonaws.com%2Fhicfiles%2Fhiseq%2FnSxhJZHdDRQ0kGDR%2F12.31.17%2FEndoC%2FEndoC_30.hic%26name%3DEndoC_30.hic%26state%3D2%2C2%2C6%2C1896.1562537317725%2C1916.657181523778%2C1.5423280423280423%2CKR%26colorScale%3D142.77439421809834%2C255%2C0%2C0%26nvi%3D6818528104%2C18679%26tracks%3Dhttps%3A%2F%2Fs3.amazonaws.com%2Fhicfiles%2Fhiseq%2FnSxhJZHdDRQ0kGDR%2F12.31.17%2FEndoC_loops%2Fmerged_loops.bedpe%7Cmerged_loops.bedpe%7C%7Crgb(18%2C0%2C255)%7C%7C%7Chttps%3A%2F%2Fs3.amazonaws.com%2Fhicfiles%2Fhiseq%2FnSxhJZHdDRQ0kGDR%2F12.31.17%2FEndoC%2Finter_30_contact_domains%2F5000_blocks%7C5000_blocks%7C%7Crgb(255%2C255%2C0)%7C%7C%7Chttps%3A%2F%2Fs3.amazonaws.com%2Fhicfiles%2Fhiseq%2FnSxhJZHdDRQ0kGDR%2F12.31.17%2FADAC_vs_EndoC%2Fdifferential_loops2.bedpe%7Cdifferential_loops2.bedpe%7C%7Crgb(18%2C255%2C0)}
 
 
-# Legacy bitly URLs
+# Legacy bitly URLs — no longer supported
+
+`juiceboxURL=` was retired in #506 (ADR-0006 decision 1). These links now fail
+with an error naming the format rather than expanding; they are kept here as the
+record of what the parameter looked like, and because `test/testURL.js` and the
+fixture corpus are driven from the third one.
+
+To recover a link like these, open the bit.ly URL in a browser and use the
+juicebox URL it redirects to — that URL is in one of the supported forms above.
 
 2  Browsers, 2D annotations
 
@@ -26,7 +34,9 @@
 * http://localhost/juicebox.js/dev/juicebox-blank.html?juiceboxURL=http://bit.ly/2C1VSHy
 
 
-# Embedded googl drive track (requires google config) 
+# Embedded googl drive track (requires google config)
+
+Also a retired `juiceboxURL=` link — see above.
 
 * http://localhost/juicebox.js/dev/juicebox-blank.html?juiceboxURL=http://bit.ly/2srvPJK
 


### PR DESCRIPTION
Closes #506.

ADR-0006 decision 1's one named exception to the frozen compatibility contract. The bit.ly expansion is gone, and with it the bearer credential committed to this public repository and the only `fetch` in `js/urlUtils.js`.

## The adapter stays, and refuses

`juiceboxURL` keeps its entry in `WIRE_FORMATS`, now raising a `SessionDecodeError` instead of expanding. Deleting the entry outright would leave `?juiceboxURL=…` matching no adapter, falling through to `query`, decoding to no config, and the host silently showing whatever it was configured with — the confusing failure the ticket rules out. What a retired format does is still part of the decoder's contract.

```
juiceboxURL= links are no longer supported: the bit.ly expansion was removed in
#506 (ADR-0006 decision 1). Open the link in a browser to read the juicebox URL
it stands for, and use that. See docs/url.md.
```

## The snapshot movement

**This is the first deliberate deviation from #503's golden-file baseline.** One fixture moved — `harvested-juiceboxURL-bitly`, `decodes` → `throws` — updated with `vitest -u -t '<id>'` rather than a bare `-u`, and logged in `testDecoderGolden.js`'s "Authorised snapshot movements" table naming this ticket as the authorising decision. No other fixture moved, which is the other half of the claim.

## Worth saying plainly

**This removed working behaviour.** ADR-0006 justified the drop by predicting the mojibake bearer token would draw a 401; measured 2026-08-09, `v4/expand` accepted it and a two-browser session decoded in full. The decision stands on the remaining grounds — nothing writes the format, it could not be tested without a third party, and its brace repair mangled every multi-browser link from browser 2 on — but this is a removal, not a tidy-up, and `docs/url.md` says so.

## Also

`test/testURL.js`'s juiceboxURL case went to bit.ly on **every `npm test`**. It now asserts the refusal, so the suite no longer touches the network on that path.

`docs/url.md` gains a **Removed forms** section — the exception list to the frozen set, with instructions for recovering an old link (open the bit.ly URL in a browser, use what it redirects to). ADR-0006 is left untouched: its line references now point at deleted code, but an ADR records a decision rather than the current tree.

**No impact on juicebox-web's share button.** That flow shortens a `?session=` URL through TinyURL and relies on an HTTP redirect; juicebox.js never saw a short link and never shortened one. The two halves belonged to different eras.

## Verification

- 687 tests pass (36 files); `npm run build` clean
- `/code-review` run on both axes; findings fixed in the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)