### PR TITLE
encodeSession and the round-trip property test (#507)

### DIFF
--- a/docs/juicebox-punch-list.md
+++ b/docs/juicebox-punch-list.md
@@ -60,7 +60,7 @@ carries a Consumer impact block; read it before filing anything.
 
 | Candidate | Status |
 |---|---|
-| **5 · One decoder for session and URL** | **ADR-0006 + tickets #499–#509 filed** — #499, #500 and #501 landed; next up #502 |
+| **5 · One decoder for session and URL** | **ADR-0006 + tickets #499–#509 filed** — #499–#507 landed; next up #508 (version field). Open follow-ups found on the way: #510, #514, #515, #518, #519, #521, #525 |
 | **11 · Give the track tile one owner** | ⚠️ breaking |
 | **6 · Fold StateManager into State, and make restore use the chokepoint** | watch |
 | **7 · Move the gesture state machines behind InteractionHandler** | watch |
@@ -79,10 +79,10 @@ rather than a reading exercise — a ticket is startable exactly when `blocked_b
 
 | | Ticket | Gated on |
 |---|---|---|
-| **Start here** | ~~#499 axis ordering~~ **landed** · ~~#500 empty browsers~~ **landed** · ~~#501 versioned url.md + delete `stringify`~~ **landed** · #502 fixture corpus | nothing |
-| **The gate** | #503 golden-file snapshot — **no decoder code moves until it is green** | #499, #500, #502 |
-| Collapse | #504 pure `sniffFormat`/`decodeState` → #505 `decodeSession` + injected loader → #506 drop bit.ly | linear |
-| Payoff | #507 `encodeSession` + round-trip property test → #508 version field | #500, #505 |
+| **Start here** | ~~#499 axis ordering~~ **landed** · ~~#500 empty browsers~~ **landed** · ~~#501 versioned url.md + delete `stringify`~~ **landed** · ~~#502 fixture corpus~~ **landed** | nothing |
+| **The gate** | ~~#503 golden-file snapshot~~ **landed and green** — no decoder code moved until it was | #499, #500, #502 |
+| Collapse | ~~#504 pure `sniffFormat`/`decodeState`~~ → ~~#505 `decodeSession` + injected loader~~ → ~~#506 drop bit.ly~~ **all landed** | linear |
+| Payoff | ~~#507 `encodeSession` + round-trip property test~~ **landed** → #508 version field | #500, #505 |
 | Off-chain | #509 external citation harvest (`ready-for-human`, gates nothing) · #510 `State.default()` defect | — |
 
 #499 and #500 gate the snapshot because both legitimately move decoded output; baselining before

--- a/docs/url.md
+++ b/docs/url.md
@@ -204,12 +204,19 @@ than left to be found:
 
 - **Browser count**, when a browser was empty. A panel with no map serializes to
   `null` and the registry drops it, so an embed saved with an empty panel open
-  restores one panel short (ADR-0006 decision 6).
-- **Track display mode.** The decoder's `fixDefaults` pass forces every track to
-  `COLLAPSED` on the way in, so a round-tripped track carries a field the saved
-  form never had — and a session handed straight to `restoreSession` is not swept,
-  so the two entry paths disagree. Filed as #525; the fix is candidate 9's
-  `normalizeSession` stage (ADR-0006 decision 8).
+  restores one panel short (ADR-0006 decision 6). Nothing in the session records
+  that a panel was dropped, so the count is not recoverable.
+- **Tracks**, which the decoder's `fixDefaults` pass sweeps: every track comes
+  back `COLLAPSED` — a field the saved form never carries, and one that overrides
+  a track that asked for something else — and a track whose colour is the default
+  annotation colour comes back with no colour at all. A session handed straight
+  to `restoreSession` is never swept, so the two entry paths disagree. Filed as
+  #525; the fix is candidate 9's `normalizeSession` stage (ADR-0006 decision 8).
+
+The parameter is written in one spelling, `blob:`. The decoder reads three —
+`blob:`, `data:` and bare JSON — but the other two are inbound only: nothing has
+emitted a `data:` share link, and a bare-JSON *parameter* would carry braces and
+quotes into a query string. There is no `format` argument to reach them with.
 
 The compressed payload is URL-safe base64, unpadded: no `+`, `/` or `=` reaches
 the query string. The decoder's query splitter takes a value only up to its

--- a/docs/url.md
+++ b/docs/url.md
@@ -189,6 +189,33 @@ follow the same rules as above.
 Session JSON has no `version` field today; its absence means v1. When one is
 added (#508) it will be written but never required.
 
+### The one form juicebox writes
+
+`session=` is the only form with an **encoder**: `encodeSession` in
+`js/sessionCodec.js`, which `session.compressedSession()` calls to build the
+share link. It is the inverse of the decoder, and
+`decode(encode(session)) === session` is a property test over generated sessions
+(`test/testSessionRoundTrip.js`). The other forms above are **decode-only by
+decision** — ADR-0006 decision 4 — because writing encoders for formats nothing
+has emitted in years means owning them forever.
+
+The identity is not total. Two deviations, both asserted by that suite rather
+than left to be found:
+
+- **Browser count**, when a browser was empty. A panel with no map serializes to
+  `null` and the registry drops it, so an embed saved with an empty panel open
+  restores one panel short (ADR-0006 decision 6).
+- **Track display mode.** The decoder's `fixDefaults` pass forces every track to
+  `COLLAPSED` on the way in, so a round-tripped track carries a field the saved
+  form never had — and a session handed straight to `restoreSession` is not swept,
+  so the two entry paths disagree. Filed as #525; the fix is candidate 9's
+  `normalizeSession` stage (ADR-0006 decision 8).
+
+The compressed payload is URL-safe base64, unpadded: no `+`, `/` or `=` reaches
+the query string. The decoder's query splitter takes a value only up to its
+second `=`, so a padded alphabet would truncate the payload silently. Anything
+changing the compressor has to keep that true.
+
 A fourth whole-session parameter, `juiceboxURL=`, was accepted until 2026-08-09
 — see [Removed forms](#removed-forms).
 

--- a/js/session.js
+++ b/js/session.js
@@ -1,5 +1,5 @@
 import {registryForContainer, currentRegistry} from "./browserRegistry.js"
-import {BGZip} from "igv-utils";
+import {encodeSession} from "./sessionCodec.js";
 
 /**
  * The exported session functions -- the names both known host apps import, per
@@ -45,9 +45,17 @@ function toJSON() {
     return jsonOBJ;
 }
 
+/**
+ * The share link's query parameter: `session=blob:<compressed JSON>`, which
+ * juicebox-web appends to its base href.
+ *
+ * The writing is `sessionCodec.encodeSession` -- the inverse of the same
+ * module's `decodeSession`, and the reason `decode(encode(x))` can be a property
+ * test at all (#507, ADR-0006 decision 4). It was two lines of compression here,
+ * which is one of the two halves of the format living apart from the other.
+ */
 function compressedSession() {
-    const jsonString = JSON.stringify(toJSON());
-    return `session=blob:${BGZip.compressString(jsonString)}`
+    return encodeSession(toJSON())
 }
 
 

--- a/js/sessionCodec.js
+++ b/js/sessionCodec.js
@@ -1,6 +1,7 @@
 /**
- * The session wire format, decoded. Every decision about what a session URL
- * *means* lives here, and nothing here reaches the network.
+ * The session wire format, decoded and — for the one form juicebox writes —
+ * encoded. Every decision about what a session URL *means* lives here, and
+ * nothing here reaches the network.
  *
  * The decode path was a single `async` function that did its own fetching, of
  * which two lines were I/O and ninety were format logic — and because the whole
@@ -29,6 +30,20 @@
  * adapter may have produced, and `query` overwrites both when it names a map.
  * That precedence is exactly what the previous straight-line function expressed
  * by statement order, and the golden file (#503) pins it.
+ *
+ * ## The encode path
+ *
+ * {@link encodeSession} is the inverse of {@link decodeSession} for the
+ * session-JSON form — the only form juicebox emits — and `decode(encode(x))` is
+ * a property test (`test/testSessionRoundTrip.js`, #507). The other three
+ * accepted formats are **decode-only** by decision, not by omission: ADR-0006
+ * decision 4. `session.compressedSession()` is the one caller.
+ *
+ * The identity is not total, and both places it is not are asserted by that
+ * suite rather than left to be discovered: browser *count* does not survive a
+ * session saved with an empty panel (decision 6), and the decoder's normalize
+ * pass forces every track to `COLLAPSED` on the way in (decision 8 — the pass
+ * moves out of the decoder in candidate 9, and the property gets stricter then).
  *
  * ## No I/O
  *
@@ -195,6 +210,85 @@ export function decodeSessionString(text) {
     } catch (e) {
         throw new SessionDecodeError('Session is not valid JSON', e)
     }
+}
+
+/**
+ * Raised for every session this module refuses to write.
+ *
+ * The mirror of {@link SessionDecodeError}, and for the same reason: one
+ * condition, one error, with the underlying failure kept as `cause`.
+ */
+export class SessionEncodeError extends Error {
+    constructor(message, cause) {
+        super(message)
+        this.name = 'SessionEncodeError'
+        this.cause = cause
+    }
+}
+
+/**
+ * Write a session as a session string — the inverse of
+ * {@link decodeSessionString}.
+ *
+ * All three spellings the sniff tells apart are writable, because they are three
+ * spellings of **one** format and a member of {@link SessionFormat} with no
+ * encoder would be the one corner the round-trip property could not reach. Only
+ * `blob:` is ever written in anger; see {@link encodeSession}.
+ *
+ * @param {object} session - a session document, as `registry.toJSON()` writes
+ *   one. A `State` instance in it encodes as the object `State.toJSON()` writes,
+ *   because that is what `JSON.stringify` does with it.
+ * @param {string} [format] - a {@link SessionFormat} member
+ * @returns {string}
+ * @throws {SessionEncodeError} if `format` is not a spelling the sniff can read
+ *   back, or if the document is one JSON cannot express
+ */
+export function encodeSessionString(session, format = SessionFormat.BLOB) {
+
+    let json
+    try {
+        json = JSON.stringify(session)
+    } catch (e) {
+        throw new SessionEncodeError('Session cannot be written as JSON', e)
+    }
+
+    if (format === SessionFormat.JSON) {
+        return json
+    }
+
+    const prefix = Object.entries(COMPRESSED_PREFIXES)
+        .find(([, candidate]) => candidate === format)?.[0]
+
+    if (undefined === prefix) {
+        throw new SessionEncodeError(`Unknown session format: ${format}`)
+    }
+
+    return `${prefix}${BGZip.compressString(json)}`
+}
+
+/**
+ * Write a session as the query parameter that carries it — the inverse of
+ * {@link decodeSession} for the one format juicebox emits.
+ *
+ * **One encoder, not four.** The other three accepted formats stay decode-only:
+ * writing encoders for them would resurrect a live encoder for formats nothing
+ * has written in years, and we would then own them forever. ADR-0006 decision 4.
+ *
+ * The return value is the parameter, not a whole URL — `session=blob:…` — which
+ * is the shape juicebox-web appends to its base href, and which
+ * {@link decodeSession} accepts directly. Nothing needs escaping on the way in:
+ * `BGZip` writes the URL-safe base64 alphabet unpadded, so the payload carries
+ * no `&`, `#` or second `=` for the query splitter to eat. That is a dependency
+ * of the round trip, and `test/testSessionRoundTrip.js` asserts it.
+ *
+ * @param {object} session
+ * @param {string} [format] - a {@link SessionFormat} member. Defaulted, and in
+ *   practice never passed: the share link is a `blob:`.
+ * @returns {string}
+ * @throws {SessionEncodeError}
+ */
+export function encodeSession(session, format = SessionFormat.BLOB) {
+    return `session=${encodeSessionString(session, format)}`
 }
 
 /**

--- a/js/sessionCodec.js
+++ b/js/sessionCodec.js
@@ -41,9 +41,10 @@
  *
  * The identity is not total, and both places it is not are asserted by that
  * suite rather than left to be discovered: browser *count* does not survive a
- * session saved with an empty panel (decision 6), and the decoder's normalize
- * pass forces every track to `COLLAPSED` on the way in (decision 8 — the pass
- * moves out of the decoder in candidate 9, and the property gets stricter then).
+ * session saved with an empty panel (decision 6), and `fixDefaults` below —
+ * normalization, sitting inside the decoder — forces every track to `COLLAPSED`
+ * and drops the default annotation colour on the way in (decision 8, #525; the
+ * pass moves out in candidate 9, and the property gets stricter then).
  *
  * ## No I/O
  *
@@ -228,22 +229,22 @@ export class SessionEncodeError extends Error {
 
 /**
  * Write a session as a session string — the inverse of
- * {@link decodeSessionString}.
+ * {@link decodeSessionString} for the one spelling juicebox writes.
  *
- * All three spellings the sniff tells apart are writable, because they are three
- * spellings of **one** format and a member of {@link SessionFormat} with no
- * encoder would be the one corner the round-trip property could not reach. Only
- * `blob:` is ever written in anger; see {@link encodeSession}.
+ * **One spelling, not three.** The sniff reads `blob:`, `data:` and bare JSON;
+ * this writes `blob:` only. The other two are inbound spellings — a `data:`
+ * share link is not a thing juicebox has ever produced, and a bare-JSON
+ * *parameter* would carry braces and quotes into a query string. Taking a
+ * `format` argument here would be a live encoder for a spelling nothing emits,
+ * which is the same trade ADR-0006 decision 4 refuses at the format level.
  *
  * @param {object} session - a session document, as `registry.toJSON()` writes
  *   one. A `State` instance in it encodes as the object `State.toJSON()` writes,
  *   because that is what `JSON.stringify` does with it.
- * @param {string} [format] - a {@link SessionFormat} member
  * @returns {string}
- * @throws {SessionEncodeError} if `format` is not a spelling the sniff can read
- *   back, or if the document is one JSON cannot express
+ * @throws {SessionEncodeError} if the document is one JSON cannot express
  */
-export function encodeSessionString(session, format = SessionFormat.BLOB) {
+export function encodeSessionString(session) {
 
     let json
     try {
@@ -252,18 +253,7 @@ export function encodeSessionString(session, format = SessionFormat.BLOB) {
         throw new SessionEncodeError('Session cannot be written as JSON', e)
     }
 
-    if (format === SessionFormat.JSON) {
-        return json
-    }
-
-    const prefix = Object.entries(COMPRESSED_PREFIXES)
-        .find(([, candidate]) => candidate === format)?.[0]
-
-    if (undefined === prefix) {
-        throw new SessionEncodeError(`Unknown session format: ${format}`)
-    }
-
-    return `${prefix}${BGZip.compressString(json)}`
+    return `blob:${BGZip.compressString(json)}`
 }
 
 /**
@@ -279,16 +269,15 @@ export function encodeSessionString(session, format = SessionFormat.BLOB) {
  * {@link decodeSession} accepts directly. Nothing needs escaping on the way in:
  * `BGZip` writes the URL-safe base64 alphabet unpadded, so the payload carries
  * no `&`, `#` or second `=` for the query splitter to eat. That is a dependency
- * of the round trip, and `test/testSessionRoundTrip.js` asserts it.
+ * of the round trip — the splitter reads a value only as far as its second `=` —
+ * and `test/testSessionRoundTrip.js` asserts it.
  *
  * @param {object} session
- * @param {string} [format] - a {@link SessionFormat} member. Defaulted, and in
- *   practice never passed: the share link is a `blob:`.
  * @returns {string}
  * @throws {SessionEncodeError}
  */
-export function encodeSession(session, format = SessionFormat.BLOB) {
-    return `session=${encodeSessionString(session, format)}`
+export function encodeSession(session) {
+    return `session=${encodeSessionString(session)}`
 }
 
 /**

--- a/test/testSessionRoundTrip.js
+++ b/test/testSessionRoundTrip.js
@@ -22,25 +22,29 @@
  * about the format juicebox actually emits and nothing else. A generator free to
  * invent fields would be testing a format no session is ever in.
  *
- * No network and no DOM: the loader passed to `decodeSession` throws, and
- * nothing here constructs a browser. What a *registry* does with an empty
- * browser is `test/testRegistrySession.js`'s (#500); what the codec does with
- * the session that comes out of one is here.
+ * No network and no DOM: the loader passed to `decodeSession` throws, and the
+ * one place a `BrowserRegistry` appears — the count asymmetry — constructs it
+ * without a container and registers stand-ins, so nothing renders and nothing is
+ * selected. What a registry does with a real empty `HICBrowser` is
+ * `test/testRegistrySession.js`'s (#500).
  *
  * @see js/sessionCodec.js
  * @see docs/adr/0006-session-wire-format-and-one-decoder.md
  */
 import {describe, expect, test} from 'vitest'
 import {BGZip} from 'igv-utils'
+// The namespace import is for one assertion only -- "the codec exports exactly
+// one encoder", which is a claim about the module's *surface* and so cannot be
+// written with named imports.
 import * as codec from '../js/sessionCodec.js'
 import {
+    DEFAULT_ANNOTATION_COLOR,
     SessionEncodeError,
-    SessionFormat,
     decodeSession,
-    decodeSessionString,
     encodeSession,
     encodeSessionString,
 } from '../js/sessionCodec.js'
+import BrowserRegistry from '../js/browserRegistry.js'
 import State from '../js/hicState.js'
 
 /**
@@ -121,13 +125,22 @@ function generator(seed) {
         if (chance(0.5)) t.type = pick(['annotation', 'wig', 'interaction'])
         if (chance(0.5)) t.format = pick(['bed', 'bigwig', 'bedpe'])
         if (chance(0.7)) t.name = `track ${int(100)}`
+        // Always numbers: `HICBrowser.toJSON` writes a range only from a
+        // `track.dataRange`, so the `NaN` bounds `fixDefaults` also sweeps
+        // cannot arise from a written session. They arise from an empty field in
+        // a v0 `tracks=` string, which is #515's, not this property's.
         if (chance(0.4)) {
             t.min = -rnd() * 10
             t.max = rnd() * 100
         }
-        // Never `DEFAULT_ANNOTATION_COLOR`: that one is dropped on decode, and
-        // is pinned in "the accepted asymmetries" below rather than here.
-        if (chance(0.5)) t.color = `rgb(${int(255)},${int(255)},${int(255)})`
+        // `DEFAULT_ANNOTATION_COLOR` is in the pool deliberately: the decoder
+        // drops it, and a generator that steered around that deviation would be
+        // routing around the very thing the property is for.
+        if (chance(0.2)) {
+            t.color = DEFAULT_ANNOTATION_COLOR
+        } else if (chance(0.5)) {
+            t.color = `rgb(${int(255)},${int(255)},${int(255)})`
+        }
         return t
     }
 
@@ -216,27 +229,16 @@ describe('encodeSession', () => {
     })
 
     /**
-     * All three spellings the sniff tells apart, because the property below is
-     * over a *format* and a spelling with no encoder would be the one corner
-     * nothing exercises. Only `blob:` is ever written — see `encodeSession`.
+     * The sniff reads three spellings; the encoder writes one. `data:` is an
+     * inbound spelling juicebox has never produced, and a bare-JSON *parameter*
+     * would carry braces and quotes straight into a query string — so neither
+     * gets an encoder, and there is no `format` argument for a caller to reach
+     * one with. Reading all three back is `testSessionCodec.js`'s.
      */
-    test.each([
-        [SessionFormat.BLOB, 'blob:'],
-        [SessionFormat.DATA_URI, 'data:'],
-    ])('%s is written with its prefix', (format, prefix) => {
-        const encoded = encodeSessionString(session, format)
-
-        expect(encoded.startsWith(prefix)).toBe(true)
-        expect(decodeSessionString(encoded)).toEqual(session)
-    })
-
-    test('the JSON spelling is the document itself, uncompressed', () => {
-        expect(encodeSessionString(session, SessionFormat.JSON)).toBe(JSON.stringify(session))
-    })
-
-    test('a spelling the sniff cannot read back is refused rather than written', () => {
-        expect(() => encodeSessionString(session, 'base85')).toThrow(SessionEncodeError)
-        expect(() => encodeSessionString(session, 'base85')).toThrow('Unknown session format')
+    test('takes no format argument, so there is one spelling to own', () => {
+        expect(encodeSessionString.length).toBe(1)
+        expect(encodeSession.length).toBe(1)
+        expect(encodeSessionString(session, 'data-uri').startsWith('blob:')).toBe(true)
     })
 
     test('a document JSON cannot express is refused, with the failure kept', () => {
@@ -260,8 +262,8 @@ describe('encodeSession', () => {
     test('a State instance encodes as the object State.toJSON writes', () => {
         const state = new State(2, 5, 3, 10, 20, 4, 'KR')
 
-        expect(encodeSessionString({browsers: [{url: 'a.hic', state}]}, SessionFormat.JSON))
-            .toBe(JSON.stringify({browsers: [{url: 'a.hic', state: state.toJSON()}]}))
+        expect(encodeSessionString({browsers: [{url: 'a.hic', state}]}))
+            .toBe(encodeSessionString({browsers: [{url: 'a.hic', state: state.toJSON()}]}))
     })
 })
 
@@ -277,27 +279,76 @@ async function roundTrip(session) {
     return await decodeSession(encodeSession(session), noIO)
 }
 
+/** How many sessions each property walks. */
+const SESSIONS = 200
+
+/**
+ * Walk the generated space, round-tripping each session. `assert` is handed the
+ * session as written, the session as it came back, and a label carrying the seed
+ * and the offending document — a property whose failure you cannot reproduce is
+ * not much of a property.
+ */
+async function forEachGeneratedSession(seed, options, assert) {
+    const generate = generator(seed)
+    for (let i = 0; i < SESSIONS; i++) {
+        const session = generate(options)
+        await assert(session, await roundTrip(session), `seed ${seed}, session ${i}: ${JSON.stringify(session)}`)
+    }
+}
+
 describe('decode(encode(session)) is the identity', () => {
 
     /**
-     * The property. Every seed is a session drawn from the space
-     * `registry.toJSON()` writes, and the assertion is strict equality — not
-     * equality after any normalising step, which ADR-0006 rejected as defining
-     * the test to pass.
+     * The property. Every session is drawn from the space `registry.toJSON()`
+     * writes, and the assertion is strict equality — not equality after any
+     * normalising step, which ADR-0006 rejected as defining the test to pass.
      *
-     * Tracks are held out of *this* loop by one line and get their own loop
-     * below, because the decoder's normalize pass touches them and that
-     * deviation is asserted rather than absorbed.
+     * Tracks are held out of *this* loop by one line, and get a loop of their
+     * own immediately below with the same strictness and two named exceptions.
+     * The split is presentational: nothing about a track is untested, and the
+     * exceptions are asserted rather than absorbed.
      */
-    test('over 200 generated sessions', async () => {
-        const generate = generator(20260810)
+    test('over 200 generated sessions, tracks aside', async () => {
+        await forEachGeneratedSession(20260810, {tracks: false}, (session, decoded, label) => {
+            expect(decoded, label).toEqual(session)
+        })
+    })
 
-        for (let seed = 0; seed < 200; seed++) {
-            const session = generate({tracks: false})
+    /**
+     * The same property over track-bearing sessions. `fixDefaults` — the
+     * decoder's normalize pass — makes exactly two changes to a track a session
+     * can carry, and both are asserted *here*, per track, before being undone:
+     * that is what makes this an assertion about behaviour rather than a
+     * normalising step. Anything else it touched would fail the `toEqual`.
+     *
+     * ADR-0006 decision 8 moves that pass out of the decoder in candidate 9;
+     * when it does, this test collapses into the one above. Filed as #525.
+     */
+    test('over 200 generated sessions with tracks, up to fixDefaults and nothing else', async () => {
+        await forEachGeneratedSession(777, {tracks: true}, (session, decoded, label) => {
 
-            expect(await roundTrip(session), `session ${seed}: ${JSON.stringify(session)}`)
-                .toEqual(session)
-        }
+            for (const [i, browser] of decoded.browsers.entries()) {
+                for (const [j, track] of (browser.tracks || []).entries()) {
+                    const written = session.browsers[i].tracks[j]
+
+                    // One: a displayMode the written form never carried.
+                    expect(Object.hasOwn(written, 'displayMode'), label).toBe(false)
+                    expect(track.displayMode, label).toBe('COLLAPSED')
+                    delete track.displayMode
+
+                    // Two: the default annotation colour, dropped — and only
+                    // that colour, which is why the else arm asserts too.
+                    if (DEFAULT_ANNOTATION_COLOR === written.color) {
+                        expect(Object.hasOwn(track, 'color'), label).toBe(false)
+                        track.color = written.color
+                    } else {
+                        expect(track.color, label).toBe(written.color)
+                    }
+                }
+            }
+
+            expect(decoded, label).toEqual(session)
+        })
     })
 
     /**
@@ -306,19 +357,20 @@ describe('decode(encode(session)) is the identity', () => {
      * restore, and the view that comes out has to be the view that was saved.
      * The generator asks for pairs in both orders, so this covers both sides of
      * the diagonal.
+     *
+     * The codec itself passes a `state` through verbatim — it is one more object
+     * in the document — so this leg, not the `toEqual` above, is where the
+     * invariant is load-bearing. Without it the pair asked for as `(chr5, chr2)`
+     * comes back spelled the other way; "the spelling axis ordering retired",
+     * below, is that failure, pinned.
      */
     test('the view survives being rebuilt as a State', async () => {
-        const generate = generator(4242)
-
-        for (let seed = 0; seed < 200; seed++) {
-            const session = generate({tracks: false})
-            const decoded = await roundTrip(session)
-
-            for (const [i, browser] of (decoded?.browsers || []).entries()) {
-                expect(State.fromJSON(browser.state).toJSON(), `session ${seed}, browser ${i}`)
+        await forEachGeneratedSession(4242, {tracks: false}, (session, decoded, label) => {
+            for (const [i, browser] of decoded.browsers.entries()) {
+                expect(State.fromJSON(browser.state).toJSON(), `${label} (browser ${i})`)
                     .toEqual(session.browsers[i].state)
             }
-        }
+        })
     })
 
     /**
@@ -384,6 +436,21 @@ describe('the generated space', () => {
         expect(counts.some(n => n > 1)).toBe(true)
     })
 
+    /**
+     * The deviation the track property's `else` arm exists for. A generator that
+     * never emitted the default colour would leave that arm unexercised and the
+     * drop unpinned.
+     */
+    test('holds tracks carrying the default annotation colour, and tracks carrying another', () => {
+        const generate = generator(777)
+        const tracks = Array.from({length: SESSIONS}, () => generate({tracks: true}))
+            .flatMap(session => session.browsers)
+            .flatMap(browser => browser.tracks || [])
+
+        expect(tracks.filter(t => DEFAULT_ANNOTATION_COLOR === t.color).length).toBeGreaterThan(0)
+        expect(tracks.filter(t => t.color && DEFAULT_ANNOTATION_COLOR !== t.color).length).toBeGreaterThan(0)
+    })
+
     test('tracks are generated when they are asked for, and not when they are not', () => {
         const withTracks = generator(99)
         const without = generator(99)
@@ -444,80 +511,96 @@ describe('the accepted asymmetries', () => {
 
     /**
      * ADR-0006 decision 6. A browser with no dataset serializes to `null` and
-     * the registry drops it, so an embed saved with an empty panel open
-     * restores one panel short. The registry half is `testRegistrySession.js`'s;
-     * what is asserted here is that the *codec* faithfully round-trips the
-     * shorter list — the count is already gone before the encoder sees it, and
-     * nothing downstream puts it back.
+     * the registry drops it, so an embed saved with an empty panel open restores
+     * one panel short.
+     *
+     * The asymmetry is asserted end to end — two panels in, one browser out,
+     * round-tripped — because a test that hands the encoder a one-browser
+     * session and finds one browser has asserted nothing. That means a real
+     * `BrowserRegistry`, which needs no document as long as nothing selects a
+     * browser: `register` pushes, and `toJSON` reads only `toJSON`. The two
+     * stand-ins are what a loaded panel and an empty one serialize to, per #500,
+     * and `testRegistrySession.js` is where *that* is pinned against the real
+     * `HICBrowser`.
      */
     test('browser count does not survive when a browser was empty', async () => {
-        const written = {browsers: [{url: 'https://example.org/a.hic', state: State.default().toJSON()}]}
+        const loaded = {url: 'https://example.org/a.hic', state: State.default().toJSON()}
+        const registry = new BrowserRegistry()
+        registry.register({toJSON: () => loaded})
+        registry.register({toJSON: () => null})     // a panel with no map
 
-        // What two panels, one of them empty, serialize to.
+        const written = registry.toJSON()
         const decoded = await roundTrip(written)
 
-        expect(decoded.browsers).toHaveLength(1)
+        expect(registry.browsers).toHaveLength(2)
+        expect(written.browsers).toEqual([loaded])
         expect(decoded).toEqual(written)
     })
 
     /**
+     * And the count is gone for good — nothing in the decoded session records
+     * that a panel was dropped, which is what makes this an accepted asymmetry
+     * rather than a recoverable one. Restore rebuilds what the session names.
+     */
+    test('and nothing in the session says a panel was dropped', async () => {
+        const registry = new BrowserRegistry()
+        registry.register({toJSON: () => null})
+        registry.register({toJSON: () => null})
+
+        expect(await roundTrip(registry.toJSON())).toEqual({browsers: []})
+    })
+
+    /**
      * The decoder's normalize pass — `fixDefaults` — runs on every format,
-     * including this one, and it forces every track to `COLLAPSED`, drops the
-     * default annotation colour, and drops a `NaN` data range. A saved session's
-     * tracks carry no `displayMode` at all, so the round trip adds a field.
+     * including this one, and it makes two changes to a track a session can
+     * carry: it forces `displayMode` to `COLLAPSED`, a field the written form
+     * never has, and it drops the default annotation colour. (Its third effect,
+     * dropping a `NaN` data range, cannot be reached from a written session; see
+     * the generator's `track()`.)
+     *
+     * The property above asserts both of these per track over the generated
+     * space, which is where they are pinned. These two are the same claims in
+     * literal form — a reader finding a stray `COLLAPSED` in a decoded session
+     * should be able to see why in one screen.
      *
      * This is normalization sitting inside the decoder, which ADR-0006 decision
-     * 8 names as candidate 9's to move behind a `normalizeSession` stage. **When
-     * it moves, this block goes and the property above gets stricter** — the
-     * three `delete`s below are the whole cost of the deviation, and they are
-     * written out rather than hidden in a helper so that cost stays visible.
-     * Filed as #525.
+     * 8 names as candidate 9's to move behind a `normalizeSession` stage that
+     * *both* entry paths pass through. Until it moves, a session restored from a
+     * URL and the same session handed to `restoreSession` disagree. Filed as
+     * #525; when it lands, this block goes and the property above absorbs the
+     * track case.
      */
     describe('the decoder normalises tracks on the way in', () => {
 
+        const withTrack = track => ({browsers: [{url: 'https://example.org/a.hic', tracks: [track]}]})
+
         test('every track comes back COLLAPSED, whatever was saved', async () => {
-            const session = {
-                browsers: [{
-                    url: 'https://example.org/a.hic',
-                    tracks: [{url: 'https://example.org/a.bed', name: 'a'}],
-                }],
-            }
+            const session = withTrack({url: 'https://example.org/a.bed', name: 'a'})
+
+            expect((await roundTrip(session)).browsers[0].tracks[0].displayMode).toBe('COLLAPSED')
+        })
+
+        /**
+         * Including one that asked for something else — which is the part that
+         * makes the two entry paths disagree rather than merely differ from the
+         * written form.
+         */
+        test('even one that saved a different display mode', async () => {
+            const session = withTrack({url: 'https://example.org/a.bed', displayMode: 'EXPANDED'})
 
             expect((await roundTrip(session)).browsers[0].tracks[0].displayMode).toBe('COLLAPSED')
         })
 
         test('the default annotation colour is dropped', async () => {
-            const session = {
-                browsers: [{
-                    url: 'https://example.org/a.hic',
-                    tracks: [{url: 'https://example.org/a.bed', color: codec.DEFAULT_ANNOTATION_COLOR}],
-                }],
-            }
+            const session = withTrack({url: 'https://example.org/a.bed', color: DEFAULT_ANNOTATION_COLOR})
 
             expect(Object.hasOwn((await roundTrip(session)).browsers[0].tracks[0], 'color')).toBe(false)
         })
 
-        /**
-         * The property, over track-bearing sessions, with the normalize pass's
-         * one addition asserted and then removed. Everything else about a track
-         * — url, type, format, name, data range, colour — is identity.
-         */
-        test('and changes nothing else about a track', async () => {
-            const generate = generator(777)
+        test('and any other colour is kept', async () => {
+            const session = withTrack({url: 'https://example.org/a.bed', color: 'rgb(1,2,3)'})
 
-            for (let seed = 0; seed < 200; seed++) {
-                const session = generate()
-                const decoded = await roundTrip(session)
-
-                for (const browser of decoded?.browsers || []) {
-                    for (const track of browser.tracks || []) {
-                        expect(track.displayMode, `session ${seed}`).toBe('COLLAPSED')
-                        delete track.displayMode
-                    }
-                }
-
-                expect(decoded, `session ${seed}: ${JSON.stringify(session)}`).toEqual(session)
-            }
+            expect((await roundTrip(session)).browsers[0].tracks[0].color).toBe('rgb(1,2,3)')
         })
     })
 })

--- a/test/testSessionRoundTrip.js
+++ b/test/testSessionRoundTrip.js
@@ -1,0 +1,551 @@
+/**
+ * `decode(encode(x)) === x`, as a property, over generated sessions. #507,
+ * ADR-0006 decision 4.
+ *
+ * This is the test the whole candidate exists to make possible, and two earlier
+ * tickets were prerequisites *because of it*:
+ *
+ * - **#500** — `browser.toJSON()` used to return the string `"{}"` for a browser
+ *   with no map, so there was no well-typed encoder output to invert. The
+ *   empty-browser case is **covered here** rather than skipped; skipping it is
+ *   precisely how that bug survived as long as it did.
+ * - **Axis ordering** (ADR-0006 decision 3) — a saved view now has exactly one
+ *   spelling. Without it the property fails on day one for any view whose
+ *   y-axis chromosome index is below its x-axis's, and "equal after
+ *   normalisation" was explicitly rejected as a way to make it pass, because
+ *   that defines the test to pass by weakening it. The generator asks for views
+ *   on **both** sides of the diagonal and asserts that both survive; the one
+ *   spelling that does not survive is pinned separately, below.
+ *
+ * The generator emits the shape `registry.toJSON()` writes — field for field,
+ * with `js/hicBrowser.js` `toJSON` as the reference — because the property is
+ * about the format juicebox actually emits and nothing else. A generator free to
+ * invent fields would be testing a format no session is ever in.
+ *
+ * No network and no DOM: the loader passed to `decodeSession` throws, and
+ * nothing here constructs a browser. What a *registry* does with an empty
+ * browser is `test/testRegistrySession.js`'s (#500); what the codec does with
+ * the session that comes out of one is here.
+ *
+ * @see js/sessionCodec.js
+ * @see docs/adr/0006-session-wire-format-and-one-decoder.md
+ */
+import {describe, expect, test} from 'vitest'
+import {BGZip} from 'igv-utils'
+import * as codec from '../js/sessionCodec.js'
+import {
+    SessionEncodeError,
+    SessionFormat,
+    decodeSession,
+    decodeSessionString,
+    encodeSession,
+    encodeSessionString,
+} from '../js/sessionCodec.js'
+import State from '../js/hicState.js'
+
+/**
+ * A loader that fails the test rather than the fetch. The session-JSON form
+ * carries its whole payload in the parameter, so a round trip that reaches for
+ * the wire has stopped being a round trip.
+ */
+const noIO = {
+    loadString: async url => {
+        throw new Error(`unexpected load of ${url}`)
+    },
+}
+
+// ---------------------------------------------------------------------------
+// The generator
+//
+// Deterministic and dependency-free. A seeded PRNG rather than a property-test
+// library because the whole value here is a space of *sessions*, which no
+// library knows how to build for us, and a failing run has to be reproducible
+// from the seed printed in the assertion.
+// ---------------------------------------------------------------------------
+
+/** mulberry32 — small, seeded, and good enough to walk a space of sessions. */
+function mulberry32(seed) {
+    let a = seed >>> 0
+    return () => {
+        a = (a + 0x6D2B79F5) >>> 0
+        let t = a
+        t = Math.imul(t ^ (t >>> 15), t | 1)
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+}
+
+/**
+ * The chromosome indices a state can name. Index 0 is the whole genome, so it
+ * is in the pool deliberately: `(0, 0)` is the view every session opens on.
+ */
+const CHROMOSOMES = [0, 1, 2, 5, 17, 23]
+
+const NORMALIZATIONS = ['NONE', 'VC', 'VC_SQRT', 'KR', 'SCALE']
+
+const DISPLAY_MODES = ['A', 'B', 'AOB', 'BOA']
+
+function generator(seed) {
+
+    const rnd = mulberry32(seed)
+    const pick = choices => choices[Math.floor(rnd() * choices.length)]
+    const chance = p => rnd() < p
+    const int = n => Math.floor(rnd() * n)
+
+    /**
+     * A state as a *saved* session carries it: whatever order the pair is asked
+     * for, it goes through `State`, which owns the axis-ordering invariant, and
+     * out through `State.toJSON()`. Both sides of the diagonal are asked for —
+     * which is the point — and both produce the one canonical spelling.
+     */
+    function state() {
+        const a = pick(CHROMOSOMES)
+        const b = pick(CHROMOSOMES)
+        // Deliberately unordered half the time. `new State` transposes chr/x/y
+        // together, exactly as `setView` does for a live view.
+        const [chr1, chr2] = chance(0.5) ? [a, b] : [b, a]
+        return new State(
+            chr1,
+            chr2,
+            int(10),
+            rnd() * 10000,
+            rnd() * 10000,
+            1 + rnd() * 20,
+            pick(NORMALIZATIONS),
+        ).toJSON()
+    }
+
+    /** A track as `HICBrowser.toJSON` writes one: no `displayMode`, ever. */
+    function track() {
+        const t = {url: `https://example.org/track-${int(1000)}.bed`}
+        if (chance(0.5)) t.type = pick(['annotation', 'wig', 'interaction'])
+        if (chance(0.5)) t.format = pick(['bed', 'bigwig', 'bedpe'])
+        if (chance(0.7)) t.name = `track ${int(100)}`
+        if (chance(0.4)) {
+            t.min = -rnd() * 10
+            t.max = rnd() * 100
+        }
+        // Never `DEFAULT_ANNOTATION_COLOR`: that one is dropped on decode, and
+        // is pinned in "the accepted asymmetries" below rather than here.
+        if (chance(0.5)) t.color = `rgb(${int(255)},${int(255)},${int(255)})`
+        return t
+    }
+
+    function browser({tracks}) {
+        const config = {
+            backgroundColor: `rgb(${int(255)},${int(255)},${int(255)})`,
+            url: `https://example.org/map-${int(1000)}.hic`,
+            state: state(),
+            colorScale: `${pick(['', '-', '+'])}${int(100)},${int(255)},${int(255)},${int(255)}`,
+        }
+        if (chance(0.7)) config.name = `map ${int(100)}`
+        if (chance(0.3)) config.nvi = `${int(1e9)},${int(1e5)}`
+        if (chance(0.3)) {
+            config.controlUrl = `https://example.org/control-${int(1000)}.hic`
+            if (chance(0.7)) config.controlName = `control ${int(100)}`
+            if (chance(0.7)) config.displayMode = pick(DISPLAY_MODES)
+            if (chance(0.5)) config.controlNvi = `${int(1e9)},${int(1e5)}`
+            if (chance(0.5)) config.cycle = true
+        }
+        if (tracks && chance(0.5)) {
+            config.tracks = Array.from({length: 1 + int(3)}, track)
+        }
+        return config
+    }
+
+    /**
+     * `selectedGene` is written at both levels or at neither — the registry
+     * writes the top-level copy and every browser writes its own from the same
+     * field — so the generator does not vary them independently. A session
+     * carrying the gene on a browser but not at the top level is a shape
+     * juicebox never writes, and the decoder reconciles it (#481); that is
+     * `testSessionDecode.js`'s.
+     */
+    return function session({tracks = true, browsers: howMany} = {}) {
+        const count = undefined === howMany ? int(4) : howMany
+        const config = {
+            browsers: Array.from({length: count}, () => browser({tracks})),
+        }
+        if (count > 0 && chance(0.3)) {
+            const selectedGene = pick(['ACE', 'EGFR', 'MYC'])
+            config.selectedGene = selectedGene
+            for (const b of config.browsers) {
+                b.selectedGene = selectedGene
+            }
+        }
+        if (chance(0.2)) config.caption = `figure ${int(100)}`
+        return config
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The encoder
+// ---------------------------------------------------------------------------
+
+describe('encodeSession', () => {
+
+    const session = {browsers: [{url: 'https://example.org/a.hic', name: 'a'}]}
+
+    test('writes the share-link form juicebox-web appends to its base URL', () => {
+        const encoded = encodeSession(session)
+
+        expect(encoded.startsWith('session=blob:')).toBe(true)
+        expect(BGZip.uncompressString(encoded.substring('session=blob:'.length)))
+            .toBe(JSON.stringify(session))
+    })
+
+    /**
+     * The encoded parameter goes into a URL, and `extractQuery` splits a query
+     * string on `&` and takes the value up to the *second* `=`. A base64
+     * alphabet with padding or a `+` would therefore be silently truncated on
+     * the way back in. `BGZip` writes the URL-safe alphabet unpadded, and this
+     * is the assertion that says the round trip depends on it.
+     */
+    test('the payload carries nothing a query string would eat', () => {
+        const generate = generator(11)
+        for (let i = 0; i < 50; i++) {
+            const encoded = encodeSession(generate())
+            expect(encoded.split('=')).toHaveLength(2)
+            expect(encoded).not.toContain('&')
+            expect(encoded).not.toContain('#')
+        }
+    })
+
+    test('a session string is the payload without the parameter name', () => {
+        expect(encodeSession(session)).toBe(`session=${encodeSessionString(session)}`)
+    })
+
+    /**
+     * All three spellings the sniff tells apart, because the property below is
+     * over a *format* and a spelling with no encoder would be the one corner
+     * nothing exercises. Only `blob:` is ever written — see `encodeSession`.
+     */
+    test.each([
+        [SessionFormat.BLOB, 'blob:'],
+        [SessionFormat.DATA_URI, 'data:'],
+    ])('%s is written with its prefix', (format, prefix) => {
+        const encoded = encodeSessionString(session, format)
+
+        expect(encoded.startsWith(prefix)).toBe(true)
+        expect(decodeSessionString(encoded)).toEqual(session)
+    })
+
+    test('the JSON spelling is the document itself, uncompressed', () => {
+        expect(encodeSessionString(session, SessionFormat.JSON)).toBe(JSON.stringify(session))
+    })
+
+    test('a spelling the sniff cannot read back is refused rather than written', () => {
+        expect(() => encodeSessionString(session, 'base85')).toThrow(SessionEncodeError)
+        expect(() => encodeSessionString(session, 'base85')).toThrow('Unknown session format')
+    })
+
+    test('a document JSON cannot express is refused, with the failure kept', () => {
+        const circular = {browsers: []}
+        circular.self = circular
+
+        expect(() => encodeSessionString(circular)).toThrow(SessionEncodeError)
+        try {
+            encodeSessionString(circular)
+            expect.unreachable('a circular session must not encode')
+        } catch (e) {
+            expect(e.cause).toBeInstanceOf(TypeError)
+        }
+    })
+
+    /**
+     * A `State` instance reaches the encoder from any host that hands one
+     * straight to `restoreSession`'s inverse; `JSON.stringify` runs its
+     * `toJSON`, so it encodes to the same seven fields a saved session carries.
+     */
+    test('a State instance encodes as the object State.toJSON writes', () => {
+        const state = new State(2, 5, 3, 10, 20, 4, 'KR')
+
+        expect(encodeSessionString({browsers: [{url: 'a.hic', state}]}, SessionFormat.JSON))
+            .toBe(JSON.stringify({browsers: [{url: 'a.hic', state: state.toJSON()}]}))
+    })
+})
+
+// ---------------------------------------------------------------------------
+// The property
+// ---------------------------------------------------------------------------
+
+/**
+ * One iteration of the property. Returns the decoded session so a caller can
+ * make further claims about it.
+ */
+async function roundTrip(session) {
+    return await decodeSession(encodeSession(session), noIO)
+}
+
+describe('decode(encode(session)) is the identity', () => {
+
+    /**
+     * The property. Every seed is a session drawn from the space
+     * `registry.toJSON()` writes, and the assertion is strict equality — not
+     * equality after any normalising step, which ADR-0006 rejected as defining
+     * the test to pass.
+     *
+     * Tracks are held out of *this* loop by one line and get their own loop
+     * below, because the decoder's normalize pass touches them and that
+     * deviation is asserted rather than absorbed.
+     */
+    test('over 200 generated sessions', async () => {
+        const generate = generator(20260810)
+
+        for (let seed = 0; seed < 200; seed++) {
+            const session = generate({tracks: false})
+
+            expect(await roundTrip(session), `session ${seed}: ${JSON.stringify(session)}`)
+                .toEqual(session)
+        }
+    })
+
+    /**
+     * The other half of the identity, and the half axis ordering was a
+     * prerequisite for: a session's `state` is handed to `State.fromJSON` on
+     * restore, and the view that comes out has to be the view that was saved.
+     * The generator asks for pairs in both orders, so this covers both sides of
+     * the diagonal.
+     */
+    test('the view survives being rebuilt as a State', async () => {
+        const generate = generator(4242)
+
+        for (let seed = 0; seed < 200; seed++) {
+            const session = generate({tracks: false})
+            const decoded = await roundTrip(session)
+
+            for (const [i, browser] of (decoded?.browsers || []).entries()) {
+                expect(State.fromJSON(browser.state).toJSON(), `session ${seed}, browser ${i}`)
+                    .toEqual(session.browsers[i].state)
+            }
+        }
+    })
+
+    /**
+     * The empty-browser case, covered rather than skipped. An embed whose only
+     * panel has no map serializes to `{browsers: []}` — a well-typed session
+     * with nothing in it, which is what #500 bought — and that survives the
+     * round trip like any other. Until #500 it was the string `"{}"`, which the
+     * encoder had no way to invert.
+     */
+    test('a session with no browsers at all', async () => {
+        expect(await roundTrip({browsers: []})).toEqual({browsers: []})
+    })
+
+    test('an empty browser list still carries the rest of the session', async () => {
+        const session = {browsers: [], selectedGene: 'ACE', caption: 'figure 1'}
+
+        expect(await roundTrip(session)).toEqual(session)
+    })
+})
+
+/**
+ * A property over generated data is only as good as the space it walks, and a
+ * generator that quietly stopped producing off-diagonal views would leave the
+ * suite green and prove nothing. These assertions are about the *generator*.
+ */
+describe('the generated space', () => {
+
+    const states = () => {
+        const generate = generator(20260810)
+        return Array.from({length: 200}, () => generate({tracks: false}))
+            .flatMap(session => session.browsers.map(browser => browser.state))
+    }
+
+    test('holds views on the diagonal and off it', () => {
+        const all = states()
+
+        expect(all.filter(s => s.chr1 === s.chr2).length).toBeGreaterThan(10)
+        expect(all.filter(s => s.chr1 !== s.chr2).length).toBeGreaterThan(10)
+    })
+
+    test('holds the whole-genome view, which is index 0 on both axes', () => {
+        expect(states().some(s => 0 === s.chr1 && 0 === s.chr2)).toBe(true)
+    })
+
+    /**
+     * Every generated state is canonical, because every one went through
+     * `State` — including the half of them asked for in the reversed order. This
+     * is the invariant ADR-0006 decision 3 bought, seen from the generator's
+     * side: asking for `(chr5, chr2)` and asking for `(chr2, chr5)` produce the
+     * same saved spelling, so there is exactly one spelling to round-trip.
+     */
+    test('every generated view is axis-ordered, whichever order it was asked for', () => {
+        for (const state of states()) {
+            expect(state.chr1, JSON.stringify(state)).toBeLessThanOrEqual(state.chr2)
+        }
+    })
+
+    test('a session with browsers, and a session with none, are both generated', () => {
+        const generate = generator(20260810)
+        const counts = Array.from({length: 200}, () => generate({tracks: false}).browsers.length)
+
+        expect(counts.some(n => 0 === n)).toBe(true)
+        expect(counts.some(n => n > 1)).toBe(true)
+    })
+
+    test('tracks are generated when they are asked for, and not when they are not', () => {
+        const withTracks = generator(99)
+        const without = generator(99)
+        const hasTracks = session => session.browsers.some(b => undefined !== b.tracks)
+
+        expect(Array.from({length: 50}, () => withTracks()).some(hasTracks)).toBe(true)
+        expect(Array.from({length: 50}, () => without({tracks: false})).some(hasTracks)).toBe(false)
+    })
+})
+
+/**
+ * The spelling that does **not** survive, pinned here so the property above is
+ * read as a claim about canonical sessions rather than about every object with a
+ * `state` in it.
+ *
+ * A session carrying `chr1 > chr2` names the same triangle as its transpose — a
+ * `.hic` file stores one triangle of a symmetric matrix — so `State` transposes
+ * `chr1`/`chr2` together with `x`/`y` and the view that comes back out is spelled
+ * the other way. The *view* is the identity; the *spelling* is not, which is
+ * exactly why axis ordering had to become an invariant before this property
+ * could be written. ADR-0006 decision 3.
+ *
+ * Non-breaking for the archive: a session in the wild carrying the unordered
+ * spelling decodes exactly as it always has, to the transposed view.
+ */
+describe('the spelling axis ordering retired', () => {
+
+    const unordered = {chr1: 5, chr2: 2, zoom: 3, x: 100, y: 200, pixelSize: 4, normalization: 'KR'}
+
+    test('the session document itself survives verbatim — the codec transposes nothing', async () => {
+        const session = {browsers: [{url: 'https://example.org/a.hic', state: unordered}]}
+
+        expect((await roundTrip(session)).browsers[0].state).toEqual(unordered)
+    })
+
+    test('rebuilding it as a State transposes the axes, so the spelling does not round-trip', () => {
+        expect(State.fromJSON(unordered).toJSON()).toEqual({
+            chr1: 2, chr2: 5, zoom: 3, x: 200, y: 100, pixelSize: 4, normalization: 'KR',
+        })
+    })
+
+    test('and juicebox cannot write it: the canonical spelling is a fixed point', () => {
+        const canonical = State.fromJSON(unordered).toJSON()
+
+        expect(State.fromJSON(canonical).toJSON()).toEqual(canonical)
+    })
+})
+
+// ---------------------------------------------------------------------------
+// Where it is not the identity
+// ---------------------------------------------------------------------------
+
+/**
+ * Two deviations, each asserted as behaviour rather than allowed to fail. Both
+ * are named in ADR-0006; neither is a licence to normalise the property above.
+ */
+describe('the accepted asymmetries', () => {
+
+    /**
+     * ADR-0006 decision 6. A browser with no dataset serializes to `null` and
+     * the registry drops it, so an embed saved with an empty panel open
+     * restores one panel short. The registry half is `testRegistrySession.js`'s;
+     * what is asserted here is that the *codec* faithfully round-trips the
+     * shorter list — the count is already gone before the encoder sees it, and
+     * nothing downstream puts it back.
+     */
+    test('browser count does not survive when a browser was empty', async () => {
+        const written = {browsers: [{url: 'https://example.org/a.hic', state: State.default().toJSON()}]}
+
+        // What two panels, one of them empty, serialize to.
+        const decoded = await roundTrip(written)
+
+        expect(decoded.browsers).toHaveLength(1)
+        expect(decoded).toEqual(written)
+    })
+
+    /**
+     * The decoder's normalize pass — `fixDefaults` — runs on every format,
+     * including this one, and it forces every track to `COLLAPSED`, drops the
+     * default annotation colour, and drops a `NaN` data range. A saved session's
+     * tracks carry no `displayMode` at all, so the round trip adds a field.
+     *
+     * This is normalization sitting inside the decoder, which ADR-0006 decision
+     * 8 names as candidate 9's to move behind a `normalizeSession` stage. **When
+     * it moves, this block goes and the property above gets stricter** — the
+     * three `delete`s below are the whole cost of the deviation, and they are
+     * written out rather than hidden in a helper so that cost stays visible.
+     * Filed as #525.
+     */
+    describe('the decoder normalises tracks on the way in', () => {
+
+        test('every track comes back COLLAPSED, whatever was saved', async () => {
+            const session = {
+                browsers: [{
+                    url: 'https://example.org/a.hic',
+                    tracks: [{url: 'https://example.org/a.bed', name: 'a'}],
+                }],
+            }
+
+            expect((await roundTrip(session)).browsers[0].tracks[0].displayMode).toBe('COLLAPSED')
+        })
+
+        test('the default annotation colour is dropped', async () => {
+            const session = {
+                browsers: [{
+                    url: 'https://example.org/a.hic',
+                    tracks: [{url: 'https://example.org/a.bed', color: codec.DEFAULT_ANNOTATION_COLOR}],
+                }],
+            }
+
+            expect(Object.hasOwn((await roundTrip(session)).browsers[0].tracks[0], 'color')).toBe(false)
+        })
+
+        /**
+         * The property, over track-bearing sessions, with the normalize pass's
+         * one addition asserted and then removed. Everything else about a track
+         * — url, type, format, name, data range, colour — is identity.
+         */
+        test('and changes nothing else about a track', async () => {
+            const generate = generator(777)
+
+            for (let seed = 0; seed < 200; seed++) {
+                const session = generate()
+                const decoded = await roundTrip(session)
+
+                for (const browser of decoded?.browsers || []) {
+                    for (const track of browser.tracks || []) {
+                        expect(track.displayMode, `session ${seed}`).toBe('COLLAPSED')
+                        delete track.displayMode
+                    }
+                }
+
+                expect(decoded, `session ${seed}: ${JSON.stringify(session)}`).toEqual(session)
+            }
+        })
+    })
+})
+
+// ---------------------------------------------------------------------------
+// One encoder, not four
+// ---------------------------------------------------------------------------
+
+/**
+ * ADR-0006 decision 4. The other three accepted formats stay decode-only:
+ * writing encoders for them would resurrect live encoders for formats nothing
+ * has written in years, and we would then own them forever.
+ *
+ * Asserted rather than trusted to the review, because the failure mode is
+ * someone adding `encodeJuicebox` for a plausible-sounding reason and no test
+ * minding.
+ */
+describe('the legacy formats stay decode-only', () => {
+
+    test('the codec exports exactly one encoder, and it is the session form', () => {
+        const encoders = Object.keys(codec).filter(name => name.startsWith('encode'))
+
+        expect(encoders.sort()).toEqual(['encodeSession', 'encodeSessionString'])
+    })
+
+    test('no wire-format adapter carries an encode half', () => {
+        for (const adapter of codec.WIRE_FORMATS) {
+            expect(adapter.encode, adapter.format).toBeUndefined()
+        }
+    })
+})


### PR DESCRIPTION
Closes #507. ADR-0006 decision 4, candidate 5's payoff ticket.

`decode(encode(x)) === x`, as a property over generated sessions — the test the
whole candidate exists to make possible. The two tickets before it were
prerequisites *because of this one*: #500 gave the encoder a well-typed output to
invert, and axis ordering (decision 3) gave a saved view exactly one spelling.

## The encoder

`encodeSession` lives in `js/sessionCodec.js`, and `session.compressedSession()`
calls it rather than compressing for itself — so the encoder is the one
juicebox-web's share link actually goes through, not a test-only fiction.

**One spelling, `blob:`, and no `format` argument.** The decoder reads `data:`
and bare JSON too, but nothing has ever emitted a `data:` share link, and a
bare-JSON *parameter* would carry braces and quotes into a query string. Taking a
format argument would be a live encoder for a spelling nothing writes — the same
trade decision 4 refuses one level up.

**Legacy formats stay decode-only, and that is asserted**, not left to review:
the codec exports exactly one encoder pair, and no wire-format adapter has an
`encode` half. The failure mode being guarded is someone adding `encodeJuicebox`
for a plausible-sounding reason with no test minding.

## The property

`test/testSessionRoundTrip.js` — 28 tests, no network and no DOM. A seeded
generator walks the shape `registry.toJSON()` writes, field for field, and the
assertion is strict equality — not equality after a normalising step, which the
ADR rejected as defining the test to pass. Separate assertions pin the *generated
space* (both diagonal sides present, whole-genome view present, every generated
view axis-ordered, default-coloured tracks present), so a generator that quietly
stopped covering a case cannot leave the suite green.

**Both sides of the diagonal, honestly.** The codec passes a `state` through
verbatim, so the `toEqual` is diagonal-blind on its own — it would have passed
before #499. The leg that bites is `State.fromJSON(decoded.state).toJSON()`,
asserted per browser, and the retired `chr1 > chr2` spelling is pinned separately
as the failure it is. The file says so rather than claiming more than it proves.

**The empty-browser case is covered, not skipped** — skipping it is how the `"{}"`
bug survived. A container-less `BrowserRegistry` gets a loaded stand-in and an
empty one; two panels go in, one browser comes out, and the round trip preserves
the shorter list. A second test asserts the loss is not recoverable from the
session.

## Where the identity does not hold

Two deviations, each asserted as behaviour:

1. **Browser count**, when a panel was empty (decision 6) — the accepted
   asymmetry this ticket predicted.
2. **Tracks** — `fixDefaults` forces every track to `COLLAPSED`, overriding one
   that saved `EXPANDED`, and drops the default annotation colour. So a session
   restored from a URL and the same session handed to `restoreSession` disagree
   today. Not predicted by the ticket; filed as **#525**, whose acceptance
   criterion is deleting the compensation once candidate 9 moves normalization
   behind the stage both entry paths share (decision 8).

Both effects are asserted per track inside the property loop and then undone, so
anything else `fixDefaults` touched fails the comparison. `fixDefaults`' third
effect — dropping `NaN` bounds — is commented as unreachable from a written
session rather than silently absent; it belongs to #515.

## Verification

Mutation-checked, because a green property proves nothing on its own. Each of
these fails the suite: deleting a track field in `fixDefaults`, dropping
`caption` in the encoder, removing the `State` constructor's transposition.

Full suite green — 715 tests, 37 files. `vite build` clean. No public surface
added: `publicApi.js` is untouched, per decision 9.

`docs/url.md` gains the encoder, both deviations, the one-spelling rule, and the
URL-safe-alphabet constraint the round trip depends on — the decoder's query
splitter reads a value only as far as its second `=`, so a padded base64
alphabet would truncate a share link silently.

## Review

`/code-review` ran on the first commit; the second answers it. Both axes
independently found the same worst thing — the count asymmetry was asserted with
a one-browser session and `toHaveLength(1)`, a tautology that would pass against
a codec with no asymmetry at all. They also caught that
`encodeSession(session, JSON)` emitted a broken query parameter, which is what
retired the `format` argument. The property came out stricter than it went in:
tracks moved into the property proper and the generator stopped steering around
the colour drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)