### PR TITLE
Stamp a version on written sessions; absence means v1 (#508)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -134,6 +134,14 @@ accepted. **v0** is the older query form documented in `docs/url.md` — a
 4-token track string, and the session JSON that `compressedSession` writes.
 Juicebox reads both and writes only v1. See `docs/adr/0006`.
 
+A session JSON juicebox writes says so, in a top-level `version` field holding
+the number 1; **a session that says nothing is v1**, which is every session ever
+saved before the field existed. It is the format's field, not the document's:
+stamped by the encoder, taken off by the decoder, never seen by
+`restoreSession`. Numbered on the same v0/v1 sequence as the rest of this
+paragraph — v0 has no session JSON, so 1 is the first number it can hold. See
+`docs/url.md` "Version" and ADR-0006 decision 7.
+
 The accepted set is pinned, not described: `test/data/wireFormatCorpus.js` holds
 one fixture per format and per decoder branch, and `test/testDecoderGolden.js`
 snapshots what today's decoder makes of each. Those snapshots *are* the

--- a/docs/url.md
+++ b/docs/url.md
@@ -12,6 +12,11 @@ emits today is the compressed session link described under
 [Session forms](#session-forms). The query form is read-only inbound: links in
 the wild, links in papers, and links written by the Java desktop application.
 
+Neither query-form version carries a version marker: they are told apart
+structurally, by token count. The session form is the one that says which
+version it is outright — see [Version](#version) — and **the absence of that
+marker means v1**, which is the rule the whole archive rests on.
+
 All parameter values must be URL encoded.
 
 > **Maintenance obligation.** This page is the only complete record of the state
@@ -182,12 +187,47 @@ follow the same rules as above.
 
 | Parameter | Description |
 | --------- | ----------- |
-| `session=` | **v1 session JSON**. A `blob:` or `data:` prefix means the rest is compressed and base64-encoded — the only form juicebox writes, as juicebox-web's share link. Anything else is loaded as a URL or file and may be either compressed or plain JSON. |
+| `session=` | **v1 session JSON**, carrying a [version](#version) field on the way out and never requiring one on the way in. A `blob:` or `data:` prefix means the rest is compressed and base64-encoded — the only form juicebox writes, as juicebox-web's share link. Anything else is loaded as a URL or file and may be either compressed or plain JSON. |
 | `juicebox={…},{…}` | one brace-wrapped query string per browser, comma-separated. Read-only legacy. |
 | `juiceboxData=` | the `juicebox=` value above, compressed. **Not** session JSON — the two share one code path, and the only difference is that this one is decompressed first. Read-only legacy. |
 
-Session JSON has no `version` field today; its absence means v1. When one is
-added (#508) it will be written but never required.
+### Version
+
+Session JSON carries a `version` field, at the top level of the document beside
+`browsers`. It holds the number **1** — the same v0/v1 sequence this page uses
+throughout, on which session JSON begins at 1 because v0 had none — and juicebox
+stamps it on every session it writes (#508,
+[ADR-0006](adr/0006-session-wire-format-and-one-decoder.md) decision 7).
+
+```json
+{"browsers": [{"url": "…"}], "version": 1}
+```
+
+**A session with no `version` field is v1.** This is the rule, not a fallback:
+every session written before the field existed lacks it — links pasted into mail
+and papers, session files on disk — and all of them decode exactly as they
+always have, with nothing logged and nothing degraded. The field is **never
+required**, and a reader that demanded one would break the entire archive to
+gain a check on nothing.
+
+A session naming any *other* version is **refused**, with a message quoting the
+version it named. A document from a future juicebox may spell fields this reader
+would misread, so half-decoding it into a view the user never saved is worse
+than saying what happened.
+
+The version belongs to the **wire format**, not to the session document: the
+encoder writes it and the decoder consumes it, in the same way the `blob:`
+prefix is written and read off. It does not reach `restoreSession`, and a
+session document obtained from `hic.toJSON()` does not carry one — which is also
+why `decode(encode(session)) === session` stays a strict identity.
+
+Only the `session=` parameter carries a version. The braced legacy forms are
+query strings with nowhere to put one, and nothing has written either in years.
+
+**What this buys today: nothing.** There is one version, and every session in
+the wild predates it. Its whole value is to whoever changes the format next, who
+would otherwise have to detect the change structurally — by sniffing — which is
+the position this format was in until #508.
 
 ### The one form juicebox writes
 

--- a/js/sessionCodec.js
+++ b/js/sessionCodec.js
@@ -39,6 +39,11 @@
  * accepted formats are **decode-only** by decision, not by omission: ADR-0006
  * decision 4. `session.compressedSession()` is the one caller.
  *
+ * Every session written here carries a version stamp and no session read here
+ * requires one — see {@link SESSION_VERSION} for what that buys and what it
+ * costs. It does not weaken the identity below, because the stamp belongs to the
+ * format rather than to the document and is taken off on the way in.
+ *
  * The identity is not total, and both places it is not are asserted by that
  * suite rather than left to be discovered: browser *count* does not survive a
  * session saved with an empty panel (decision 6), and `fixDefaults` below —
@@ -108,6 +113,32 @@ export const SessionFormat = {
     DATA_URI: 'data-uri',
     JSON: 'json',
 }
+
+/**
+ * The version stamped on every session juicebox writes, and the only one it
+ * reads. ADR-0006 decision 7, #508.
+ *
+ * **A session that carries no version is v1.** Not a fallback and not a degraded
+ * path — the rule, and it has to be, because every session ever saved predates
+ * the field: links pasted into mail and papers years ago, session files on disk,
+ * the corpus in `test/data/wireFormatCorpus.js`. Requiring the field would break
+ * the entire archive to gain a check on nothing.
+ *
+ * **It buys nothing now.** There is one version and one reader of it. Its whole
+ * value is to whoever changes the format next, who would otherwise have to
+ * detect structurally what a discriminator states outright — which is exactly
+ * the position this format was in until #508.
+ *
+ * The version belongs to the **wire format**, not to the session document:
+ * {@link encodeSession} writes it and {@link takeSessionVersion} takes it off,
+ * the same way the `blob:` prefix is written and read off. Nothing downstream of
+ * {@link decodeSession} sees it, which is what keeps `decode(encode(x)) === x` a
+ * strict identity rather than an identity with an exception.
+ *
+ * @see docs/url.md — "Version", where the rule is specified rather than
+ *   described, since the format is a contract with users
+ */
+export const SESSION_VERSION = 1
 
 const COMPRESSED_PREFIXES = {
     'blob:': SessionFormat.BLOB,
@@ -238,9 +269,16 @@ export class SessionEncodeError extends Error {
  * `format` argument here would be a live encoder for a spelling nothing emits,
  * which is the same trade ADR-0006 decision 4 refuses at the format level.
  *
+ * **No version stamp here.** The stamp goes on in {@link encodeSession}, one
+ * layer up, because that is the layer its reader sits in: the `session=` adapter
+ * consumes it. Keeping both halves at the same layer is what makes this function
+ * and {@link decodeSessionString} exact inverses — this one compresses a
+ * document, that one parses one back, and neither has an opinion about what is
+ * in it.
+ *
  * @param {object} session - a session document, as `registry.toJSON()` writes
- *   one. A `State` instance in it encodes as the object `State.toJSON()` writes,
- *   because that is what `JSON.stringify` does with it.
+ *   one — a plain object. A `State` instance *in* it encodes as the object
+ *   `State.toJSON()` writes, because that is what `JSON.stringify` does with it.
  * @returns {string}
  * @throws {SessionEncodeError} if the document is one JSON cannot express
  */
@@ -272,12 +310,22 @@ export function encodeSessionString(session) {
  * of the round trip — the splitter reads a value only as far as its second `=` —
  * and `test/testSessionRoundTrip.js` asserts it.
  *
+ * **The version is stamped here**, and here only: this is the one place juicebox
+ * writes the `session=` format, and the inverse of the one place that reads a
+ * version off it ({@link SESSION_VERSION}, #508). The caller's document is not
+ * touched — the stamp goes into the copy that is serialized — and a `version`
+ * already on the document is overwritten rather than honoured, because what
+ * juicebox writes is what juicebox writes.
+ *
+ * A session is a plain document here, as `registry.toJSON()` writes one; a
+ * top-level `toJSON()` method on the object itself is not consulted.
+ *
  * @param {object} session
  * @returns {string}
  * @throws {SessionEncodeError}
  */
 export function encodeSession(session) {
-    return `session=${encodeSessionString(session)}`
+    return `session=${encodeSessionString({...session, version: SESSION_VERSION})}`
 }
 
 /**
@@ -597,6 +645,49 @@ function parseFailure(origin, e) {
 }
 
 /**
+ * Take the version off a decoded session document — the read half of
+ * {@link SESSION_VERSION}, and the inverse of the stamp {@link encodeSession}
+ * writes.
+ *
+ * Three rules:
+ *
+ * 1. **No version means v1**, so the document is returned exactly as it arrived,
+ *    with nothing logged. This is the common case forever, not a fallback.
+ * 2. **{@link SESSION_VERSION} is accepted and consumed** — taken off rather
+ *    than passed on, because a version describes the wire format and not the
+ *    session.
+ * 3. **Anything else is refused, by name.** A session from a future juicebox may
+ *    spell fields this reader would misread, so half-decoding it into a view the
+ *    user never saved is worse than saying what happened. Quoting the version
+ *    lets a bug report say which juicebox wrote the link.
+ *
+ * Only the `session=` adapter calls this: the braced legacy forms are query
+ * strings with nowhere to put a version, and nothing has written one in years.
+ * A copy comes back rather than a mutated argument, which is the same courtesy
+ * the encoder extends to its caller's document.
+ *
+ * @param {object} session - a decoded session document
+ * @returns {object} the document, without its version field
+ * @throws {SessionDecodeError} if the version is one this juicebox cannot read
+ */
+function takeSessionVersion(session) {
+
+    if (null === session || typeof session !== 'object' || !Object.hasOwn(session, 'version')) {
+        return session
+    }
+
+    const {version, ...document} = session
+
+    if (SESSION_VERSION !== version) {
+        throw new SessionDecodeError(
+            `Session was written in wire format version ${JSON.stringify(version)}, and this ` +
+            `juicebox reads version ${SESSION_VERSION}. Update juicebox to open it. See docs/url.md.`)
+    }
+
+    return document
+}
+
+/**
  * @typedef {object} DecodeContext
  * @property {object} query - the query parameters, as `extractQuery` read them.
  *   Context rather than an argument because an adapter may rewrite it for the
@@ -680,6 +771,17 @@ export const WIRE_FORMATS = [
                     console.error("Error loading session from URL/file:", e);
                     throw new Error(`Failed to load session from URL/file: ${e.message}`);
                 }
+            }
+
+            // Outside the arms on purpose, and after all three. Outside, because
+            // each arm rewraps what it catches -- the URL arm's wrapper reads
+            // `cause.message`, which a version refusal does not have, so a check
+            // inside would report `undefined` to the user (#521). After, because
+            // the version is a property of the document, not of where it was
+            // read from: a session named by a URL is version-checked exactly as
+            // one carried in the parameter.
+            if (ctx.config) {
+                ctx.config = takeSessionVersion(ctx.config)
             }
         },
     },

--- a/test/testRegistrySession.js
+++ b/test/testRegistrySession.js
@@ -6,6 +6,7 @@ import HICBrowser from '../js/hicBrowser.js'
 import {withContainers} from './utils/browserFixture.js'
 import {withStubbedLoads} from './utils/stubbedLoads.js'
 import {BGZip} from 'igv-utils'
+import {SESSION_VERSION} from '../js/sessionCodec.js'
 
 /**
  * A session belongs to one embed -- #482, decision 5 of ADR-0004.
@@ -179,6 +180,13 @@ describe('exported toJSON', () => {
         expect(toJSON().caption).toBe('a figure legend')
     })
 
+    /**
+     * The share link carries the document `toJSON()` returns, plus the wire
+     * format's version stamp — which the encoder adds and the decoder consumes,
+     * so it is present here and absent from `toJSON()` itself (#508, ADR-0006
+     * decision 7). `test/testSessionRoundTrip.js` owns the stamp; this asserts
+     * that nothing else differs between what a host reads and what it shares.
+     */
     it('compresses the same document it returns', () => {
         const registry = registryForContainer(dom.container)
         registry.add(fakeBrowser('a', registry))
@@ -188,7 +196,7 @@ describe('exported toJSON', () => {
 
         expect(compressed.startsWith('session=blob:')).toBe(true)
         expect(JSON.parse(BGZip.uncompressString(compressed.slice('session=blob:'.length))))
-            .toEqual({browsers: [{name: 'a'}], selectedGene: 'ace'})
+            .toEqual({browsers: [{name: 'a'}], selectedGene: 'ace', version: SESSION_VERSION})
     })
 })
 

--- a/test/testSessionDecode.js
+++ b/test/testSessionDecode.js
@@ -30,7 +30,13 @@
  */
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import {BGZip} from 'igv-utils'
-import {SessionDecodeError, WIRE_FORMATS, decodeSession} from '../js/sessionCodec.js'
+import {
+    SESSION_VERSION,
+    SessionDecodeError,
+    WIRE_FORMATS,
+    decodeSession,
+    encodeSession,
+} from '../js/sessionCodec.js'
 import State from '../js/hicState.js'
 
 /**
@@ -201,6 +207,100 @@ describe('decodeSession — the retired bit.ly form', () => {
         await expect(decodeSession(
             '?juiceboxURL=http://bit.ly/2C1VSHy&hicUrl=https://example.org/one.hic', noIO))
             .rejects.toThrow(SessionDecodeError)
+    })
+})
+
+/**
+ * The read half of the version stamp — `js/sessionCodec.js` `SESSION_VERSION`
+ * carries what it is for. #508, ADR-0006 decision 7.
+ *
+ * Since the field buys nothing today, what is asserted here is mostly what it
+ * does *not* do: it is never required, its absence is not a degraded path, and a
+ * session that carries it decodes to the same document as one that does not.
+ * The write half, and the strict identity that depends on the field being taken
+ * back off, are `test/testSessionRoundTrip.js`'s.
+ */
+describe('decodeSession — the version stamp', () => {
+
+    test('a session with no version field decodes as v1, unremarked', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        const config = await decodeSession(`?session=blob:${compress(oneBrowserSession)}`, noIO)
+
+        expect(config).toEqual(oneBrowserSession)
+        expect(warn).not.toHaveBeenCalled()
+        expect(error).not.toHaveBeenCalled()
+    })
+
+    test('the version juicebox writes decodes to the same document, field consumed', async () => {
+        const stamped = {...oneBrowserSession, version: SESSION_VERSION}
+
+        expect(await decodeSession(`?session=blob:${compress(stamped)}`, noIO))
+            .toEqual(oneBrowserSession)
+    })
+
+    test('what juicebox itself writes decodes, which is the round trip in one line', async () => {
+        expect(await decodeSession(encodeSession(oneBrowserSession), noIO))
+            .toEqual(oneBrowserSession)
+    })
+
+    test('an unknown version is refused, and the message names it', async () => {
+        const future = {...oneBrowserSession, version: 2}
+
+        await expect(decodeSession(`?session=blob:${compress(future)}`, noIO))
+            .rejects.toThrow(SessionDecodeError)
+        await expect(decodeSession(`?session=blob:${compress(future)}`, noIO))
+            .rejects.toThrow(/version 2/)
+    })
+
+    /**
+     * Refused *before* anything is read out of it, which is the difference
+     * between a session that fails and one that half-decodes into a view the
+     * user did not save.
+     */
+    test('and nothing of it is decoded', async () => {
+        const future = {browsers: [{url: 'https://example.org/one.hic'}], version: 2, selectedGene: 'MYC'}
+
+        await expect(decodeSession(`?session=blob:${compress(future)}`, noIO))
+            .rejects.toThrow(SessionDecodeError)
+    })
+
+    /**
+     * A version is a version whichever arm carried the document. The URL arm is
+     * the one that wraps what it catches (#521), so it is the arm where a
+     * message can be lost on the way out.
+     */
+    test('a fetched session is version-checked too, and the version survives the report', async () => {
+        await expect(decodeSession('?session=https://example.org/session.json', {
+            ...noIO,
+            loadString: async () => JSON.stringify({...oneBrowserSession, version: 7}),
+        })).rejects.toThrow(/version 7/)
+    })
+
+    /**
+     * The version is a number, and a string spelling of it is a different
+     * format — one nothing here wrote. Refusing it is the same call as refusing
+     * version 2: this reader does not know what wrote the document, so it does
+     * not guess. The message quotes the value, so the two cases are told apart
+     * in a bug report.
+     */
+    test('a version that is not the number 1 is unknown, however it is spelled', async () => {
+        await expect(decodeSession(`?session=blob:${compress({...oneBrowserSession, version: '1'})}`, noIO))
+            .rejects.toThrow(/version "1"/)
+    })
+
+    /**
+     * The legacy forms carry no version and are not made to. `?juicebox=` is a
+     * braced query string per browser; a `version` token in one would decode to
+     * nothing, exactly as any other unrecognised parameter does.
+     */
+    test('the braced legacy form is untouched by any of this', async () => {
+        const input = '?juicebox={hicUrl%3Dhttps%3A%2F%2Fexample.org%2Fone.hic%26version%3D2}'
+        const config = await decodeSession(input, noIO)
+
+        expect(config.browsers[0].url).toBe('https://example.org/one.hic')
+        expect(config.browsers[0].version).toBeUndefined()
     })
 })
 

--- a/test/testSessionRoundTrip.js
+++ b/test/testSessionRoundTrip.js
@@ -39,6 +39,7 @@ import {BGZip} from 'igv-utils'
 import * as codec from '../js/sessionCodec.js'
 import {
     DEFAULT_ANNOTATION_COLOR,
+    SESSION_VERSION,
     SessionEncodeError,
     decodeSession,
     encodeSession,
@@ -204,7 +205,50 @@ describe('encodeSession', () => {
 
         expect(encoded.startsWith('session=blob:')).toBe(true)
         expect(BGZip.uncompressString(encoded.substring('session=blob:'.length)))
-            .toBe(JSON.stringify(session))
+            .toBe(JSON.stringify({...session, version: SESSION_VERSION}))
+    })
+
+    /**
+     * The write half of the version stamp (#508, ADR-0006 decision 7);
+     * `testSessionDecode.js` owns the read half, and `SESSION_VERSION`'s own doc
+     * comment owns why the field exists at all.
+     *
+     * It does not appear in the property below because the decoder takes it back
+     * off, which is what keeps that property a strict identity rather than
+     * "equal apart from one field" — the same weakening ADR-0006 rejected for
+     * axis ordering.
+     */
+    describe('the version stamp', () => {
+
+        const written = encoded => JSON.parse(BGZip.uncompressString(encoded.substring('session=blob:'.length)))
+
+        test('every session juicebox writes carries the version', () => {
+            expect(written(encodeSession(session))).toEqual({...session, version: SESSION_VERSION})
+        })
+
+        test('over one the caller handed it — what juicebox writes is what juicebox writes', () => {
+            expect(written(encodeSession({...session, version: 0})).version).toBe(SESSION_VERSION)
+        })
+
+        test('and the caller\'s own document is not touched', () => {
+            const document = {browsers: []}
+            encodeSession(document)
+
+            expect(Object.hasOwn(document, 'version')).toBe(false)
+        })
+
+        /**
+         * The stamp sits at the parameter layer, beside the adapter that reads
+         * it, so that the two string-level functions stay exact inverses of each
+         * other with no opinion about what is in the document. A host reaching
+         * for `encodeSessionString` gets a compressor, not a writer of the
+         * format.
+         */
+        test('the string encoder stamps nothing — the two layers do not overlap', () => {
+            const string = encodeSessionString(session)
+
+            expect(JSON.parse(BGZip.uncompressString(string.substring('blob:'.length)))).toEqual(session)
+        })
     })
 
     /**
@@ -224,8 +268,14 @@ describe('encodeSession', () => {
         }
     })
 
+    /**
+     * The parameter is the string with a name in front — and, since #508, the
+     * version stamp: the string encoder compresses a document, and the parameter
+     * encoder is the one that writes the format.
+     */
     test('a session string is the payload without the parameter name', () => {
-        expect(encodeSession(session)).toBe(`session=${encodeSessionString(session)}`)
+        expect(encodeSession(session))
+            .toBe(`session=${encodeSessionString({...session, version: SESSION_VERSION})}`)
     })
 
     /**


### PR DESCRIPTION
Closes #508. ADR-0006 decision 7, candidate 5.

`encodeSession` stamps `version: 1` on every session juicebox writes; the `session=` adapter reads it and takes it back off.

**The rule that matters is the read one: a session with no version field is v1**, returned verbatim, with nothing logged and no degraded path. Every session ever saved lacks the field — links pasted into mail and papers, session files on disk, the whole fixture corpus — so requiring it would break the archive to gain a check on nothing. A session naming any *other* version is refused with a message quoting it, rather than half-decoding into a view the user never saved.

**This buys nothing today, which is the point.** Its value is to whoever changes the format next and would otherwise have to detect the change structurally — the position this format was in until now.

## Two layering calls

- **The stamp sits at the parameter layer** (`encodeSession`), not the string layer (`encodeSessionString`), so that `encodeSessionString`/`decodeSessionString` stay exact inverses with no opinion about the document, and the write and read halves live at the same layer as each other.
- **The check runs after the `session=` adapter's three arms**, not inside `decodeSessionString`. Each arm rewraps what it catches, and the URL arm's wrapper reads `cause.message` (#521) — a check inside would have reported `undefined` where the version belongs.

Because the version is taken back off, it never reaches `restoreSession`, and `decode(encode(x)) === x` stays a **strict** identity rather than acquiring an exception — the same weakening ADR-0006 rejected for axis ordering.

## Scope, stated

Only the `session=` wire format carries a version. `hic.toJSON()` output does not, and a document handed straight to `restoreSession` is not version-checked: the version describes the format, not the session. Consequence: a session *file* written by a future v2 juicebox would reach `restoreSession` unchecked. Putting the field on the document instead is a different decision from decision 7 and would cost the strict identity.

## Hosts, confirmed by reading rather than asserted

- **juicebox-web** — `initializationHelper.js:416` hands the parsed config straight to `hic.restoreSession`; `:420` saves `hic.toJSON()`, which carries no version.
- **Spacewalk** — `sessionBootstrapper.js:36` decompresses and `JSON.parse`s the blob, then reads named fields only.
- **An older juicebox** reading a stamped link: `registry.restoreSession` reads `browsers`, `selectedGene`, `syncDatasets` by name and ignores the rest.

## Tests

Full suite green: **727 passed, 37 files**. The golden decoder snapshots did not move, which is the evidence that nothing changed for links already in the wild.

- `test/testSessionDecode.js` — the read half: absence is unremarked (asserted with `console.warn`/`console.error` spies), the stamp decodes to the same document, an unknown version is refused by name on both the `blob:` and fetched-document paths, and the braced legacy forms are untouched.
- `test/testSessionRoundTrip.js` — the write half, and that the string encoder stamps nothing.
- `test/testRegistrySession.js` — the share link is the document `toJSON()` returns plus the stamp, and nothing else.

## Docs

`docs/url.md` gains a **Version** section under Session forms, beside the version definitions, plus a pointer from the v0/v1 paragraph at the top. `CONTEXT.md`'s wire-format entry gains a short paragraph, including why session JSON begins at 1 on the same v0/v1 sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)