### PR TITLE
Gate candidate 9: snapshot the resolved config every entry path produces (#531)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -170,6 +170,19 @@ applying defaults, expanding URL shortcuts, reconciling a selected gene — and 
 reached by every entry path, including a session handed straight to
 `restoreSession`. Format knowledge never crosses into normalize.
 
+**Entry path** — one of the four doors a config comes in by: `hic.init`,
+`hic.restoreSession`, `createBrowser` and `createBrowserList`. All four accept a
+single browser config, since `createBrowserList` reads `session.browsers ||
+[session]`; the query/URL form reaches `HICBrowser` through `init`.
+
+**Resolved config** — a browser config *after* every normalizer upstream of
+`HICBrowser` has had it, which is the object `browser.config` then holds. Not a
+copy: every normalizer rewrites the host's own object in place, so the host's
+config and the browser's are one object. It is an observable surface, because
+juicebox-web reads `browser.config` back (ADR-0003). Which normalizers a config
+meets depends on its entry path, and today they disagree — `test/testConfigGolden.js`
+pins the disagreements (#531, candidate 9).
+
 **Dispose** vs **reset** vs **clear dataset** — the three teardown verbs, in
 descending order of how much they destroy. See `docs/adr/0005`.
 

--- a/docs/juicebox-punch-list.md
+++ b/docs/juicebox-punch-list.md
@@ -61,7 +61,7 @@ Each card carries a Consumer impact block; read it before filing anything.
 
 | Candidate | Status |
 |---|---|
-| **9 · Give the config schema one reader** | **next up** — seam already drawn by ADR-0006 decision 8; may not need its own ADR |
+| **9 · Give the config schema one reader** | **filed — #531–#536**, frontier is #531. Seam already drawn by ADR-0006 decision 8; no ADR opened |
 | **11 · Give the track tile one owner** | ⚠️ breaking |
 | **6 · Fold StateManager into State, and make restore use the chokepoint** | watch |
 | **7 · Move the gesture state machines behind InteractionHandler** | watch |
@@ -76,11 +76,39 @@ entirely. One `normalizeSession` stage that *both* entry paths pass through make
 copies deletable. That deletion was held back from 5 on purpose: both at once doubles the blast
 radius on `hic.init`, the most-used public surface.
 
-So the hard question — where the seam goes and why — is answered. The one genuinely open piece is
+So the hard question — where the seam goes and why — is answered. The one genuinely open piece was
 **whether normalizing at both entry points changes what `restoreSession` accepts**, and that is
-consumer-facing, so it may still be worth an ADR (ADR-0007 is claimed by #477; **ADR-0008 is the
-next free number**). Decide that first; if the answer is "no change", this is `/to-tickets` against
-decision 8 rather than a fresh ADR.
+consumer-facing, so it might have been worth an ADR.
+
+**Decided: no ADR.** The answer is "no change to what is *accepted*" — normalize **defaults and
+coerces, never rejects**, which is an acceptance criterion on every ticket that could violate it.
+What *does* change is what `restoreSession` *produces*, and only for the three divergences #533
+closes deliberately. That is `/to-tickets` against decision 8, not a fresh ADR. ADR-0008 stays the
+next free number.
+
+**Filed as six tickets, gate first** — the shape candidate 5 proved:
+
+| # | Ticket | Blocked by |
+|---|---|---|
+| #531 | Gate: snapshot the resolved config every entry path produces today | — **frontier** |
+| #532 | Extract `normalizeSession`: a pure, session-shaped normalize stage | #531 |
+| #533 | Move the remaining normalization across the seam | #532 |
+| #534 | Delete the duplicate URL-shortcut expansion | #533 |
+| #535 | Normalize once, at the entry | #533 |
+| #536 | Downstream readers stop defaulting, and the schema is written down | #535 |
+
+#534 and #535 run in parallel after #533. **#533 is the only ticket that deliberately moves
+snapshots** — it closes three divergences at once: track defaults skipped by `restoreSession`, the
+`selectedGene` reconciliation, and `syncDatasets` honoured by `createBrowserList` but not
+`createBrowser`. Blocking edges are GitHub-native, so the frontier is queryable rather than read
+off this table.
+
+**Two card corrections found while decomposing**, both from candidate 5 landing — recorded here and
+in #466 rather than on the frozen card: `normalizeConfig` **already exists** in `createBrowser.js`
+(browser-shaped, unexported, called once per browser), so #532 deepens it rather than inventing it,
+and the new stage is named `normalizeSession` to avoid the collision. `fixDefaults` now lives in
+`sessionCodec.js`, not `urlUtils.js`. The card also lists `js/browserUIManager.js`, which candidate
+3 deleted.
 
 **9 inherits the gate 5 had to build.** The golden-file snapshot over the wire-format corpus is
 green and covers every accepted format; normalization changes are exactly the kind that move
@@ -118,7 +146,7 @@ session before any ticket existed.
 **Skill:** `/to-tickets` when you pick one up. Full routing rules, and the reason to file tickets
 *before* the blocker clears, are in `docs/agents/triage-labels.md`. **ADR-0005 went to candidate 8
 and ADR-0006 to candidate 5. ADR-0007 is claimed by #477, so ADR-0008 is the next free number** —
-and candidate 9 may not need one, per above.
+and candidate 9 does not need one, per above.
 
 When a candidate lands: tick it in [#466](https://github.com/aidenlab/juicebox.js/issues/466) and
 add an Outcome box to its card. That is the only time either file is touched.

--- a/test/__snapshots__/testConfigGolden.js.snap
+++ b/test/__snapshots__/testConfigGolden.js.snap
@@ -1,0 +1,5330 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`resolved config golden file — one browser config, through every entry path > background-color-as-a-string 1`] = `
+{
+  "createBrowser(container, config)": {
+    "atConstruction": [
+      {
+        "backgroundColor": {
+          "b": 255,
+          "g": 255,
+          "r": 255,
+        },
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "backgroundColor": {
+            "b": 255,
+            "g": 255,
+            "r": 255,
+          },
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "createBrowserList(container, session)": {
+    "atConstruction": [
+      {
+        "backgroundColor": {
+          "b": 255,
+          "g": 255,
+          "r": 255,
+        },
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "backgroundColor": {
+            "b": 255,
+            "g": 255,
+            "r": 255,
+          },
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.init(container, config)": {
+    "atConstruction": [
+      {
+        "backgroundColor": {
+          "b": 255,
+          "g": 255,
+          "r": 255,
+        },
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "backgroundColor": {
+            "b": 255,
+            "g": 255,
+            "r": 255,
+          },
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.restoreSession(container, session)": {
+    "atConstruction": [
+      {
+        "backgroundColor": {
+          "b": 255,
+          "g": 255,
+          "r": 255,
+        },
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "backgroundColor": {
+            "b": 255,
+            "g": 255,
+            "r": 255,
+          },
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — one browser config, through every entry path > color-scale-as-a-string 1`] = `
+{
+  "createBrowser(container, config)": {
+    "atConstruction": [
+      {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 0.05,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 100,
+        },
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "colorScale": {
+            "__class": "ColorScale",
+            "b": 0,
+            "binsize": 0.05,
+            "cache": [],
+            "g": 0,
+            "nbins": 2000,
+            "r": 255,
+            "threshold": 100,
+          },
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "createBrowserList(container, session)": {
+    "atConstruction": [
+      {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 0.05,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 100,
+        },
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "colorScale": {
+            "__class": "ColorScale",
+            "b": 0,
+            "binsize": 0.05,
+            "cache": [],
+            "g": 0,
+            "nbins": 2000,
+            "r": 255,
+            "threshold": 100,
+          },
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.init(container, config)": {
+    "atConstruction": [
+      {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 0.05,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 100,
+        },
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "colorScale": {
+            "__class": "ColorScale",
+            "b": 0,
+            "binsize": 0.05,
+            "cache": [],
+            "g": 0,
+            "nbins": 2000,
+            "r": 255,
+            "threshold": 100,
+          },
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.restoreSession(container, session)": {
+    "atConstruction": [
+      {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 0.05,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 100,
+        },
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "colorScale": {
+            "__class": "ColorScale",
+            "b": 0,
+            "binsize": 0.05,
+            "cache": [],
+            "g": 0,
+            "nbins": 2000,
+            "r": 255,
+            "threshold": 100,
+          },
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — one browser config, through every entry path > display-flags-set-explicitly-false 1`] = `
+{
+  "createBrowser(container, config)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": false,
+        "showHicContactMapLabel": false,
+        "showLocusGoto": false,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": false,
+          "showHicContactMapLabel": false,
+          "showLocusGoto": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "createBrowserList(container, session)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": false,
+        "showHicContactMapLabel": false,
+        "showLocusGoto": false,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": false,
+          "showHicContactMapLabel": false,
+          "showLocusGoto": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.init(container, config)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": false,
+        "showHicContactMapLabel": false,
+        "showLocusGoto": false,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": false,
+          "showHicContactMapLabel": false,
+          "showLocusGoto": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.restoreSession(container, session)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": false,
+        "showHicContactMapLabel": false,
+        "showLocusGoto": false,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": false,
+          "showHicContactMapLabel": false,
+          "showLocusGoto": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — one browser config, through every entry path > empty-config 1`] = `
+{
+  "createBrowser(container, config)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "createBrowserList(container, session)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.init(container, config)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.restoreSession(container, session)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — one browser config, through every entry path > figure-mode 1`] = `
+{
+  "createBrowser(container, config)": {
+    "atConstruction": [
+      {
+        "figureMode": true,
+        "showChromosomeSelector": false,
+        "showHicContactMapLabel": false,
+        "showLocusGoto": false,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "figureMode": true,
+          "showChromosomeSelector": false,
+          "showHicContactMapLabel": false,
+          "showLocusGoto": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": true,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "createBrowserList(container, session)": {
+    "atConstruction": [
+      {
+        "figureMode": true,
+        "showChromosomeSelector": false,
+        "showHicContactMapLabel": false,
+        "showLocusGoto": false,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "figureMode": true,
+          "showChromosomeSelector": false,
+          "showHicContactMapLabel": false,
+          "showLocusGoto": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": true,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.init(container, config)": {
+    "atConstruction": [
+      {
+        "figureMode": true,
+        "showChromosomeSelector": false,
+        "showHicContactMapLabel": false,
+        "showLocusGoto": false,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "figureMode": true,
+          "showChromosomeSelector": false,
+          "showHicContactMapLabel": false,
+          "showLocusGoto": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": true,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.restoreSession(container, session)": {
+    "atConstruction": [
+      {
+        "figureMode": true,
+        "showChromosomeSelector": false,
+        "showHicContactMapLabel": false,
+        "showLocusGoto": false,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "figureMode": true,
+          "showChromosomeSelector": false,
+          "showHicContactMapLabel": false,
+          "showLocusGoto": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": true,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — one browser config, through every entry path > host-shaped-full-config 1`] = `
+{
+  "createBrowser(container, config)": {
+    "atConstruction": [
+      {
+        "controlName": "Control",
+        "controlUrl": "https://example.com/control.hic",
+        "name": "A",
+        "nvi": "2851728310,36479",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": 0,
+          "y": 0,
+          "zoom": 4,
+        },
+        "tracks": [
+          {
+            "name": "genes",
+            "url": "https://example.com/genes.bed",
+          },
+        ],
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "controlName": "Control",
+          "controlUrl": "https://example.com/control.hic",
+          "name": "A",
+          "nvi": "2851728310,36479",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "state": {
+            "chr1": 1,
+            "chr2": 1,
+            "normalization": "NONE",
+            "pixelSize": 1,
+            "x": 0,
+            "y": 0,
+            "zoom": 4,
+          },
+          "tracks": [
+            {
+              "name": "genes",
+              "url": "https://example.com/genes.bed",
+            },
+          ],
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "createBrowserList(container, session)": {
+    "atConstruction": [
+      {
+        "controlName": "Control",
+        "controlUrl": "https://example.com/control.hic",
+        "name": "A",
+        "nvi": "2851728310,36479",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": 0,
+          "y": 0,
+          "zoom": 4,
+        },
+        "tracks": [
+          {
+            "name": "genes",
+            "url": "https://example.com/genes.bed",
+          },
+        ],
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "controlName": "Control",
+          "controlUrl": "https://example.com/control.hic",
+          "name": "A",
+          "nvi": "2851728310,36479",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "state": {
+            "chr1": 1,
+            "chr2": 1,
+            "normalization": "NONE",
+            "pixelSize": 1,
+            "x": 0,
+            "y": 0,
+            "zoom": 4,
+          },
+          "tracks": [
+            {
+              "name": "genes",
+              "url": "https://example.com/genes.bed",
+            },
+          ],
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.init(container, config)": {
+    "atConstruction": [
+      {
+        "controlName": "Control",
+        "controlUrl": "https://example.com/control.hic",
+        "name": "A",
+        "nvi": "2851728310,36479",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": 0,
+          "y": 0,
+          "zoom": 4,
+        },
+        "tracks": [
+          {
+            "name": "genes",
+            "url": "https://example.com/genes.bed",
+          },
+        ],
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "controlName": "Control",
+          "controlUrl": "https://example.com/control.hic",
+          "name": "A",
+          "nvi": "2851728310,36479",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "state": {
+            "chr1": 1,
+            "chr2": 1,
+            "normalization": "NONE",
+            "pixelSize": 1,
+            "x": 0,
+            "y": 0,
+            "zoom": 4,
+          },
+          "tracks": [
+            {
+              "name": "genes",
+              "url": "https://example.com/genes.bed",
+            },
+          ],
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.restoreSession(container, session)": {
+    "atConstruction": [
+      {
+        "controlName": "Control",
+        "controlUrl": "https://example.com/control.hic",
+        "name": "A",
+        "nvi": "2851728310,36479",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": 0,
+          "y": 0,
+          "zoom": 4,
+        },
+        "tracks": [
+          {
+            "name": "genes",
+            "url": "https://example.com/genes.bed",
+          },
+        ],
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "controlName": "Control",
+          "controlUrl": "https://example.com/control.hic",
+          "name": "A",
+          "nvi": "2851728310,36479",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "state": {
+            "chr1": 1,
+            "chr2": 1,
+            "normalization": "NONE",
+            "pixelSize": 1,
+            "x": 0,
+            "y": 0,
+            "zoom": 4,
+          },
+          "tracks": [
+            {
+              "name": "genes",
+              "url": "https://example.com/genes.bed",
+            },
+          ],
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — one browser config, through every entry path > mini-mode-the-legacy-spelling-of-figure-mode 1`] = `
+{
+  "createBrowser(container, config)": {
+    "atConstruction": [
+      {
+        "miniMode": true,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "miniMode": true,
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": true,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "createBrowserList(container, session)": {
+    "atConstruction": [
+      {
+        "miniMode": true,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "miniMode": true,
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": true,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.init(container, config)": {
+    "atConstruction": [
+      {
+        "miniMode": true,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "miniMode": true,
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": true,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.restoreSession(container, session)": {
+    "atConstruction": [
+      {
+        "miniMode": true,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "miniMode": true,
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": true,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — one browser config, through every entry path > syncDatasets-false-on-a-single-browser-config 1`] = `
+{
+  "createBrowser(container, config)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "syncDatasets": false,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "syncDatasets": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "createBrowserList(container, session)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "syncDatasets": false,
+        "synchable": false,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "syncDatasets": false,
+          "synchable": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": false,
+      },
+    ],
+  },
+  "hic.init(container, config)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "syncDatasets": false,
+        "synchable": false,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "syncDatasets": false,
+          "synchable": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": false,
+      },
+    ],
+  },
+  "hic.restoreSession(container, session)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "syncDatasets": false,
+        "synchable": false,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "syncDatasets": false,
+          "synchable": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": false,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — one browser config, through every entry path > synchable-false-on-the-browser-config 1`] = `
+{
+  "createBrowser(container, config)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "synchable": false,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "synchable": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": false,
+      },
+    ],
+  },
+  "createBrowserList(container, session)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "synchable": false,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "synchable": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": false,
+      },
+    ],
+  },
+  "hic.init(container, config)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "synchable": false,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "synchable": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": false,
+      },
+    ],
+  },
+  "hic.restoreSession(container, session)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "synchable": false,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "synchable": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": false,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — one browser config, through every entry path > track-carrying-the-defaults-fixDefaults-strips 1`] = `
+{
+  "createBrowser(container, config)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "color": "rgb(22, 129, 198)",
+            "max": NaN,
+            "min": NaN,
+            "name": "annotations",
+            "url": "https://example.com/annotations.bed",
+          },
+        ],
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "tracks": [
+            {
+              "color": "rgb(22, 129, 198)",
+              "max": NaN,
+              "min": NaN,
+              "name": "annotations",
+              "url": "https://example.com/annotations.bed",
+            },
+          ],
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "createBrowserList(container, session)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "color": "rgb(22, 129, 198)",
+            "max": NaN,
+            "min": NaN,
+            "name": "annotations",
+            "url": "https://example.com/annotations.bed",
+          },
+        ],
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "tracks": [
+            {
+              "color": "rgb(22, 129, 198)",
+              "max": NaN,
+              "min": NaN,
+              "name": "annotations",
+              "url": "https://example.com/annotations.bed",
+            },
+          ],
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.init(container, config)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "color": "rgb(22, 129, 198)",
+            "max": NaN,
+            "min": NaN,
+            "name": "annotations",
+            "url": "https://example.com/annotations.bed",
+          },
+        ],
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "tracks": [
+            {
+              "color": "rgb(22, 129, 198)",
+              "max": NaN,
+              "min": NaN,
+              "name": "annotations",
+              "url": "https://example.com/annotations.bed",
+            },
+          ],
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.restoreSession(container, session)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "color": "rgb(22, 129, 198)",
+            "max": NaN,
+            "min": NaN,
+            "name": "annotations",
+            "url": "https://example.com/annotations.bed",
+          },
+        ],
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "tracks": [
+            {
+              "color": "rgb(22, 129, 198)",
+              "max": NaN,
+              "min": NaN,
+              "name": "annotations",
+              "url": "https://example.com/annotations.bed",
+            },
+          ],
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — one browser config, through every entry path > unknown-field-a-host-invented 1`] = `
+{
+  "createBrowser(container, config)": {
+    "atConstruction": [
+      {
+        "hostPrivateField": {
+          "anything": [
+            1,
+            2,
+            3,
+          ],
+        },
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "hostPrivateField": {
+            "anything": [
+              1,
+              2,
+              3,
+            ],
+          },
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "createBrowserList(container, session)": {
+    "atConstruction": [
+      {
+        "hostPrivateField": {
+          "anything": [
+            1,
+            2,
+            3,
+          ],
+        },
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "hostPrivateField": {
+            "anything": [
+              1,
+              2,
+              3,
+            ],
+          },
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.init(container, config)": {
+    "atConstruction": [
+      {
+        "hostPrivateField": {
+          "anything": [
+            1,
+            2,
+            3,
+          ],
+        },
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "hostPrivateField": {
+            "anything": [
+              1,
+              2,
+              3,
+            ],
+          },
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.restoreSession(container, session)": {
+    "atConstruction": [
+      {
+        "hostPrivateField": {
+          "anything": [
+            1,
+            2,
+            3,
+          ],
+        },
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "hostPrivateField": {
+            "anything": [
+              1,
+              2,
+              3,
+            ],
+          },
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — one browser config, through every entry path > url-shortcuts-in-map-control-and-track 1`] = `
+{
+  "createBrowser(container, config)": {
+    "atConstruction": [
+      {
+        "controlUrl": "*s3e_/wapl_hic/WT.hic",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "name": "encode track",
+            "url": "*enc/ENCFF000ABC.bigWig",
+          },
+        ],
+        "url": "*s3/hiseq/gm12878/in-situ/HIC009.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "controlUrl": "*s3e_/wapl_hic/WT.hic",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "tracks": [
+            {
+              "name": "encode track",
+              "url": "*enc/ENCFF000ABC.bigWig",
+            },
+          ],
+          "url": "*s3/hiseq/gm12878/in-situ/HIC009.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "createBrowserList(container, session)": {
+    "atConstruction": [
+      {
+        "controlUrl": "*s3e_/wapl_hic/WT.hic",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "name": "encode track",
+            "url": "*enc/ENCFF000ABC.bigWig",
+          },
+        ],
+        "url": "*s3/hiseq/gm12878/in-situ/HIC009.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "controlUrl": "*s3e_/wapl_hic/WT.hic",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "tracks": [
+            {
+              "name": "encode track",
+              "url": "*enc/ENCFF000ABC.bigWig",
+            },
+          ],
+          "url": "*s3/hiseq/gm12878/in-situ/HIC009.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.init(container, config)": {
+    "atConstruction": [
+      {
+        "controlUrl": "http://hicfiles.s3.amazonaws.com/external/wapl_hic/WT.hic",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "name": "encode track",
+            "url": "https://www.encodeproject.org/files/ENCFF000ABC.bigWig",
+          },
+        ],
+        "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "controlUrl": "http://hicfiles.s3.amazonaws.com/external/wapl_hic/WT.hic",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "tracks": [
+            {
+              "name": "encode track",
+              "url": "https://www.encodeproject.org/files/ENCFF000ABC.bigWig",
+            },
+          ],
+          "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.restoreSession(container, session)": {
+    "atConstruction": [
+      {
+        "controlUrl": "http://hicfiles.s3.amazonaws.com/external/wapl_hic/WT.hic",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "name": "encode track",
+            "url": "https://www.encodeproject.org/files/ENCFF000ABC.bigWig",
+          },
+        ],
+        "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "controlUrl": "http://hicfiles.s3.amazonaws.com/external/wapl_hic/WT.hic",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "tracks": [
+            {
+              "name": "encode track",
+              "url": "https://www.encodeproject.org/files/ENCFF000ABC.bigWig",
+            },
+          ],
+          "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — session documents, through the session-shaped paths > session-with-per-browser-divergent-flags 1`] = `
+{
+  "createBrowserList(container, session)": {
+    "atConstruction": [
+      {
+        "figureMode": true,
+        "showChromosomeSelector": false,
+        "showHicContactMapLabel": false,
+        "showLocusGoto": false,
+        "url": "https://example.com/a.hic",
+      },
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": false,
+        "url": "https://example.com/b.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "figureMode": true,
+          "showChromosomeSelector": false,
+          "showHicContactMapLabel": false,
+          "showLocusGoto": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": true,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": false,
+          "url": "https://example.com/b.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.init(container, config)": {
+    "atConstruction": [
+      {
+        "figureMode": true,
+        "showChromosomeSelector": false,
+        "showHicContactMapLabel": false,
+        "showLocusGoto": false,
+        "url": "https://example.com/a.hic",
+      },
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": false,
+        "url": "https://example.com/b.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "figureMode": true,
+          "showChromosomeSelector": false,
+          "showHicContactMapLabel": false,
+          "showLocusGoto": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": true,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": false,
+          "url": "https://example.com/b.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.restoreSession(container, session)": {
+    "atConstruction": [
+      {
+        "figureMode": true,
+        "showChromosomeSelector": false,
+        "showHicContactMapLabel": false,
+        "showLocusGoto": false,
+        "url": "https://example.com/a.hic",
+      },
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": false,
+        "url": "https://example.com/b.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "figureMode": true,
+          "showChromosomeSelector": false,
+          "showHicContactMapLabel": false,
+          "showLocusGoto": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": true,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": false,
+          "url": "https://example.com/b.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — session documents, through the session-shaped paths > session-with-syncDatasets-false 1`] = `
+{
+  "createBrowserList(container, session)": {
+    "atConstruction": [
+      {
+        "name": "A",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "synchable": false,
+        "url": "https://example.com/a.hic",
+      },
+      {
+        "name": "B",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "synchable": false,
+        "url": "https://example.com/b.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "name": "A",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "synchable": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": false,
+      },
+      {
+        "config": {
+          "name": "B",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "synchable": false,
+          "url": "https://example.com/b.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": false,
+      },
+    ],
+  },
+  "hic.init(container, config)": {
+    "atConstruction": [
+      {
+        "name": "A",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "synchable": false,
+        "url": "https://example.com/a.hic",
+      },
+      {
+        "name": "B",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "synchable": false,
+        "url": "https://example.com/b.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "name": "A",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "synchable": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": false,
+      },
+      {
+        "config": {
+          "name": "B",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "synchable": false,
+          "url": "https://example.com/b.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": false,
+      },
+    ],
+  },
+  "hic.restoreSession(container, session)": {
+    "atConstruction": [
+      {
+        "name": "A",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "synchable": false,
+        "url": "https://example.com/a.hic",
+      },
+      {
+        "name": "B",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "synchable": false,
+        "url": "https://example.com/b.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "name": "A",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "synchable": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": false,
+      },
+      {
+        "config": {
+          "name": "B",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "synchable": false,
+          "url": "https://example.com/b.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": false,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — session documents, through the session-shaped paths > session-with-url-shortcuts-in-both-browsers 1`] = `
+{
+  "createBrowserList(container, session)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "*s3/hiseq/gm12878/in-situ/HIC009.hic",
+      },
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "url": "*enc/ENCFF000ABC.bigWig",
+          },
+        ],
+        "url": "*s3e/wapl_hic/WT.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "*s3/hiseq/gm12878/in-situ/HIC009.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "tracks": [
+            {
+              "url": "*enc/ENCFF000ABC.bigWig",
+            },
+          ],
+          "url": "*s3e/wapl_hic/WT.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.init(container, config)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+      },
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "url": "https://www.encodeproject.org/files/ENCFF000ABC.bigWig",
+          },
+        ],
+        "url": "https://hicfiles.s3.amazonaws.com/external/wapl_hic/WT.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "tracks": [
+            {
+              "url": "https://www.encodeproject.org/files/ENCFF000ABC.bigWig",
+            },
+          ],
+          "url": "https://hicfiles.s3.amazonaws.com/external/wapl_hic/WT.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.restoreSession(container, session)": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+      },
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "url": "https://www.encodeproject.org/files/ENCFF000ABC.bigWig",
+          },
+        ],
+        "url": "https://hicfiles.s3.amazonaws.com/external/wapl_hic/WT.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "tracks": [
+            {
+              "url": "https://www.encodeproject.org/files/ENCFF000ABC.bigWig",
+            },
+          ],
+          "url": "https://hicfiles.s3.amazonaws.com/external/wapl_hic/WT.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — session documents, through the session-shaped paths > two-browser-session 1`] = `
+{
+  "createBrowserList(container, session)": {
+    "atConstruction": [
+      {
+        "name": "A",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+      {
+        "name": "B",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/b.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "name": "A",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+      {
+        "config": {
+          "name": "B",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/b.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.init(container, config)": {
+    "atConstruction": [
+      {
+        "name": "A",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+      {
+        "name": "B",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/b.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "name": "A",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+      {
+        "config": {
+          "name": "B",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/b.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "hic.restoreSession(container, session)": {
+    "atConstruction": [
+      {
+        "name": "A",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+      {
+        "name": "B",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/b.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "name": "A",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+      {
+        "config": {
+          "name": "B",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/b.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — the Spacewalk sequence, restoring into a live embed > session-with-per-browser-divergent-flags 1`] = `
+{
+  "afterInit": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+      },
+    ],
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": undefined,
+        "synchable": true,
+      },
+    ],
+  },
+  "afterRestore": {
+    "atConstruction": [
+      {
+        "figureMode": true,
+        "showChromosomeSelector": false,
+        "showHicContactMapLabel": false,
+        "showLocusGoto": false,
+        "url": "https://example.com/a.hic",
+      },
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": false,
+        "url": "https://example.com/b.hic",
+      },
+    ],
+    "readBack": [
+      {
+        "config": {
+          "figureMode": true,
+          "showChromosomeSelector": false,
+          "showHicContactMapLabel": false,
+          "showLocusGoto": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": true,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": false,
+          "url": "https://example.com/b.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — the Spacewalk sequence, restoring into a live embed > session-with-syncDatasets-false 1`] = `
+{
+  "afterInit": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+      },
+    ],
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": undefined,
+        "synchable": true,
+      },
+    ],
+  },
+  "afterRestore": {
+    "atConstruction": [
+      {
+        "name": "A",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "synchable": false,
+        "url": "https://example.com/a.hic",
+      },
+      {
+        "name": "B",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "synchable": false,
+        "url": "https://example.com/b.hic",
+      },
+    ],
+    "readBack": [
+      {
+        "config": {
+          "name": "A",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "synchable": false,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": false,
+      },
+      {
+        "config": {
+          "name": "B",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "synchable": false,
+          "url": "https://example.com/b.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": false,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — the Spacewalk sequence, restoring into a live embed > session-with-url-shortcuts-in-both-browsers 1`] = `
+{
+  "afterInit": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+      },
+    ],
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": undefined,
+        "synchable": true,
+      },
+    ],
+  },
+  "afterRestore": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+      },
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "url": "https://www.encodeproject.org/files/ENCFF000ABC.bigWig",
+          },
+        ],
+        "url": "https://hicfiles.s3.amazonaws.com/external/wapl_hic/WT.hic",
+      },
+    ],
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "tracks": [
+            {
+              "url": "https://www.encodeproject.org/files/ENCFF000ABC.bigWig",
+            },
+          ],
+          "url": "https://hicfiles.s3.amazonaws.com/external/wapl_hic/WT.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — the Spacewalk sequence, restoring into a live embed > two-browser-session 1`] = `
+{
+  "afterInit": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+      },
+    ],
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": undefined,
+        "synchable": true,
+      },
+    ],
+  },
+  "afterRestore": {
+    "atConstruction": [
+      {
+        "name": "A",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/a.hic",
+      },
+      {
+        "name": "B",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.com/b.hic",
+      },
+    ],
+    "readBack": [
+      {
+        "config": {
+          "name": "A",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+      {
+        "config": {
+          "name": "B",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://example.com/b.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > harvested-external-state-numeric-normalization 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "__class": "State",
+        "chr1": 1,
+        "chr2": 1,
+        "normalization": "2000",
+        "pixelSize": 8.024052224929061,
+        "x": 0,
+        "y": 0,
+        "zoom": 0,
+      },
+      "url": "http://hicfiles.s3.amazonaws.com/external/li/mcf7-rnapii-saturated.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "__class": "State",
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "2000",
+          "pixelSize": 8.024052224929061,
+          "x": 0,
+          "y": 0,
+          "zoom": 0,
+        },
+        "url": "http://hicfiles.s3.amazonaws.com/external/li/mcf7-rnapii-saturated.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > harvested-juicebox-encoded-braces 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "name": "HFFc6 DpnII",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+    },
+    {
+      "cycle": undefined,
+      "name": "H1-hESC DpnII",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/a0859349-5f06-4ad3-b56f-b1166b34a9eb/4DNFIIMZB6Y9.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "name": "HFFc6 DpnII",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+    {
+      "config": {
+        "cycle": undefined,
+        "name": "H1-hESC DpnII",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/a0859349-5f06-4ad3-b56f-b1166b34a9eb/4DNFIIMZB6Y9.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > harvested-juicebox-literal-braces 1`] = `
+{
+  "atConstruction": [
+    {
+      "colorScale": {
+        "__class": "ColorScale",
+        "b": 0,
+        "binsize": 0.07210918707440236,
+        "cache": [],
+        "g": 0,
+        "nbins": 2000,
+        "r": 255,
+        "threshold": 144.21837414880474,
+      },
+      "cycle": undefined,
+      "name": "ADAC_30.hic",
+      "nvi": "7989194045,18679",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "__class": "State",
+        "chr1": 2,
+        "chr2": 2,
+        "normalization": "KR",
+        "pixelSize": 1.5423280423280423,
+        "x": 1896.1562537317725,
+        "y": 1916.657181523778,
+        "zoom": 6,
+      },
+      "tracks": [
+        {
+          "color": "rgb(255,255,0)",
+          "displayMode": "COLLAPSED",
+          "name": "5000_blocks",
+          "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC/inter_30_contact_domains/5000_blocks",
+        },
+        {
+          "color": "rgb(0,36,255)",
+          "displayMode": "COLLAPSED",
+          "name": "merged_loops.bedpe",
+          "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_loops/merged_loops.bedpe",
+        },
+        {
+          "color": "rgb(0,255,36)",
+          "displayMode": "COLLAPSED",
+          "name": "differential_loops1.bedpe",
+          "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_vs_EndoC/differential_loops1.bedpe",
+        },
+      ],
+      "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC/ADAC_30.hic",
+    },
+    {
+      "colorScale": {
+        "__class": "ColorScale",
+        "b": 0,
+        "binsize": 0.07138719710904917,
+        "cache": [],
+        "g": 0,
+        "nbins": 2000,
+        "r": 255,
+        "threshold": 142.77439421809834,
+      },
+      "cycle": undefined,
+      "name": "EndoC_30.hic",
+      "nvi": "6818528104,18679",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "__class": "State",
+        "chr1": 2,
+        "chr2": 2,
+        "normalization": "KR",
+        "pixelSize": 1.5423280423280423,
+        "x": 1896.1562537317725,
+        "y": 1916.657181523778,
+        "zoom": 6,
+      },
+      "tracks": [
+        {
+          "color": "rgb(18,0,255)",
+          "displayMode": "COLLAPSED",
+          "name": "merged_loops.bedpe",
+          "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC_loops/merged_loops.bedpe",
+        },
+        {
+          "color": "rgb(255,255,0)",
+          "displayMode": "COLLAPSED",
+          "name": "5000_blocks",
+          "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC/inter_30_contact_domains/5000_blocks",
+        },
+        {
+          "color": "rgb(18,255,0)",
+          "displayMode": "COLLAPSED",
+          "name": "differential_loops2.bedpe",
+          "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_vs_EndoC/differential_loops2.bedpe",
+        },
+      ],
+      "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC/EndoC_30.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 0.07210918707440236,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 144.21837414880474,
+        },
+        "cycle": undefined,
+        "name": "ADAC_30.hic",
+        "nvi": "7989194045,18679",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "__class": "State",
+          "chr1": 2,
+          "chr2": 2,
+          "normalization": "KR",
+          "pixelSize": 1.5423280423280423,
+          "x": 1896.1562537317725,
+          "y": 1916.657181523778,
+          "zoom": 6,
+        },
+        "tracks": [
+          {
+            "color": "rgb(255,255,0)",
+            "displayMode": "COLLAPSED",
+            "name": "5000_blocks",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC/inter_30_contact_domains/5000_blocks",
+          },
+          {
+            "color": "rgb(0,36,255)",
+            "displayMode": "COLLAPSED",
+            "name": "merged_loops.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_loops/merged_loops.bedpe",
+          },
+          {
+            "color": "rgb(0,255,36)",
+            "displayMode": "COLLAPSED",
+            "name": "differential_loops1.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_vs_EndoC/differential_loops1.bedpe",
+          },
+        ],
+        "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC/ADAC_30.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+    {
+      "config": {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 0.07138719710904917,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 142.77439421809834,
+        },
+        "cycle": undefined,
+        "name": "EndoC_30.hic",
+        "nvi": "6818528104,18679",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "__class": "State",
+          "chr1": 2,
+          "chr2": 2,
+          "normalization": "KR",
+          "pixelSize": 1.5423280423280423,
+          "x": 1896.1562537317725,
+          "y": 1916.657181523778,
+          "zoom": 6,
+        },
+        "tracks": [
+          {
+            "color": "rgb(18,0,255)",
+            "displayMode": "COLLAPSED",
+            "name": "merged_loops.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC_loops/merged_loops.bedpe",
+          },
+          {
+            "color": "rgb(255,255,0)",
+            "displayMode": "COLLAPSED",
+            "name": "5000_blocks",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC/inter_30_contact_domains/5000_blocks",
+          },
+          {
+            "color": "rgb(18,255,0)",
+            "displayMode": "COLLAPSED",
+            "name": "differential_loops2.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_vs_EndoC/differential_loops2.bedpe",
+          },
+        ],
+        "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC/EndoC_30.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > harvested-query-4dn-control-map 1`] = `
+{
+  "atConstruction": [
+    {
+      "controlName": "H1-hESC DpnII",
+      "controlUrl": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/a0859349-5f06-4ad3-b56f-b1166b34a9eb/4DNFIIMZB6Y9.hic",
+      "cycle": undefined,
+      "name": "HFFc6 DpnII",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "controlName": "H1-hESC DpnII",
+        "controlUrl": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/a0859349-5f06-4ad3-b56f-b1166b34a9eb/4DNFIIMZB6Y9.hic",
+        "cycle": undefined,
+        "name": "HFFc6 DpnII",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > harvested-query-4dn-state-colorscale-track 1`] = `
+{
+  "atConstruction": [
+    {
+      "colorScale": {
+        "__class": "ColorScale",
+        "b": 0,
+        "binsize": 0.05,
+        "cache": [],
+        "g": 0,
+        "nbins": 2000,
+        "r": 255,
+        "threshold": 100,
+      },
+      "cycle": undefined,
+      "name": "HFFc6 DpnII",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "__class": "State",
+        "chr1": 1,
+        "chr2": 1,
+        "normalization": "NONE",
+        "pixelSize": 1,
+        "x": 0,
+        "y": 0,
+        "zoom": 4,
+      },
+      "tracks": [
+        {
+          "displayMode": "COLLAPSED",
+          "name": "RefSeq genes",
+          "url": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/refGene.txt.gz",
+        },
+      ],
+      "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 0.05,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 100,
+        },
+        "cycle": undefined,
+        "name": "HFFc6 DpnII",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "__class": "State",
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": 0,
+          "y": 0,
+          "zoom": 4,
+        },
+        "tracks": [
+          {
+            "displayMode": "COLLAPSED",
+            "name": "RefSeq genes",
+            "url": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/refGene.txt.gz",
+          },
+        ],
+        "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > harvested-query-degron-fully-encoded 1`] = `
+{
+  "atConstruction": [
+    {
+      "colorScale": {
+        "__class": "ColorScale",
+        "b": undefined,
+        "binsize": 0.036,
+        "cache": [],
+        "g": undefined,
+        "nbins": 2000,
+        "r": undefined,
+        "threshold": 72,
+      },
+      "cycle": undefined,
+      "name": "Rao et al. | Biorxiv 2017 Combined Untreated",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "__class": "State",
+        "chr1": 3,
+        "chr2": 3,
+        "normalization": "KR",
+        "pixelSize": 1.55,
+        "x": 19215,
+        "y": 19215,
+        "zoom": 7,
+      },
+      "tracks": [
+        {
+          "color": "rgb(0,150,0)",
+          "displayMode": "COLLAPSED",
+          "max": 3,
+          "min": 0,
+          "name": "Untreated H3K36me3",
+          "url": "https://s3.amazonaws.com/hicfiles/hiseq/degron/chipseq_data/untreated/H3K36me3_FE.bw",
+        },
+        {
+          "color": "rgb(0,150,0)",
+          "displayMode": "COLLAPSED",
+          "max": 7,
+          "min": 0,
+          "name": "Untreated H3K4me1",
+          "url": "https://s3.amazonaws.com/hicfiles/hiseq/degron/chipseq_data/untreated/H3K4me1_FE.bw",
+        },
+      ],
+      "url": "https://s3.amazonaws.com/hicfiles/hiseq/degron/untreated/unsynchronized/combined.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": undefined,
+          "binsize": 0.036,
+          "cache": [],
+          "g": undefined,
+          "nbins": 2000,
+          "r": undefined,
+          "threshold": 72,
+        },
+        "cycle": undefined,
+        "name": "Rao et al. | Biorxiv 2017 Combined Untreated",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "__class": "State",
+          "chr1": 3,
+          "chr2": 3,
+          "normalization": "KR",
+          "pixelSize": 1.55,
+          "x": 19215,
+          "y": 19215,
+          "zoom": 7,
+        },
+        "tracks": [
+          {
+            "color": "rgb(0,150,0)",
+            "displayMode": "COLLAPSED",
+            "max": 3,
+            "min": 0,
+            "name": "Untreated H3K36me3",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/degron/chipseq_data/untreated/H3K36me3_FE.bw",
+          },
+          {
+            "color": "rgb(0,150,0)",
+            "displayMode": "COLLAPSED",
+            "max": 7,
+            "min": 0,
+            "name": "Untreated H3K4me1",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/degron/chipseq_data/untreated/H3K4me1_FE.bw",
+          },
+        ],
+        "url": "https://s3.amazonaws.com/hicfiles/hiseq/degron/untreated/unsynchronized/combined.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > harvested-query-dnazoo-no-state 1`] = `
+{
+  "atConstruction": [
+    {
+      "colorScale": {
+        "__class": "ColorScale",
+        "b": 0,
+        "binsize": 9.778,
+        "cache": [],
+        "g": 0,
+        "nbins": 2000,
+        "r": 255,
+        "threshold": 19556,
+      },
+      "cycle": undefined,
+      "name": "Draft assembly",
+      "nvi": "2592278165,834",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "url": "https://dnazoo.s3.amazonaws.com/Ailurus_fulgens/ASM200746v1.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 9.778,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 19556,
+        },
+        "cycle": undefined,
+        "name": "Draft assembly",
+        "nvi": "2592278165,834",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://dnazoo.s3.amazonaws.com/Ailurus_fulgens/ASM200746v1.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > harvested-query-gm12878-nvi 1`] = `
+{
+  "atConstruction": [
+    {
+      "colorScale": {
+        "__class": "ColorScale",
+        "b": undefined,
+        "binsize": 0.0145,
+        "cache": [],
+        "g": undefined,
+        "nbins": 2000,
+        "r": undefined,
+        "threshold": 29,
+      },
+      "cycle": undefined,
+      "name": "Rao and Huntley et al. | Cell 2014 GM12878 (human) in situ MboI HIC009 (95M)",
+      "nvi": "2851728310,36479",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "__class": "State",
+        "chr1": 1,
+        "chr2": 1,
+        "normalization": "NONE",
+        "pixelSize": 1,
+        "x": 1115.253105,
+        "y": 1149.253105,
+        "zoom": 4,
+      },
+      "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": undefined,
+          "binsize": 0.0145,
+          "cache": [],
+          "g": undefined,
+          "nbins": 2000,
+          "r": undefined,
+          "threshold": 29,
+        },
+        "cycle": undefined,
+        "name": "Rao and Huntley et al. | Cell 2014 GM12878 (human) in situ MboI HIC009 (95M)",
+        "nvi": "2851728310,36479",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "__class": "State",
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": 1115.253105,
+          "y": 1149.253105,
+          "zoom": 4,
+        },
+        "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > harvested-query-wapl-ko 1`] = `
+{
+  "atConstruction": [
+    {
+      "colorScale": {
+        "__class": "ColorScale",
+        "b": undefined,
+        "binsize": 0.009448099314069635,
+        "cache": [],
+        "g": undefined,
+        "nbins": 2000,
+        "r": undefined,
+        "threshold": 18.89619862813927,
+      },
+      "cycle": undefined,
+      "name": "Haarhuis et al. | Cell 2017 Hap1 knockout WAPL clone 1",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "__class": "State",
+        "chr1": 3,
+        "chr2": 3,
+        "normalization": "KR",
+        "pixelSize": 1,
+        "x": 5537.98746,
+        "y": 5537.749239047619,
+        "zoom": 6,
+      },
+      "tracks": [
+        {
+          "displayMode": "COLLAPSED",
+          "name": "GM12878_CTCF_orientation.bed",
+          "url": "http://hicfiles.s3.amazonaws.com/external/GM12878_CTCF_orientation.bed",
+        },
+        {
+          "displayMode": "COLLAPSED",
+          "name": "gencode.v18.collapsed.bed.gz",
+          "url": "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/gencode.v18.collapsed.bed.gz",
+        },
+      ],
+      "url": "https://s3.amazonaws.com/hicfiles/external/wapl_hic/WaplKO_1.14.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": undefined,
+          "binsize": 0.009448099314069635,
+          "cache": [],
+          "g": undefined,
+          "nbins": 2000,
+          "r": undefined,
+          "threshold": 18.89619862813927,
+        },
+        "cycle": undefined,
+        "name": "Haarhuis et al. | Cell 2017 Hap1 knockout WAPL clone 1",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "__class": "State",
+          "chr1": 3,
+          "chr2": 3,
+          "normalization": "KR",
+          "pixelSize": 1,
+          "x": 5537.98746,
+          "y": 5537.749239047619,
+          "zoom": 6,
+        },
+        "tracks": [
+          {
+            "displayMode": "COLLAPSED",
+            "name": "GM12878_CTCF_orientation.bed",
+            "url": "http://hicfiles.s3.amazonaws.com/external/GM12878_CTCF_orientation.bed",
+          },
+          {
+            "displayMode": "COLLAPSED",
+            "name": "gencode.v18.collapsed.bed.gz",
+            "url": "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/gencode.v18.collapsed.bed.gz",
+          },
+        ],
+        "url": "https://s3.amazonaws.com/hicfiles/external/wapl_hic/WaplKO_1.14.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > harvested-query-wapl-wt 1`] = `
+{
+  "atConstruction": [
+    {
+      "colorScale": {
+        "__class": "ColorScale",
+        "b": undefined,
+        "binsize": 0.009448099314069635,
+        "cache": [],
+        "g": undefined,
+        "nbins": 2000,
+        "r": undefined,
+        "threshold": 18.89619862813927,
+      },
+      "cycle": undefined,
+      "name": "Haarhuis et al. | Cell 2017 Hap1 control",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "__class": "State",
+        "chr1": 3,
+        "chr2": 3,
+        "normalization": "KR",
+        "pixelSize": 1,
+        "x": 5537.98746,
+        "y": 5537.749239047619,
+        "zoom": 6,
+      },
+      "tracks": [
+        {
+          "displayMode": "COLLAPSED",
+          "name": "GM12878_CTCF_orientation.bed",
+          "url": "http://hicfiles.s3.amazonaws.com/external/GM12878_CTCF_orientation.bed",
+        },
+        {
+          "displayMode": "COLLAPSED",
+          "name": "gencode.v18.collapsed.bed.gz",
+          "url": "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/gencode.v18.collapsed.bed.gz",
+        },
+      ],
+      "url": "https://s3.amazonaws.com/hicfiles/external/wapl_hic/WT.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": undefined,
+          "binsize": 0.009448099314069635,
+          "cache": [],
+          "g": undefined,
+          "nbins": 2000,
+          "r": undefined,
+          "threshold": 18.89619862813927,
+        },
+        "cycle": undefined,
+        "name": "Haarhuis et al. | Cell 2017 Hap1 control",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "__class": "State",
+          "chr1": 3,
+          "chr2": 3,
+          "normalization": "KR",
+          "pixelSize": 1,
+          "x": 5537.98746,
+          "y": 5537.749239047619,
+          "zoom": 6,
+        },
+        "tracks": [
+          {
+            "displayMode": "COLLAPSED",
+            "name": "GM12878_CTCF_orientation.bed",
+            "url": "http://hicfiles.s3.amazonaws.com/external/GM12878_CTCF_orientation.bed",
+          },
+          {
+            "displayMode": "COLLAPSED",
+            "name": "gencode.v18.collapsed.bed.gz",
+            "url": "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/gencode.v18.collapsed.bed.gz",
+          },
+        ],
+        "url": "https://s3.amazonaws.com/hicfiles/external/wapl_hic/WT.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > harvested-session-blob-adac-endoc 1`] = `
+{
+  "atConstruction": [
+    {
+      "colorScale": {
+        "__class": "ColorScale",
+        "b": 0,
+        "binsize": 0.07210918707440236,
+        "cache": [],
+        "g": 0,
+        "nbins": 2000,
+        "r": 255,
+        "threshold": 144.21837414880474,
+      },
+      "name": "ADAC_30.hic",
+      "nvi": "7989194045,18679",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": "2,2,6,1896.1562537317725,1916.657181523778,1.5423280423280423,KR",
+      "tracks": [
+        {
+          "color": "rgb(255,255,0)",
+          "displayMode": "COLLAPSED",
+          "name": "5000_blocks",
+          "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC/inter_30_contact_domains/5000_blocks",
+        },
+        {
+          "color": "rgb(0,36,255)",
+          "displayMode": "COLLAPSED",
+          "name": "merged_loops.bedpe",
+          "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_loops/merged_loops.bedpe",
+        },
+        {
+          "color": "rgb(0,255,36)",
+          "displayMode": "COLLAPSED",
+          "name": "differential_loops1.bedpe",
+          "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_vs_EndoC/differential_loops1.bedpe",
+        },
+      ],
+      "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC/ADAC_30.hic",
+    },
+    {
+      "colorScale": {
+        "__class": "ColorScale",
+        "b": 0,
+        "binsize": 0.07138719710904917,
+        "cache": [],
+        "g": 0,
+        "nbins": 2000,
+        "r": 255,
+        "threshold": 142.77439421809834,
+      },
+      "name": "EndoC_30.hic",
+      "nvi": "6818528104,18679",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": "2,2,6,1896.1562537317725,1916.657181523778,1.5423280423280423,KR",
+      "tracks": [
+        {
+          "color": "rgb(18,0,255)",
+          "displayMode": "COLLAPSED",
+          "name": "merged_loops.bedpe",
+          "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC_loops/merged_loops.bedpe",
+        },
+        {
+          "color": "rgb(255,255,0)",
+          "displayMode": "COLLAPSED",
+          "name": "5000_blocks",
+          "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC/inter_30_contact_domains/5000_blocks",
+        },
+        {
+          "color": "rgb(18,255,0)",
+          "displayMode": "COLLAPSED",
+          "name": "differential_loops2.bedpe",
+          "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_vs_EndoC/differential_loops2.bedpe",
+        },
+      ],
+      "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC/EndoC_30.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 0.07210918707440236,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 144.21837414880474,
+        },
+        "name": "ADAC_30.hic",
+        "nvi": "7989194045,18679",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": "2,2,6,1896.1562537317725,1916.657181523778,1.5423280423280423,KR",
+        "tracks": [
+          {
+            "color": "rgb(255,255,0)",
+            "displayMode": "COLLAPSED",
+            "name": "5000_blocks",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC/inter_30_contact_domains/5000_blocks",
+          },
+          {
+            "color": "rgb(0,36,255)",
+            "displayMode": "COLLAPSED",
+            "name": "merged_loops.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_loops/merged_loops.bedpe",
+          },
+          {
+            "color": "rgb(0,255,36)",
+            "displayMode": "COLLAPSED",
+            "name": "differential_loops1.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_vs_EndoC/differential_loops1.bedpe",
+          },
+        ],
+        "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC/ADAC_30.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+    {
+      "config": {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 0.07138719710904917,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 142.77439421809834,
+        },
+        "name": "EndoC_30.hic",
+        "nvi": "6818528104,18679",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": "2,2,6,1896.1562537317725,1916.657181523778,1.5423280423280423,KR",
+        "tracks": [
+          {
+            "color": "rgb(18,0,255)",
+            "displayMode": "COLLAPSED",
+            "name": "merged_loops.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC_loops/merged_loops.bedpe",
+          },
+          {
+            "color": "rgb(255,255,0)",
+            "displayMode": "COLLAPSED",
+            "name": "5000_blocks",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC/inter_30_contact_domains/5000_blocks",
+          },
+          {
+            "color": "rgb(18,255,0)",
+            "displayMode": "COLLAPSED",
+            "name": "differential_loops2.bedpe",
+            "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/ADAC_vs_EndoC/differential_loops2.bedpe",
+          },
+        ],
+        "url": "https://s3.amazonaws.com/hicfiles/hiseq/nSxhJZHdDRQ0kGDR/12.31.17/EndoC/EndoC_30.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-juicebox-browser-carrying-selected-gene 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "name": "A",
+      "selectedGene": "MYC",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "url": "https://example.org/a.hic",
+    },
+    {
+      "cycle": undefined,
+      "name": "B",
+      "selectedGene": "ACE",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "url": "https://example.org/b.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "name": "A",
+        "selectedGene": "MYC",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+    {
+      "config": {
+        "cycle": undefined,
+        "name": "B",
+        "selectedGene": "ACE",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.org/b.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-juiceboxData-compressed 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "name": "HFFc6 DpnII",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+    },
+    {
+      "cycle": undefined,
+      "name": "H1-hESC DpnII",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/a0859349-5f06-4ad3-b56f-b1166b34a9eb/4DNFIIMZB6Y9.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "name": "HFFc6 DpnII",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+    {
+      "config": {
+        "cycle": undefined,
+        "name": "H1-hESC DpnII",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/a0859349-5f06-4ad3-b56f-b1166b34a9eb/4DNFIIMZB6Y9.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-colorscale-bare-threshold 1`] = `
+{
+  "atConstruction": [
+    {
+      "colorScale": {
+        "__class": "ColorScale",
+        "b": undefined,
+        "binsize": 0.009448099314069635,
+        "cache": [],
+        "g": undefined,
+        "nbins": 2000,
+        "r": undefined,
+        "threshold": 18.89619862813927,
+      },
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": undefined,
+          "binsize": 0.009448099314069635,
+          "cache": [],
+          "g": undefined,
+          "nbins": 2000,
+          "r": undefined,
+          "threshold": 18.89619862813927,
+        },
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-colorscale-diff 1`] = `
+{
+  "atConstruction": [
+    {
+      "colorScale": {
+        "__class": "DiffColorScale",
+        "negativeScale": {
+          "__class": "ColorScale",
+          "b": 255,
+          "binsize": 0.0025,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 0,
+          "threshold": 5,
+        },
+        "positiveScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 0.0025,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 5,
+        },
+        "threshold": 2,
+      },
+      "controlUrl": "https://example.org/b.hic",
+      "cycle": undefined,
+      "displayMode": "AMB",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "colorScale": {
+          "__class": "DiffColorScale",
+          "negativeScale": {
+            "__class": "ColorScale",
+            "b": 255,
+            "binsize": 0.0025,
+            "cache": [],
+            "g": 0,
+            "nbins": 2000,
+            "r": 0,
+            "threshold": 5,
+          },
+          "positiveScale": {
+            "__class": "ColorScale",
+            "b": 0,
+            "binsize": 0.0025,
+            "cache": [],
+            "g": 0,
+            "nbins": 2000,
+            "r": 255,
+            "threshold": 5,
+          },
+          "threshold": 2,
+        },
+        "controlUrl": "https://example.org/b.hic",
+        "cycle": undefined,
+        "displayMode": "AMB",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-colorscale-four-token 1`] = `
+{
+  "atConstruction": [
+    {
+      "colorScale": {
+        "__class": "ColorScale",
+        "b": 0,
+        "binsize": 0.05,
+        "cache": [],
+        "g": 0,
+        "nbins": 2000,
+        "r": 255,
+        "threshold": 100,
+      },
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 0.05,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 100,
+        },
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-colorscale-ratio 1`] = `
+{
+  "atConstruction": [
+    {
+      "colorScale": {
+        "__class": "RatioColorScale",
+        "negativeScale": {
+          "__class": "ColorScale",
+          "b": 255,
+          "binsize": 0.0025,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 0,
+          "threshold": 5,
+        },
+        "positiveScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 0.0025,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 5,
+        },
+        "threshold": 2,
+      },
+      "controlUrl": "https://example.org/b.hic",
+      "cycle": undefined,
+      "displayMode": "AOB",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "colorScale": {
+          "__class": "RatioColorScale",
+          "negativeScale": {
+            "__class": "ColorScale",
+            "b": 255,
+            "binsize": 0.0025,
+            "cache": [],
+            "g": 0,
+            "nbins": 2000,
+            "r": 0,
+            "threshold": 5,
+          },
+          "positiveScale": {
+            "__class": "ColorScale",
+            "b": 0,
+            "binsize": 0.0025,
+            "cache": [],
+            "g": 0,
+            "nbins": 2000,
+            "r": 255,
+            "threshold": 5,
+          },
+          "threshold": 2,
+        },
+        "controlUrl": "https://example.org/b.hic",
+        "cycle": undefined,
+        "displayMode": "AOB",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-every-parameter 1`] = `
+{
+  "atConstruction": [
+    {
+      "colorScale": {
+        "__class": "ColorScale",
+        "b": 0,
+        "binsize": 0.05,
+        "cache": [],
+        "g": 0,
+        "nbins": 2000,
+        "r": 255,
+        "threshold": 100,
+      },
+      "controlName": "B",
+      "controlNvi": "789,10",
+      "controlUrl": "https://example.org/b.hic",
+      "cycle": "true",
+      "displayMode": "AOB",
+      "name": "A",
+      "nvi": "123,456",
+      "selectedGene": "MYC",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "__class": "State",
+        "chr1": 1,
+        "chr2": 1,
+        "normalization": "KR",
+        "pixelSize": 1,
+        "x": 0,
+        "y": 0,
+        "zoom": 4,
+      },
+      "tracks": [
+        {
+          "color": "rgb(255,0,0)",
+          "displayMode": "COLLAPSED",
+          "max": 50,
+          "min": 0,
+          "name": "A",
+          "url": "https://example.org/a.bed",
+        },
+      ],
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 0.05,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 100,
+        },
+        "controlName": "B",
+        "controlNvi": "789,10",
+        "controlUrl": "https://example.org/b.hic",
+        "cycle": "true",
+        "displayMode": "A",
+        "name": "A",
+        "nvi": "123,456",
+        "selectedGene": "MYC",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "__class": "State",
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "KR",
+          "pixelSize": 1,
+          "x": 0,
+          "y": 0,
+          "zoom": 4,
+        },
+        "tracks": [
+          {
+            "color": "rgb(255,0,0)",
+            "displayMode": "COLLAPSED",
+            "max": 50,
+            "min": 0,
+            "name": "A",
+            "url": "https://example.org/a.bed",
+          },
+        ],
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-state-too-few-tokens 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "__class": "State",
+        "chr1": 1,
+        "chr2": 2,
+        "normalization": "NONE",
+        "pixelSize": 1,
+        "x": NaN,
+        "y": NaN,
+        "zoom": NaN,
+      },
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "__class": "State",
+          "chr1": 1,
+          "chr2": 2,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": NaN,
+          "y": NaN,
+          "zoom": NaN,
+        },
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-state-transposed 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "__class": "State",
+        "chr1": 3,
+        "chr2": 5,
+        "normalization": "KR",
+        "pixelSize": 2,
+        "x": 200,
+        "y": 100,
+        "zoom": 6,
+      },
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "__class": "State",
+          "chr1": 3,
+          "chr2": 5,
+          "normalization": "KR",
+          "pixelSize": 2,
+          "x": 200,
+          "y": 100,
+          "zoom": 6,
+        },
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-state-v0-six-token 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "__class": "State",
+        "chr1": 1,
+        "chr2": 2,
+        "normalization": "NONE",
+        "pixelSize": 3,
+        "x": 10,
+        "y": 20,
+        "zoom": 4,
+      },
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "__class": "State",
+          "chr1": 1,
+          "chr2": 2,
+          "normalization": "NONE",
+          "pixelSize": 3,
+          "x": 10,
+          "y": 20,
+          "zoom": 4,
+        },
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-state-v1-eight-token 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "__class": "State",
+        "chr1": 3,
+        "chr2": 5,
+        "normalization": "NONE",
+        "pixelSize": 2,
+        "x": 100,
+        "y": 200,
+        "zoom": 6,
+      },
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "__class": "State",
+          "chr1": 3,
+          "chr2": 5,
+          "normalization": "NONE",
+          "pixelSize": 2,
+          "x": 100,
+          "y": 200,
+          "zoom": 6,
+        },
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-state-v1-legacy-viewport 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "__class": "State",
+        "chr1": 3,
+        "chr2": 5,
+        "normalization": "KR",
+        "pixelSize": 2,
+        "x": 100,
+        "y": 200,
+        "zoom": 6,
+      },
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "__class": "State",
+          "chr1": 3,
+          "chr2": 5,
+          "normalization": "KR",
+          "pixelSize": 2,
+          "x": 100,
+          "y": 200,
+          "zoom": 6,
+        },
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-state-v1-nine-token 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "__class": "State",
+        "chr1": 3,
+        "chr2": 5,
+        "normalization": "KR",
+        "pixelSize": 2,
+        "x": 100,
+        "y": 200,
+        "zoom": 6,
+      },
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "__class": "State",
+          "chr1": 3,
+          "chr2": 5,
+          "normalization": "KR",
+          "pixelSize": 2,
+          "x": 100,
+          "y": 200,
+          "zoom": 6,
+        },
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-tracks-bare-url 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "tracks": [
+        {
+          "color": "https://example.org/a.bed",
+          "displayMode": "COLLAPSED",
+          "url": "https://example.org/a.bed",
+        },
+      ],
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "color": "https://example.org/a.bed",
+            "displayMode": "COLLAPSED",
+            "url": "https://example.org/a.bed",
+          },
+        ],
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-tracks-default-color-stripped 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "tracks": [
+        {
+          "displayMode": "COLLAPSED",
+          "max": 50,
+          "min": 0,
+          "name": "A",
+          "url": "https://example.org/a.bed",
+        },
+      ],
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "displayMode": "COLLAPSED",
+            "max": 50,
+            "min": 0,
+            "name": "A",
+            "url": "https://example.org/a.bed",
+          },
+        ],
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-tracks-empty-range 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "tracks": [
+        {
+          "color": "rgb(255,0,0)",
+          "displayMode": "COLLAPSED",
+          "name": "A",
+          "url": "https://example.org/a.bed",
+        },
+      ],
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "color": "rgb(255,0,0)",
+            "displayMode": "COLLAPSED",
+            "name": "A",
+            "url": "https://example.org/a.bed",
+          },
+        ],
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-tracks-four-field 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "tracks": [
+        {
+          "color": "rgb(255,0,0)",
+          "displayMode": "COLLAPSED",
+          "max": 50,
+          "min": 0,
+          "name": "A",
+          "url": "https://example.org/a.bed",
+        },
+      ],
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "color": "rgb(255,0,0)",
+            "displayMode": "COLLAPSED",
+            "max": 50,
+            "min": 0,
+            "name": "A",
+            "url": "https://example.org/a.bed",
+          },
+        ],
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-tracks-name-with-bar 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "tracks": [
+        {
+          "color": "rgb(255,0,0)",
+          "displayMode": "COLLAPSED",
+          "max": 50,
+          "min": 0,
+          "name": "A|B",
+          "url": "https://example.org/a.bed",
+        },
+      ],
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "color": "rgb(255,0,0)",
+            "displayMode": "COLLAPSED",
+            "max": 50,
+            "min": 0,
+            "name": "A|B",
+            "url": "https://example.org/a.bed",
+          },
+        ],
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-tracks-negative-range 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "tracks": [
+        {
+          "color": "rgb(255,0,0)",
+          "displayMode": "COLLAPSED",
+          "max": 5,
+          "min": -5,
+          "name": "A",
+          "url": "https://example.org/a.bed",
+        },
+      ],
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "color": "rgb(255,0,0)",
+            "displayMode": "COLLAPSED",
+            "max": 5,
+            "min": -5,
+            "name": "A",
+            "url": "https://example.org/a.bed",
+          },
+        ],
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-tracks-three-field 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "tracks": [
+        {
+          "color": "rgb(255,0,0)",
+          "displayMode": "COLLAPSED",
+          "name": "A",
+          "url": "https://example.org/a.bed",
+        },
+      ],
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "color": "rgb(255,0,0)",
+            "displayMode": "COLLAPSED",
+            "name": "A",
+            "url": "https://example.org/a.bed",
+          },
+        ],
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-tracks-two-field 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "tracks": [
+        {
+          "color": "rgb(255,0,0)",
+          "displayMode": "COLLAPSED",
+          "url": "https://example.org/a.bed|rgb(255,0,0)",
+        },
+      ],
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "color": "rgb(255,0,0)",
+            "displayMode": "COLLAPSED",
+            "url": "https://example.org/a.bed|rgb(255,0,0)",
+          },
+        ],
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-tracks-undefined-url 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "tracks": [],
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [],
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-url-shortcuts-http 1`] = `
+{
+  "atConstruction": [
+    {
+      "controlUrl": "http://hicfiles.s3.amazonaws.com/external/b.hic",
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "url": "http://hicfiles.s3.amazonaws.com/hiseq/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "controlUrl": "http://hicfiles.s3.amazonaws.com/external/b.hic",
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "http://hicfiles.s3.amazonaws.com/hiseq/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-query-url-shortcuts-https 1`] = `
+{
+  "atConstruction": [
+    {
+      "controlUrl": "https://www.encodeproject.org/files/ENCFF000.hic",
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "tracks": [
+        {
+          "color": "rgb(255,0,0)",
+          "displayMode": "COLLAPSED",
+          "max": 50,
+          "min": 0,
+          "name": "B",
+          "url": "https://hicfiles.s3.amazonaws.com/external/b.bed",
+        },
+      ],
+      "url": "https://hicfiles.s3.amazonaws.com/hiseq/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "controlUrl": "https://www.encodeproject.org/files/ENCFF000.hic",
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "color": "rgb(255,0,0)",
+            "displayMode": "COLLAPSED",
+            "max": 50,
+            "min": 0,
+            "name": "B",
+            "url": "https://hicfiles.s3.amazonaws.com/external/b.bed",
+          },
+        ],
+        "url": "https://hicfiles.s3.amazonaws.com/hiseq/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-session-and-hic-url-together 1`] = `
+{
+  "atConstruction": [
+    {
+      "cycle": undefined,
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "url": "https://example.org/wins.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://example.org/wins.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-session-data-prefix 1`] = `
+{
+  "atConstruction": [
+    {
+      "colorScale": {
+        "__class": "ColorScale",
+        "b": 0,
+        "binsize": 0.05,
+        "cache": [],
+        "g": 0,
+        "nbins": 2000,
+        "r": 255,
+        "threshold": 100,
+      },
+      "name": "HFFc6 DpnII",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "chr1": 1,
+        "chr2": 1,
+        "normalization": "NONE",
+        "pixelSize": 1,
+        "x": 0,
+        "y": 0,
+        "zoom": 4,
+      },
+      "tracks": [],
+      "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 0.05,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 100,
+        },
+        "name": "HFFc6 DpnII",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": 0,
+          "y": 0,
+          "zoom": 4,
+        },
+        "tracks": [],
+        "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-session-url-blob-prefixed 1`] = `
+{
+  "atConstruction": [
+    {
+      "colorScale": {
+        "__class": "ColorScale",
+        "b": 0,
+        "binsize": 0.05,
+        "cache": [],
+        "g": 0,
+        "nbins": 2000,
+        "r": 255,
+        "threshold": 100,
+      },
+      "name": "HFFc6 DpnII",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "chr1": 1,
+        "chr2": 1,
+        "normalization": "NONE",
+        "pixelSize": 1,
+        "x": 0,
+        "y": 0,
+        "zoom": 4,
+      },
+      "tracks": [],
+      "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 0.05,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 100,
+        },
+        "name": "HFFc6 DpnII",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": 0,
+          "y": 0,
+          "zoom": 4,
+        },
+        "tracks": [],
+        "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-session-url-plain-json 1`] = `
+{
+  "atConstruction": [
+    {
+      "name": "A",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "chr1": 1,
+        "chr2": 1,
+        "normalization": "NONE",
+        "pixelSize": 1,
+        "x": 0,
+        "y": 0,
+        "zoom": 4,
+      },
+      "url": "https://example.org/a.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "name": "A",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": 0,
+          "y": 0,
+          "zoom": 4,
+        },
+        "url": "https://example.org/a.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the query path, over the wire-format corpus > synth-session-with-selected-gene 1`] = `
+{
+  "atConstruction": [
+    {
+      "colorScale": {
+        "__class": "ColorScale",
+        "b": 0,
+        "binsize": 0.05,
+        "cache": [],
+        "g": 0,
+        "nbins": 2000,
+        "r": 255,
+        "threshold": 100,
+      },
+      "name": "HFFc6 DpnII",
+      "showChromosomeSelector": true,
+      "showHicContactMapLabel": true,
+      "showLocusGoto": true,
+      "state": {
+        "chr1": 1,
+        "chr2": 1,
+        "normalization": "NONE",
+        "pixelSize": 1,
+        "x": 0,
+        "y": 0,
+        "zoom": 4,
+      },
+      "tracks": [],
+      "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+    },
+  ],
+  "readBack": [
+    {
+      "config": {
+        "colorScale": {
+          "__class": "ColorScale",
+          "b": 0,
+          "binsize": 0.05,
+          "cache": [],
+          "g": 0,
+          "nbins": 2000,
+          "r": 255,
+          "threshold": 100,
+        },
+        "name": "HFFc6 DpnII",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": 0,
+          "y": 0,
+          "zoom": 4,
+        },
+        "tracks": [],
+        "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/8f064770-6008-4f74-bfca-268d4a22d745/4DNFIMROE6N4.hic",
+      },
+      "figureMode": undefined,
+      "sameObjectAsInput": undefined,
+      "synchable": true,
+    },
+  ],
+}
+`;
+
+exports[`resolved config golden file — the same input as a URL and as a config > the-same-locus-through-a-URL-and-through-a-config 1`] = `
+{
+  "viaHostConfig": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": 0,
+          "y": 0,
+          "zoom": 4,
+        },
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "state": {
+            "chr1": 1,
+            "chr2": 1,
+            "normalization": "NONE",
+            "pixelSize": 1,
+            "x": 0,
+            "y": 0,
+            "zoom": 4,
+          },
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "viaQuery": {
+    "atConstruction": [
+      {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "state": {
+          "__class": "State",
+          "chr1": 1,
+          "chr2": 1,
+          "normalization": "NONE",
+          "pixelSize": 1,
+          "x": 0,
+          "y": 0,
+          "zoom": 4,
+        },
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "readBack": [
+      {
+        "config": {
+          "cycle": undefined,
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "state": {
+            "__class": "State",
+            "chr1": 1,
+            "chr2": 1,
+            "normalization": "NONE",
+            "pixelSize": 1,
+            "x": 0,
+            "y": 0,
+            "zoom": 4,
+          },
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": undefined,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — the same input as a URL and as a config > the-same-shortcut-URL-through-a-URL-and-through-a-config 1`] = `
+{
+  "viaHostConfig": {
+    "atConstruction": [
+      {
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "viaQuery": {
+    "atConstruction": [
+      {
+        "cycle": undefined,
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+      },
+    ],
+    "readBack": [
+      {
+        "config": {
+          "cycle": undefined,
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC009.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": undefined,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`resolved config golden file — the same input as a URL and as a config > the-same-track-through-a-URL-and-through-a-config 1`] = `
+{
+  "viaHostConfig": {
+    "atConstruction": [
+      {
+        "name": "A",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "color": "rgb(22, 129, 198)",
+            "name": "annotations",
+            "url": "https://example.com/annotations.bed",
+          },
+        ],
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "outcome": "builds",
+    "readBack": [
+      {
+        "config": {
+          "name": "A",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "tracks": [
+            {
+              "color": "rgb(22, 129, 198)",
+              "name": "annotations",
+              "url": "https://example.com/annotations.bed",
+            },
+          ],
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": true,
+        "synchable": true,
+      },
+    ],
+  },
+  "viaQuery": {
+    "atConstruction": [
+      {
+        "cycle": undefined,
+        "name": "A",
+        "showChromosomeSelector": true,
+        "showHicContactMapLabel": true,
+        "showLocusGoto": true,
+        "tracks": [
+          {
+            "displayMode": "COLLAPSED",
+            "name": "annotations",
+            "url": "https://example.com/annotations.bed",
+          },
+        ],
+        "url": "https://example.com/a.hic",
+      },
+    ],
+    "readBack": [
+      {
+        "config": {
+          "cycle": undefined,
+          "name": "A",
+          "showChromosomeSelector": true,
+          "showHicContactMapLabel": true,
+          "showLocusGoto": true,
+          "tracks": [
+            {
+              "displayMode": "COLLAPSED",
+              "name": "annotations",
+              "url": "https://example.com/annotations.bed",
+            },
+          ],
+          "url": "https://example.com/a.hic",
+        },
+        "figureMode": undefined,
+        "sameObjectAsInput": undefined,
+        "synchable": true,
+      },
+    ],
+  },
+}
+`;

--- a/test/data/configEntryPathCorpus.js
+++ b/test/data/configEntryPathCorpus.js
@@ -1,0 +1,276 @@
+/**
+ * The config fixtures — one input per thing an entry path is known, or
+ * suspected, to treat differently. #531, the gate for candidate 9.
+ *
+ * Candidate 9 is "give the config schema one reader". Today there is no reader:
+ * `createBrowser.normalizeConfig` applies some defaults, `sessionCodec.fixDefaults`
+ * applies others, `expandSessionUrlShortcuts` runs in two places, and
+ * `HICBrowser` itself reads raw fields and defaults them inline. Which of those
+ * a config meets depends on which door it came in through.
+ *
+ * **These fixtures carry inputs, not expected outputs** — the same rule as
+ * `wireFormatCorpus.js`, and for the same reason (ADR-0006, "How we know the
+ * decoder did not change"). A hand-written expectation here would encode one
+ * reader's understanding of four scattered normalizers, which is precisely the
+ * understanding candidate 9 exists because nobody has. The consuming test,
+ * `test/testConfigGolden.js`, snapshots what each entry path actually produces.
+ *
+ * Every fixture is a *single browser config*, deliberately, because all four
+ * entry paths accept that shape: `createBrowserList` reads `session.browsers ||
+ * [session]`, so a bare config is a one-browser session. That is what lets one
+ * snapshot hold all four paths side by side and makes a divergence a visible
+ * difference between columns rather than a claim in a comment. Fixtures that are
+ * only meaningful as a multi-browser session are in `sessionFixtures` below and
+ * run through the session-shaped paths only.
+ *
+ * **Every fixture here is synthesized, and that is a real limitation.**
+ * `wireFormatCorpus.js` marks each fixture `harvested` or `synthesized` because
+ * a synthesized-only corpus is circular: it encodes what its author thinks the
+ * code accepts, and so reproduces a misreading faithfully. There is no
+ * equivalent harvest available for configs — a config is an argument a host
+ * passes in code, not a string a user pastes into a tracker, so there is no
+ * inbound population to sample. What exists instead is the two known host apps,
+ * and `host-shaped-full-config` and `empty-config` are shaped after
+ * juicebox-web's call and Spacewalk's respectively (ADR-0003 measures both
+ * surfaces). The non-circular half of this gate is the query suite, which drives
+ * the genuinely harvested `wireFormatCorpus` inputs through the same machinery.
+ *
+ * `divergence` records what the fixture was written to expose. It is a note
+ * about *why this input is here*, not an assertion — read the snapshot for what
+ * actually happens. Where a note names a ticket, that ticket is the one expected
+ * to move the snapshot.
+ *
+ * @see test/testConfigGolden.js — the consuming golden file
+ * @see test/data/wireFormatCorpus.js — the same discipline, for the wire format
+ */
+
+/**
+ * The default annotation colour, as a literal.
+ *
+ * Deliberately not imported from `js/sessionCodec.js`: a characterization
+ * fixture that derives its input from the code under test moves when that code
+ * moves, which is the one thing a gate must not do.
+ */
+export const DEFAULT_ANNOTATION_COLOR_LITERAL = 'rgb(22, 129, 198)'
+
+export const configFixtures = [
+
+    {
+        id: 'host-shaped-full-config',
+        note: 'The juicebox-web shape: a map, a control map, tracks, and the display flags a host sets explicitly. The baseline every other fixture is a variation on.',
+        divergence: 'None expected — this is the control.',
+        config: {
+            url: 'https://example.com/a.hic',
+            name: 'A',
+            controlUrl: 'https://example.com/control.hic',
+            controlName: 'Control',
+            nvi: '2851728310,36479',
+            state: {chr1: 1, chr2: 1, zoom: 4, x: 0, y: 0, pixelSize: 1, normalization: 'NONE'},
+            tracks: [{url: 'https://example.com/genes.bed', name: 'genes'}],
+        },
+    },
+
+    {
+        id: 'track-carrying-the-defaults-fixDefaults-strips',
+        note: 'A track with the default annotation colour, NaN data limits, and no displayMode — exactly what `fixDefaults` in js/sessionCodec.js:935 exists to clean up.',
+        divergence: '**Known divergence, and it is *between suites*, not between these four columns.** `fixDefaults` runs inside `decodeSession` and nowhere else, so none of the four config-shaped doors meets it: all four keep the default colour, keep the NaN limits, and get no `displayMode`. The path that does strip them is the query one, and `divergenceProbes` below puts the two side by side in a single snapshot. #533 closes this by moving track-default fixing across the decode/normalize seam.',
+        config: {
+            url: 'https://example.com/a.hic',
+            tracks: [{
+                url: 'https://example.com/annotations.bed',
+                name: 'annotations',
+                color: DEFAULT_ANNOTATION_COLOR_LITERAL,
+                min: NaN,
+                max: NaN,
+            }],
+        },
+    },
+
+    {
+        id: 'url-shortcuts-in-map-control-and-track',
+        note: 'The `*s3/` and `*enc/` shortcuts, in all three places a session can carry one.',
+        divergence: '**Known divergence.** Expansion happens in `BrowserRegistry.restoreSession`, so the two paths that go through a registry restore expand, and the two browser-creation paths reached directly do not — a host calling `hic.createBrowser` with a shortcut URL hands an unexpanded `*s3/…` straight to the loader. This is the second of the two copies ADR-0006 decision 8 left standing; #534 deletes the duplicate and #535 moves the survivor to the entry.',
+        config: {
+            url: '*s3/hiseq/gm12878/in-situ/HIC009.hic',
+            controlUrl: '*s3e_/wapl_hic/WT.hic',
+            tracks: [{url: '*enc/ENCFF000ABC.bigWig', name: 'encode track'}],
+        },
+    },
+
+    {
+        id: 'figure-mode',
+        note: '`figureMode: true`, which `setDefaults` turns into three explicit `false` flags.',
+        divergence: 'None expected: both browser-creation paths call `normalizeConfig`, and the two entry paths above them end in one of those two.',
+        config: {url: 'https://example.com/a.hic', figureMode: true},
+    },
+
+    {
+        id: 'mini-mode-the-legacy-spelling-of-figure-mode',
+        note: '`miniMode: true`, the backward-compatible spelling `HICBrowser` still reads at hicBrowser.js:103.',
+        divergence: '**Known divergence, and not between paths — between readers.** `setDefaults` tests `config.figureMode === true` only, so `miniMode` leaves the three display flags defaulted to `true` while `browser.figureMode` is `true`. Every path agrees, and every path is inconsistent with itself. The snapshot pins the resolved flags; `browser.figureMode` is snapshotted beside the config because that disagreement is invisible in the config alone. #536 is where the schema says which spelling wins.',
+        config: {url: 'https://example.com/a.hic', miniMode: true},
+    },
+
+    {
+        id: 'display-flags-set-explicitly-false',
+        note: 'A host that turns the three chrome elements off by hand rather than through `figureMode`.',
+        divergence: 'None expected — `??` leaves an explicit `false` alone. Here to pin that, since a defaulting rewritten as `||` would silently flip all three.',
+        config: {
+            url: 'https://example.com/a.hic',
+            showLocusGoto: false,
+            showHicContactMapLabel: false,
+            showChromosomeSelector: false,
+        },
+    },
+
+    {
+        id: 'color-scale-as-a-string',
+        note: 'The colour scale in its wire spelling. `normalizeConfig` parses a string into a scale object in place, so the *host\'s own object* comes back holding a class instance where it put a string.',
+        divergence: 'None expected between paths. Pinned because the in-place rewrite is observable to a host that reuses its config object, and because `browser.config.colorScale` is a class instance in the snapshot rather than the string the host wrote.',
+        config: {url: 'https://example.com/a.hic', colorScale: '100,255,0,0'},
+    },
+
+    {
+        id: 'background-color-as-a-string',
+        note: 'The other in-place string→object rewrite in `normalizeConfig`.',
+        divergence: 'None expected between paths. Same reason as the colour scale.',
+        config: {url: 'https://example.com/a.hic', backgroundColor: '255,255,255'},
+    },
+
+    {
+        id: 'synchable-false-on-the-browser-config',
+        note: '`synchable` set per browser, which is where `HICBrowser` reads it (hicBrowser.js:127).',
+        divergence: 'None expected — this is the field the *session-level* `syncDatasets` is translated into, and it is the half that behaves the same everywhere.',
+        config: {url: 'https://example.com/a.hic', synchable: false},
+    },
+
+    {
+        id: 'unknown-field-a-host-invented',
+        note: 'A field no reader in juicebox knows about.',
+        divergence: 'None expected — every path carries it through untouched, and the schema #536 writes down must keep doing so. "Normalize defaults and coerces, never rejects" (#466) is only checkable if something unrecognized is in the corpus.',
+        config: {url: 'https://example.com/a.hic', hostPrivateField: {anything: [1, 2, 3]}},
+    },
+
+    {
+        id: 'syncDatasets-false-on-a-single-browser-config',
+        note: 'The session-level sync opt-out, on a config that is also a one-browser session — which is what every one of these four paths accepts.',
+        divergence: '**Known divergence, visible between the columns below.** `createBrowserList` reads `syncDatasets` and writes `synchable: false` onto each browser config; `createBrowser` never looks at it, so the same input produces a synchable browser through one creation path and an unsynchable one through the other. One of the three divergences #533 closes.',
+        config: {url: 'https://example.com/a.hic', syncDatasets: false},
+    },
+
+    {
+        id: 'empty-config',
+        note: 'The degenerate input: no map at all. Spacewalk passes `{}` to `init` and drives everything through `restoreSession` afterwards, so this is a shape that runs in production.',
+        divergence: 'None expected. Pinned because "what a config contains" has to include the empty one, and because the defaults are the whole of the answer here.',
+        config: {},
+    },
+]
+
+/**
+ * Pairs: the *same map, the same track, the same locus*, expressed once as a URL
+ * and once as a host config.
+ *
+ * The divergences the four columns above cannot show are the ones between the
+ * query path and the config paths, because those two take different input types
+ * and so cannot be columns of the same table. A pair is how they become
+ * comparable: whatever differs between `viaQuery` and `viaHostConfig` for inputs
+ * that mean the same thing is a divergence, and there is nowhere else for it to
+ * have come from.
+ *
+ * `url` is a whole href, as `init()` reads it from `window.location.href`.
+ */
+export const divergenceProbes = [
+
+    {
+        id: 'the-same-track-through-a-URL-and-through-a-config',
+        note: 'One map, one BED track, the default annotation colour, no data range.',
+        divergence: '**The `fixDefaults` divergence, in one snapshot.** The query side loses `color` (stripped for being the default), gains `displayMode: "COLLAPSED"` forced onto every track, and carries the empty data range as the decoder leaves it; the config side keeps what the host wrote. Same track, two answers. #533.',
+        url: 'http://localhost/juicebox/?hicUrl=https://example.com/a.hic&name=A&tracks=https://example.com/annotations.bed|annotations||rgb(22, 129, 198)',
+        config: {
+            url: 'https://example.com/a.hic',
+            name: 'A',
+            tracks: [{
+                url: 'https://example.com/annotations.bed',
+                name: 'annotations',
+                color: DEFAULT_ANNOTATION_COLOR_LITERAL,
+            }],
+        },
+    },
+
+    {
+        id: 'the-same-locus-through-a-URL-and-through-a-config',
+        note: 'One map at one locus, the state written once as the `state=` token string and once as the JSON object a host or a saved session carries.',
+        divergence: '**A type divergence.** The query path hands `HICBrowser` a `State` *instance*; a host config carries a plain object, which `DataLoader` passes to `State.fromJSON` later. Both work today because everything downstream reads fields rather than methods — which is exactly the kind of accident a schema with one reader is meant to remove. Pinned so that a normalize stage which starts coercing (in either direction) does it visibly.',
+        url: 'http://localhost/juicebox/?hicUrl=https://example.com/a.hic&state=1,1,4,0,0,1,NONE',
+        config: {
+            url: 'https://example.com/a.hic',
+            state: {chr1: 1, chr2: 1, zoom: 4, x: 0, y: 0, pixelSize: 1, normalization: 'NONE'},
+        },
+    },
+
+    {
+        id: 'the-same-shortcut-URL-through-a-URL-and-through-a-config',
+        note: 'The `*s3/` shortcut, in the two forms it can arrive in.',
+        divergence: 'None expected *here*, and that is the finding: the query path expands inside `decodeQuery` and the config path expands inside `BrowserRegistry.restoreSession`, by two separate copies of the same code (ADR-0006 decision 8). The pair agrees; #534 deletes one copy and the pair must still agree afterwards.',
+        url: 'http://localhost/juicebox/?hicUrl=*s3/hiseq/gm12878/in-situ/HIC009.hic',
+        config: {url: '*s3/hiseq/gm12878/in-situ/HIC009.hic'},
+    },
+]
+
+/**
+ * Fixtures that only mean anything as a multi-browser session, and so run
+ * through the two session-shaped entry paths rather than all four.
+ */
+export const sessionFixtures = [
+
+    {
+        id: 'two-browser-session',
+        note: 'What juicebox writes and what a share link restores: two browsers, a selected gene, a caption.',
+        divergence: '`selectedGene` and `caption` are session-level and never reach a browser config — the registry keeps the first, the exported `restoreSession` writes the second to a page element. Pinned so that a normalize stage which starts copying session fields down into browser configs is visible as a snapshot movement.',
+        session: {
+            browsers: [
+                {url: 'https://example.com/a.hic', name: 'A'},
+                {url: 'https://example.com/b.hic', name: 'B'},
+            ],
+            selectedGene: 'MYC',
+            caption: 'Figure 1',
+        },
+    },
+
+    {
+        id: 'session-with-syncDatasets-false',
+        note: 'The session-level opt-out of the sync group.',
+        divergence: '**Known divergence.** `createBrowserList` translates `syncDatasets: false` into `synchable: false` on every browser config; `createBrowser` never looks at `syncDatasets` at all. A host reaching the single-browser creation path with this session gets a synchable browser. Listed in #466 as one of the three divergences #533 closes.',
+        session: {
+            syncDatasets: false,
+            browsers: [
+                {url: 'https://example.com/a.hic', name: 'A'},
+                {url: 'https://example.com/b.hic', name: 'B'},
+            ],
+        },
+    },
+
+    {
+        id: 'session-with-per-browser-divergent-flags',
+        note: 'Two browsers whose configs disagree about the display flags — one in figure mode, one not.',
+        divergence: 'None expected: `normalizeConfig` is applied per browser, not per session. Pinned because a normalize stage lifted to the session level could quietly make one browser\'s flags win over the other\'s.',
+        session: {
+            browsers: [
+                {url: 'https://example.com/a.hic', figureMode: true},
+                {url: 'https://example.com/b.hic', showLocusGoto: false},
+            ],
+        },
+    },
+
+    {
+        id: 'session-with-url-shortcuts-in-both-browsers',
+        note: 'The shortcut expansion, in the multi-browser shape it was written for.',
+        divergence: 'Same divergence as the single-browser shortcut fixture: the registry restore expands, `createBrowserList` reached directly does not.',
+        session: {
+            browsers: [
+                {url: '*s3/hiseq/gm12878/in-situ/HIC009.hic'},
+                {url: '*s3e/wapl_hic/WT.hic', tracks: [{url: '*enc/ENCFF000ABC.bigWig'}]},
+            ],
+        },
+    },
+]

--- a/test/testConfigGolden.js
+++ b/test/testConfigGolden.js
@@ -1,0 +1,527 @@
+/**
+ * The golden-file characterization test for the resolved config. #531.
+ *
+ * **Nothing in the config-handling code moves until this file is green.** It is
+ * candidate 9's gate, and it is the same instrument #503 was for candidate 5:
+ * drive representative inputs through every entry path, snapshot what comes out,
+ * and let the refactor pass by coming back byte-identical.
+ *
+ * ## What is snapshotted, and why it is two things
+ *
+ * Each fixture is driven through the four entry paths a config can arrive by,
+ * and each path contributes two records:
+ *
+ * - **`atConstruction`** — the config as it reaches `HICBrowser`, captured at
+ *   `HICBrowser.prototype.init` (the constructor assigns `this.config` and does
+ *   not rewrite it, so the two are the same object one line apart). This is
+ *   everything the normalizers upstream of the browser did.
+ * - **`readBack`** — `browser.config` off the live instance afterwards, plus the
+ *   two members the browser derives from a config rather than storing
+ *   (`figureMode`, `synchable`). juicebox-web reads `browser.config` back
+ *   (ADR-0003), so the resolved config is an *observable surface*: a change to
+ *   it is consumer-visible whether or not any juicebox code notices. The pair
+ *   also catches `init()` writing to the host's own object -- `config.displayMode
+ *   = "A"` at hicBrowser.js:217 is one such write.
+ *
+ * `sameObjectAsInput` is snapshotted beside them because none of this is copied:
+ * every normalizer mutates in place, so the host's own object is the browser's
+ * config. A refactor that starts returning a normalized *copy* is a behaviour
+ * change for a host that holds a reference, and this is the line that catches it.
+ *
+ * ## Why one snapshot holds all four paths
+ *
+ * Because the divergences are the point. No file in this repo states what a
+ * config contains; four modules each interpret a subset, and the entry paths
+ * have silently diverged. Putting the paths side by side in one snapshot turns
+ * "the paths disagree" from a claim in a review card into a difference between
+ * two columns of a committed file. Where a fixture exists to expose one, its
+ * `divergence` note in `test/data/configEntryPathCorpus.js` says which -- and
+ * names the ticket expected to close it.
+ *
+ * ## Updating a snapshot — the convention
+ *
+ * Unchanged from #503, and it applies here for the same reason: a bare
+ * `vitest -u` is exactly what makes a deliberate movement and an accidental one
+ * indistinguishable.
+ *
+ * 1. Read the diff fixture by fixture. A column you did not expect to move is a
+ *    bug report, not a snapshot to accept.
+ * 2. Update only what moved -- `vitest -u -t '<fixture id>'`, never a bare `-u`.
+ * 3. Add a row to the log below naming the ticket that authorised it.
+ *
+ * ### Authorised snapshot movements
+ *
+ * | Date | Fixtures | Authorised by |
+ * |------|----------|---------------|
+ * | 2026-08-10 | all — baseline taken | #531. No production code changed; this is the gate, taken before candidate 9 moves anything. |
+ *
+ * @see test/data/configEntryPathCorpus.js — the inputs and their divergence notes
+ * @see test/testDecoderGolden.js — the same instrument, one seam upstream
+ */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+import {igvxhr} from 'igv-utils'
+import HICBrowser from '../js/hicBrowser.js'
+import DataLoader from '../js/dataLoader.js'
+import {init} from '../js/init.js'
+import {restoreSession} from '../js/session.js'
+import {createBrowser, createBrowserList} from '../js/createBrowser.js'
+import {registryForContainer} from '../js/browserRegistry.js'
+import {withContainers} from './utils/browserFixture.js'
+import {withStubbedLoads} from './utils/stubbedLoads.js'
+import {configFixtures, divergenceProbes, sessionFixtures} from './data/configEntryPathCorpus.js'
+import {selfContained, viaLoader} from './data/wireFormatCorpus.js'
+
+/**
+ * The two loads `withStubbedLoads` does not cover, stubbed for the same reason
+ * it covers the others: they are the network, and a config fixture naming a
+ * control map or a normalization vector would otherwise go to the wire.
+ *
+ * Local to this file rather than added to the shared helper: no other suite
+ * drives a config with a control map, so putting these in `withStubbedLoads`
+ * would change what every existing suite stubs in order to serve one. (The
+ * `browserFixture` change in the same commit goes the other way because it is
+ * purely additive -- an extra return value and an extra method, nothing that
+ * alters what an existing caller sees.) What the stub reproduces is only what
+ * the config path downstream of it reads: `controlUrl` on the browser, and a
+ * dataset present enough for `isWholeGenome` and the resolution selector.
+ */
+function withStubbedControlLoads() {
+
+    beforeEach(() => {
+        vi.spyOn(DataLoader.prototype, 'loadHicControlFile').mockImplementation(async function (config) {
+            this.browser.controlUrl = config.url
+            this.browser.controlDataset = {
+                url: config.url,
+                name: config.name,
+                genomeId: 'hg19',
+                isWholeGenome: () => false,
+                bpResolutions: [2500000, 1000000],
+                isCompatible: () => true,
+            }
+        })
+        vi.spyOn(DataLoader.prototype, 'loadNormalizationFile').mockImplementation(async () => undefined)
+    })
+}
+
+/**
+ * A config rendered as plain, order-stable data.
+ *
+ * Three things this does that a raw `toMatchSnapshot()` of the object would not:
+ *
+ * 1. **Keys are sorted.** Insertion order is an artefact of which normalizer
+ *    wrote which field, and it differs between paths for reasons that are not
+ *    behaviour. Sorting makes the columns comparable by eye.
+ * 2. **Class instances keep their class.** `colorScale` arrives as a string on
+ *    one path and a `ColorScale` on another; `state` as a plain object from
+ *    `JSON.parse` and as a `State` from the query decoder. Those are different
+ *    values and the snapshot has to say so.
+ * 3. **Nothing calls `toJSON()`.** A wire projection would hide exactly the
+ *    fields a normalize stage is most likely to drop.
+ *
+ * `testDecoderGolden.js` reaches (2) and (3) with a snapshot serializer instead.
+ * The two are deliberately not shared: a serializer is installed on `expect` and
+ * so applies to everything a file snapshots, which is right there and wrong here
+ * -- this file snapshots a nested record where only the config subtrees want the
+ * treatment, and it wants sorted keys, which a serializer cannot add without
+ * changing how every other suite's objects print.
+ */
+function snapshotable(value) {
+
+    if (value === null || typeof value !== 'object') {
+        return typeof value === 'function' ? '[Function]' : value
+    }
+
+    if (Array.isArray(value)) {
+        return value.map(snapshotable)
+    }
+
+    const entries = Object.keys(value).sort().map(key => [key, snapshotable(value[key])])
+    const plain = Object.fromEntries(entries)
+
+    const className = value.constructor?.name
+    return className === undefined || className === 'Object'
+        ? plain
+        : {__class: className, ...plain}
+}
+
+/**
+ * What one browser looks like once a path has built it.
+ *
+ * `figureMode` and `synchable` are here because they are read off a config and
+ * stored, not stored as config: `browser.figureMode` is true for `miniMode`
+ * while `config.showLocusGoto` is defaulted as though it were not, and that
+ * disagreement is invisible in the config alone.
+ */
+function describeBrowser(browser, input) {
+    return {
+        config: snapshotable(browser.config),
+        figureMode: browser.figureMode,
+        synchable: browser.synchable,
+        // Every normalizer mutates in place, so today this is `true` everywhere.
+        // It is snapshotted rather than asserted because "the host's object *is*
+        // the browser's config" is a property of the current design, not a
+        // requirement -- a normalize stage that copies would move this line, and
+        // that is a consumer-visible change worth arriving deliberately.
+        sameObjectAsInput: input === undefined ? undefined : browser.config === input,
+    }
+}
+
+/**
+ * The four doors a config can come in by.
+ *
+ * All four take a single browser config: `createBrowserList` reads
+ * `session.browsers || [session]`, so a bare config is a one-browser session,
+ * and `restoreSession` and `init` end in one of the two creation paths. That
+ * shared shape is what makes the four comparable.
+ *
+ * `init` navigates first: it consults `window.location.href` unless the host
+ * opts out, and a URL carrying no juicebox parameters is what a host app that
+ * embeds juicebox on an ordinary page presents. Setting
+ * `queryParametersSupported: false` instead would have put an extra field in
+ * every snapshot on one column only.
+ */
+const ENTRY_PATHS = [
+    {
+        name: 'hic.init(container, config)',
+        sessionShaped: true,
+        run: async (container, config, dom) => {
+            dom.navigate('http://localhost/host.html')
+            await init(container, config)
+        },
+    },
+    {
+        name: 'hic.restoreSession(container, session)',
+        sessionShaped: true,
+        run: async (container, config) => {
+            await restoreSession(container, config)
+        },
+    },
+    {
+        name: 'createBrowser(container, config)',
+        // The one path that takes a browser config and *only* a browser config:
+        // it builds one browser, so `browsers` and `syncDatasets` mean nothing
+        // to it. That is why it is excluded from the session suite -- and, since
+        // the exclusion is a claim about the path rather than about its name, it
+        // is a flag rather than a substring match on the caption.
+        sessionShaped: false,
+        run: async (container, config) => {
+            await createBrowser(container, config)
+        },
+    },
+    {
+        name: 'createBrowserList(container, session)',
+        sessionShaped: true,
+        run: async (container, config) => {
+            await createBrowserList(container, config)
+        },
+    },
+]
+
+const HOST_CONFIG_PATH = ENTRY_PATHS[0]
+
+const SESSION_PATHS = ENTRY_PATHS.filter(path => path.sessionShaped)
+
+/**
+ * The three things every suite below needs: containers, the loads a test cannot
+ * do, and the capture of what reached `HICBrowser`.
+ *
+ * One function rather than four repetitions of the same four lines, and it
+ * returns the two holders the tests read -- neither of which exists until
+ * `beforeEach` has run.
+ */
+function goldenSuite() {
+
+    const dom = withContainers()
+    withStubbedLoads()
+    withStubbedControlLoads()
+
+    return {dom, capture: captureConstructionConfigs()}
+}
+
+/**
+ * Drive one input through one path in a container of its own, and return both
+ * records as data -- including a rejection, which is as much a part of what a
+ * path does with a config as an acceptance is.
+ *
+ * The input is cloned per path because every normalizer mutates in place: two
+ * paths sharing a fixture object would have the first path's rewrites in the
+ * second path's input, and the divergence the snapshot is for would vanish.
+ */
+async function drive(path, dom, input, capture) {
+
+    const container = dom.another()
+    const clone = structuredClone(input)
+    const inputBrowsers = clone.browsers || [clone]
+
+    capture.take()
+
+    try {
+        await path.run(container, clone, dom)
+    } catch (e) {
+        return {outcome: 'throws', error: {name: e?.name, message: e?.message}}
+    }
+
+    const browsers = registryForContainer(container).browsers
+
+    return {
+        outcome: 'builds',
+        atConstruction: capture.take(),
+        readBack: browsers.map((browser, i) => describeBrowser(browser, inputBrowsers[i])),
+    }
+}
+
+/**
+ * The query path's counterpart to `drive`: navigate to `href`, initialize with
+ * the empty config a host that leaves the URL in charge passes, and return the
+ * same two records.
+ *
+ * `init(container, {})` rather than a call to `extractConfig`: what is being
+ * characterized is the whole path from the address bar to `browser.config`, and
+ * the decode half of it already has a golden file of its own.
+ */
+async function driveQuery(dom, href, capture) {
+
+    const container = dom.another()
+    capture.take()
+
+    dom.navigate(href)
+    await init(container, {})
+
+    return {
+        atConstruction: capture.take(),
+        readBack: registryForContainer(container).browsers.map(browser => describeBrowser(browser)),
+    }
+}
+
+/**
+ * Capture the config *as it reaches the browser*, before `init()` has had a
+ * chance to write to it.
+ *
+ * A spy rather than a constructor hook: the constructor assigns `this.config`
+ * and the very next thing any path does is `await browser.init(config)`, with
+ * the same object and nothing in between. Rendered immediately, because the
+ * object it holds is the one everything downstream then mutates.
+ *
+ * `take()` returns what has accumulated *and* clears it, so a driver never
+ * reaches into the captor's array to reset it: one path's browsers cannot leak
+ * into the next path's column, and there is one place that rule is written.
+ */
+function captureConstructionConfigs() {
+
+    let captured = []
+
+    beforeEach(() => {
+        captured = []
+        const original = HICBrowser.prototype.init
+        vi.spyOn(HICBrowser.prototype, 'init').mockImplementation(async function (config) {
+            captured.push(snapshotable(config))
+            return original.call(this, config)
+        })
+    })
+
+    return {
+        take() {
+            const taken = captured
+            captured = []
+            return taken
+        },
+    }
+}
+
+/**
+ * "Every entry path is covered" has to hold by construction, not by having been
+ * true the day it was written -- the same guard `testDecoderGolden.js` puts over
+ * its three partitions, and for the same reason: the one failure mode a golden
+ * file cannot survive is a case that stops being snapshotted in silence.
+ *
+ * The session suite runs a subset of the paths, so the subset is checked rather
+ * than assumed: exactly one path is not session-shaped, and it is the one that
+ * builds a single browser. A path added without a `sessionShaped` flag fails
+ * here instead of quietly running in one suite only.
+ */
+test('every entry path is driven, and the session subset is the one path short', () => {
+
+    expect(ENTRY_PATHS.map(path => path.name)).toEqual([
+        'hic.init(container, config)',
+        'hic.restoreSession(container, session)',
+        'createBrowser(container, config)',
+        'createBrowserList(container, session)',
+    ])
+
+    expect(ENTRY_PATHS.every(path => typeof path.sessionShaped === 'boolean'),
+        'a path with no sessionShaped flag would be dropped from the session suite in silence').toBe(true)
+
+    expect(ENTRY_PATHS.filter(path => !path.sessionShaped).map(path => path.name))
+        .toEqual(['createBrowser(container, config)'])
+
+    expect(SESSION_PATHS).toHaveLength(ENTRY_PATHS.length - 1)
+    expect(HOST_CONFIG_PATH.name).toBe('hic.init(container, config)')
+})
+
+/**
+ * A fixture id names a snapshot, so two fixtures sharing one would leave a
+ * single entry standing for both -- silently, and differently depending on
+ * which ran last.
+ */
+test('every fixture id is unique within its corpus', () => {
+    for (const corpus of [configFixtures, sessionFixtures, divergenceProbes]) {
+        expect(new Set(corpus.map(f => f.id)).size).toBe(corpus.length)
+    }
+})
+
+describe('resolved config golden file — one browser config, through every entry path', () => {
+
+    const {dom, capture} = goldenSuite()
+
+    for (const fixture of configFixtures) {
+        test(fixture.id, async () => {
+
+            const byPath = {}
+            for (const path of ENTRY_PATHS) {
+                byPath[path.name] = await drive(path, dom, fixture.config, capture)
+            }
+
+            expect(byPath).toMatchSnapshot()
+        })
+    }
+})
+
+describe('resolved config golden file — session documents, through the session-shaped paths', () => {
+
+    const {dom, capture} = goldenSuite()
+
+    for (const fixture of sessionFixtures) {
+        test(fixture.id, async () => {
+
+            const byPath = {}
+            for (const path of SESSION_PATHS) {
+                byPath[path.name] = await drive(path, dom, fixture.session, capture)
+            }
+
+            expect(byPath).toMatchSnapshot()
+        })
+    }
+})
+
+/**
+ * The Spacewalk sequence: `init(container, {})` first, then `restoreSession`
+ * into the *same* embed.
+ *
+ * The suites above give each path a container of its own, which is the right
+ * isolation for comparing columns and the wrong shape for the one host that
+ * matters most here. Spacewalk initializes with an empty config and drives
+ * everything through `restoreSession` afterwards, so its restore always lands on
+ * a registry that already holds a browser -- `deleteAll()` then rebuild, not a
+ * cold start. That re-entrancy is a different code path and gets its own
+ * snapshot.
+ *
+ * Both halves are recorded, because the interesting question is whether the
+ * second one is affected by the first having happened.
+ */
+describe('resolved config golden file — the Spacewalk sequence, restoring into a live embed', () => {
+
+    const {dom, capture} = goldenSuite()
+
+    for (const fixture of sessionFixtures) {
+        test(fixture.id, async () => {
+
+            const container = dom.another()
+
+            dom.navigate('http://localhost/host.html')
+            capture.take()
+            await init(container, {})
+
+            const afterInit = {
+                atConstruction: capture.take(),
+                readBack: registryForContainer(container).browsers.map(browser => describeBrowser(browser)),
+            }
+
+            const session = structuredClone(fixture.session)
+            await restoreSession(container, session)
+
+            const afterRestore = {
+                atConstruction: capture.take(),
+                readBack: registryForContainer(container).browsers
+                    .map((browser, i) => describeBrowser(browser, (session.browsers || [session])[i])),
+            }
+
+            expect({afterInit, afterRestore}).toMatchSnapshot()
+        })
+    }
+})
+
+/**
+ * The query/URL path, over the wire-format corpus rather than over fixtures
+ * invented here.
+ *
+ * #503 pins what `decodeSession` *returns*; what this pins is what happens to
+ * that value on its way to a browser -- the registry's shortcut expansion, the
+ * per-browser defaults, and the fields `HICBrowser` reads. The two golden files
+ * meet at `init.js:50`, and the corpus is deliberately the same one so that a
+ * fixture added there is covered on both sides of the seam.
+ *
+ * Only the fixtures that decode to a config are here: a `no-config` URL leaves
+ * the host's config in place, which is the `hic.init` column above, and a
+ * rejection never reaches a browser. Those are #503's to pin, and it does.
+ *
+ * The corpus's bare-query fixtures are given a base URL, since a page has one.
+ * `extractQuery` reads from the first `?`, so the base is not part of what is
+ * being characterized -- but it *is* part of what JSDOM parses, which is the
+ * other reason to navigate rather than to hand `extractConfig` a raw string:
+ * a URL a user pastes has been through a URL parser before juicebox sees it.
+ */
+describe('resolved config golden file — the query path, over the wire-format corpus', () => {
+
+    const {dom, capture} = goldenSuite()
+
+    const decoding = [...selfContained, ...viaLoader].filter(f => f.outcome === 'decodes')
+
+    beforeEach(() => {
+        // A tripwire, as in #503: nothing on this path should reach the network.
+        // The session-URL fixtures re-stub it with their own recorded response.
+        vi.spyOn(igvxhr, 'loadString').mockImplementation(async () => {
+            throw new Error('unexpected network access from the config golden-file suite')
+        })
+    })
+
+    for (const fixture of decoding) {
+        test(fixture.id, async () => {
+
+            if (fixture.loaderResponse !== undefined) {
+                vi.spyOn(igvxhr, 'loadString').mockImplementation(async () => fixture.loaderResponse)
+            }
+
+            const href = fixture.input.startsWith('?')
+                ? `http://localhost/juicebox/${fixture.input}`
+                : fixture.input
+
+            expect(await driveQuery(dom, href, capture)).toMatchSnapshot()
+        })
+    }
+})
+
+/**
+ * The divergences the four columns cannot show: query path against config path,
+ * on inputs that mean the same thing.
+ *
+ * A URL and a config are different types, so they cannot be two columns of the
+ * table above. Pairing them is the substitute -- and it is a real one, because
+ * the inputs are equivalent by construction, so anything that differs between
+ * the two answers was put there by a normalizer that only one path meets.
+ *
+ * @see test/data/configEntryPathCorpus.js — each probe's `divergence` note
+ */
+describe('resolved config golden file — the same input as a URL and as a config', () => {
+
+    const {dom, capture} = goldenSuite()
+
+    for (const probe of divergenceProbes) {
+        test(probe.id, async () => {
+
+            const viaQuery = await driveQuery(dom, probe.url, capture)
+            const viaHostConfig = await drive(HOST_CONFIG_PATH, dom, probe.config, capture)
+
+            expect({viaQuery, viaHostConfig}).toMatchSnapshot()
+        })
+    }
+})

--- a/test/utils/browserFixture.js
+++ b/test/utils/browserFixture.js
@@ -91,7 +91,7 @@ export function withDOM() {
         window.close()
     }
 
-    return {window, container, restore}
+    return {dom, window, container, restore}
 }
 
 /**
@@ -140,6 +140,12 @@ export function withContainers() {
             fixture.window.document.body.appendChild(element)
             return element
         }
+        // The one thing `init()` reads that is neither an argument nor a DOM
+        // node: `window.location.href`. JSDOM's `location` is unforgeable, so
+        // the page is navigated rather than the property replaced -- which is
+        // also the honest simulation, since a URL a user pastes has been
+        // through a real URL parser before juicebox sees it.
+        context.navigate = href => fixture.dom.reconfigure({url: href})
     })
 
     afterEach(() => {


### PR DESCRIPTION
Closes #531.

The characterization gate for candidate 9, landing **before one line of config-handling code moves**. Same instrument #503 was for candidate 5: snapshot the observable output first, then refactor until the snapshots come back byte-identical.

**No production code changes.** Tests 731 → 796.

## What is snapshotted

Each record captures two things per browser:

- **`atConstruction`** — the config as it reaches `HICBrowser`, captured at `HICBrowser.prototype.init`.
- **`readBack`** — `browser.config` off the live instance afterwards, plus `figureMode`, `synchable` and `sameObjectAsInput`. juicebox-web reads `browser.config` back (ADR-0003), so the resolved config is an observable surface; `sameObjectAsInput` is there because every normalizer rewrites the host's own object in place, and a refactor that starts copying is a consumer-visible change.

## Coverage

| Suite | What it drives |
|---|---|
| one browser config, every entry path | all four doors — `hic.init`, `hic.restoreSession`, `createBrowser`, `createBrowserList` — side by side in one snapshot |
| session documents | the session-shaped paths, multi-browser fixtures |
| the Spacewalk sequence | `init(container, {})` then `restoreSession` into the **live** embed — the re-entrant restore the fresh-container suites cannot reach |
| the query path | the existing `wireFormatCorpus`, every fixture that decodes, driven through real JSDOM navigation rather than a raw string |
| URL vs config pairs | the same map/track/locus expressed both ways, for divergences a single table cannot show |

## Divergences now pinned in a committed file

Facts in a snapshot rather than claims in a review card, each annotated at its fixture with the ticket expected to move it:

- **`fixDefaults` runs only on the query path.** None of the four config-shaped doors meets it: they keep the default annotation colour, keep NaN data limits, and get no `displayMode`. (#533)
- **URL-shortcut expansion only on the paths that go through a registry restore.** `createBrowser` / `createBrowserList` reached directly hand `*s3/…` unexpanded to the loader. (#534, #535)
- **`syncDatasets: false`** becomes `synchable: false` via `createBrowserList` and is ignored by `createBrowser`. (#533)
- **`state` arrives as a `State` instance** from the query path and as a plain object from a host config.

## Acceptance criteria

- [x] A snapshot test covers all entry paths, including the query/URL path over the existing wire-format corpus
- [x] `browser.config` as read back off the instance is snapshotted, not just the input config
- [x] Known divergences between entry paths are visible in the snapshot and annotated at the fixture
- [x] No production code changes
- [x] Full suite green — 796 tests, 38 files

## Notes

- The gate bites: flipping one `?? true` to `?? false` in `setDefaults` fails 56 of 59 config snapshots.
- `test/utils/browserFixture.js` is additive only — it exposes `dom` and a `navigate()` so `window.location.href` can be set for the URL path.
- `CONTEXT.md` gains *entry path* and *resolved config*, the two terms this gate is written in, per `docs/agents/domain.md`.
- Fixtures here are synthesized and the file says so: a config is an argument a host passes in code, not a string a user pastes, so there is no inbound population to harvest. The non-circular half of the gate is the query suite, which drives the genuinely harvested `wireFormatCorpus` inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)