### PR TITLE
Extract normalizeSession: a pure, session-shaped normalize stage (#532)

### DIFF
--- a/js/createBrowser.js
+++ b/js/createBrowser.js
@@ -22,9 +22,12 @@ const defaultSize = { width: 640, height: 640 };
 
 async function createBrowser(hicContainer, config, callback) {
 
-    // A single browser config is a session with its one browser inlined, so the
-    // session-shaped stage takes it as it is. See js/normalizeSession.js.
-    normalizeSession(config);
+    // Wrapped rather than handed over as it is: this door takes a browser
+    // config and *only* a browser config, so a `browsers` member on it is an
+    // ordinary unread member and must not steer the stage away from the object
+    // that actually becomes `browser.config`. The wrapper is discarded;
+    // `config` is what is normalized. See js/normalizeSession.js.
+    normalizeSession({browsers: [config]});
 
     const browser = new HICBrowser(hicContainer, config);
     await browser.init(config);

--- a/js/createBrowser.js
+++ b/js/createBrowser.js
@@ -2,11 +2,9 @@
  * @author Jim Robinson Dec-2020
  */
 
-import { StringUtils } from 'igv-utils';
 import HICBrowser from './hicBrowser.js';
 import {registryForContainer, getMostRecentlySelectedBrowser, currentRegistry} from './browserRegistry.js';
-import {parseColorScale} from './colorScaleParser.js';
-import ContactMatrixView from "./contactMatrixView.js";
+import {normalizeSession} from './normalizeSession.js';
 
 const defaultSize = { width: 640, height: 640 };
 
@@ -24,7 +22,9 @@ const defaultSize = { width: 640, height: 640 };
 
 async function createBrowser(hicContainer, config, callback) {
 
-    normalizeConfig(config);
+    // A single browser config is a session with its one browser inlined, so the
+    // session-shaped stage takes it as it is. See js/normalizeSession.js.
+    normalizeSession(config);
 
     const browser = new HICBrowser(hicContainer, config);
     await browser.init(config);
@@ -39,14 +39,17 @@ async function createBrowser(hicContainer, config, callback) {
 async function createBrowserList(hicContainer, session) {
 
     const registry = registryForContainer(hicContainer);
+
+    // One call for the whole document: the stage walks the same
+    // `browsers || [session]` shape this loop does. See js/normalizeSession.js.
+    normalizeSession(session);
+
     const configList = session.browsers || [session];
     const initPromises = [];
 
     registry.clear();
 
     for (const config of configList) {
-
-        normalizeConfig(config);
 
         if (session.syncDatasets === false) {
             config.synchable = false;
@@ -118,33 +121,6 @@ function getCurrentBrowser() {
  */
 function getAllBrowsers() {
     return currentRegistry()?.browsers || [];
-}
-
-function normalizeConfig(config) {
-
-    setDefaults(config);
-
-    if (StringUtils.isString(config.colorScale)) {
-        config.colorScale = parseColorScale(config.colorScale);
-    }
-    if (StringUtils.isString(config.backgroundColor)) {
-        config.backgroundColor = ContactMatrixView.parseBackgroundColor(config.backgroundColor);
-    }
-}
-
-function setDefaults(config) {
-
-    if (config.figureMode === true) {
-        config.showLocusGoto = false;
-        config.showHicContactMapLabel = false;
-        config.showChromosomeSelector = false;
-    } else {
-
-
-        config.showLocusGoto = config.showLocusGoto ?? true;
-        config.showHicContactMapLabel = config.showHicContactMapLabel ?? true;
-        config.showChromosomeSelector = config.showChromosomeSelector ?? true;
-    }
 }
 
 export {

--- a/js/normalizeSession.js
+++ b/js/normalizeSession.js
@@ -1,0 +1,106 @@
+/**
+ * The normalize stage: a session document in, the same document resolved out.
+ *
+ * ## Where this sits
+ *
+ * ADR-0006 decision 8 names two stages, decode and normalize, and candidate 5
+ * deliberately stopped at the line between them. This module is the normalize
+ * side, given a name and a module of its own so that the question "what does a
+ * config resolve to?" can be asked without building a browser (#532).
+ *
+ * Nothing has moved *across* the seam here. What this module does is exactly
+ * what the two unexported functions inside `createBrowser.js` did, in the same
+ * order: default the three chrome-visibility flags, with the `figureMode`
+ * special case, and coerce the two members a session can carry as strings.
+ * `fixDefaults`, the `selectedGene` reconciliation and the second copy of the
+ * URL-shortcut expansion are still on the decoder's side; #533 and #534 move
+ * them.
+ *
+ * ## Session-shaped, not browser-shaped
+ *
+ * A single-browser config is a session with its one browser inlined -- the same
+ * shape convention {@link expandSessionUrlShortcuts} already uses, and the shape
+ * `createBrowserList` has always read. Walking `session.browsers || [session]`
+ * is what lets both browser-creation entry points delegate to one call rather
+ * than one call per browser.
+ *
+ * ## "Pure" here means free of the world, not free of mutation
+ *
+ * No DOM, no network, no globals, no browser instance: the stage can be driven
+ * from object literals, which is what `test/testNormalizeSession.js` does.
+ *
+ * It does mutate, and returns the document it was handed. That is deliberate and
+ * is the behaviour #531 pinned: every normalizer in this codebase rewrites the
+ * host's own object, so `browser.config === theObjectTheHostPassed` holds today
+ * and juicebox-web reads `browser.config` back off the live instance (ADR-0003).
+ * Returning a normalized *copy* would be a consumer-visible change, and it is
+ * not this ticket's to make -- `sameObjectAsInput` is snapshotted in the golden
+ * file precisely so that such a change has to arrive deliberately.
+ *
+ * ## It defaults and coerces; it never rejects
+ *
+ * The config object is the most-used public surface juicebox has. A normalize
+ * stage that tightened validation would reject configs that work today, so no
+ * ticket in candidate 9 adds validation here. `test/testNormalizeSession.js`
+ * drives the inputs a validating stage would be most tempted by.
+ *
+ * @see docs/adr/0006-session-wire-format-and-one-decoder.md -- decision 8
+ * @see test/testConfigGolden.js -- the characterization gate this must not move
+ */
+
+import {StringUtils} from 'igv-utils'
+import {parseColorScale} from './colorScaleParser.js'
+import ContactMatrixView from './contactMatrixView.js'
+
+/**
+ * Resolve a session document in place, and return it.
+ *
+ * @param {Object} session - a session naming `browsers`, or a single browser
+ *                           config, which is the same thing with its one
+ *                           browser inlined
+ * @returns {Object} the same object, resolved
+ */
+export function normalizeSession(session) {
+
+    for (const config of session.browsers || [session]) {
+        normalizeBrowserConfig(config)
+    }
+
+    return session
+}
+
+function normalizeBrowserConfig(config) {
+
+    setChromeDefaults(config)
+
+    if (StringUtils.isString(config.colorScale)) {
+        config.colorScale = parseColorScale(config.colorScale)
+    }
+    if (StringUtils.isString(config.backgroundColor)) {
+        config.backgroundColor = ContactMatrixView.parseBackgroundColor(config.backgroundColor)
+    }
+}
+
+/**
+ * The three flags that decide whether a browser draws its chrome.
+ *
+ * `figureMode` forces all three off rather than defaulting them, which is why
+ * this is not three `??`s: a host asking for `figureMode` *and* a locus box gets
+ * figure mode. Note that `HICBrowser` reads `miniMode` as a figure mode too and
+ * this stage does not -- a live disagreement, pinned in the golden file, and
+ * candidate 9's to close later rather than here.
+ */
+function setChromeDefaults(config) {
+
+    if (config.figureMode === true) {
+        config.showLocusGoto = false
+        config.showHicContactMapLabel = false
+        config.showChromosomeSelector = false
+    } else {
+        config.showLocusGoto = config.showLocusGoto ?? true
+        config.showHicContactMapLabel = config.showHicContactMapLabel ?? true
+        config.showChromosomeSelector = config.showChromosomeSelector ?? true
+    }
+}
+
+export default normalizeSession

--- a/js/normalizeSession.js
+++ b/js/normalizeSession.js
@@ -10,7 +10,7 @@
  *
  * Nothing has moved *across* the seam here. What this module does is exactly
  * what the two unexported functions inside `createBrowser.js` did, in the same
- * order: default the three chrome-visibility flags, with the `figureMode`
+ * order: default the three widget-visibility flags, with the `figureMode`
  * special case, and coerce the two members a session can carry as strings.
  * `fixDefaults`, the `selectedGene` reconciliation and the second copy of the
  * URL-shortcut expansion are still on the decoder's side; #533 and #534 move
@@ -19,10 +19,15 @@
  * ## Session-shaped, not browser-shaped
  *
  * A single-browser config is a session with its one browser inlined -- the same
- * shape convention {@link expandSessionUrlShortcuts} already uses, and the shape
- * `createBrowserList` has always read. Walking `session.browsers || [session]`
- * is what lets both browser-creation entry points delegate to one call rather
- * than one call per browser.
+ * shape convention `expandSessionUrlShortcuts` (`js/sessionCodec.js`) already
+ * uses, and the shape `createBrowserList` has always read. Walking
+ * `session.browsers || [session]` is what lets both browser-creation entry
+ * points delegate to one call rather than one call per browser.
+ *
+ * The convention is a *reading* of a document, not a test any object passes: a
+ * caller that already knows it holds exactly one browser config -- `createBrowser`
+ * does -- says so by wrapping it, `normalizeSession({browsers: [config]})`, and
+ * does not have to hope the config carries no member spelled `browsers`.
  *
  * ## "Pure" here means free of the world, not free of mutation
  *
@@ -71,7 +76,7 @@ export function normalizeSession(session) {
 
 function normalizeBrowserConfig(config) {
 
-    setChromeDefaults(config)
+    setWidgetVisibilityDefaults(config)
 
     if (StringUtils.isString(config.colorScale)) {
         config.colorScale = parseColorScale(config.colorScale)
@@ -82,7 +87,8 @@ function normalizeBrowserConfig(config) {
 }
 
 /**
- * The three flags that decide whether a browser draws its chrome.
+ * The three flags that decide whether a browser draws the widgets around its
+ * contact map -- the locus box, the map label and the chromosome selector.
  *
  * `figureMode` forces all three off rather than defaulting them, which is why
  * this is not three `??`s: a host asking for `figureMode` *and* a locus box gets
@@ -90,7 +96,7 @@ function normalizeBrowserConfig(config) {
  * this stage does not -- a live disagreement, pinned in the golden file, and
  * candidate 9's to close later rather than here.
  */
-function setChromeDefaults(config) {
+function setWidgetVisibilityDefaults(config) {
 
     if (config.figureMode === true) {
         config.showLocusGoto = false
@@ -102,5 +108,3 @@ function setChromeDefaults(config) {
         config.showChromosomeSelector = config.showChromosomeSelector ?? true
     }
 }
-
-export default normalizeSession

--- a/test/data/configEntryPathCorpus.js
+++ b/test/data/configEntryPathCorpus.js
@@ -2,9 +2,10 @@
  * The config fixtures — one input per thing an entry path is known, or
  * suspected, to treat differently. #531, the gate for candidate 9.
  *
- * Candidate 9 is "give the config schema one reader". Today there is no reader:
- * `createBrowser.normalizeConfig` applies some defaults, `sessionCodec.fixDefaults`
- * applies others, `expandSessionUrlShortcuts` runs in two places, and
+ * Candidate 9 is "give the config schema one reader". There is not yet one
+ * reader: `normalizeSession` (`js/normalizeSession.js`, #532) applies some
+ * defaults, `sessionCodec.fixDefaults` applies others,
+ * `expandSessionUrlShortcuts` runs in two places, and
  * `HICBrowser` itself reads raw fields and defaults them inline. Which of those
  * a config meets depends on which door it came in through.
  *
@@ -99,15 +100,15 @@ export const configFixtures = [
 
     {
         id: 'figure-mode',
-        note: '`figureMode: true`, which `setDefaults` turns into three explicit `false` flags.',
-        divergence: 'None expected: both browser-creation paths call `normalizeConfig`, and the two entry paths above them end in one of those two.',
+        note: '`figureMode: true`, which `normalizeSession` turns into three explicit `false` flags.',
+        divergence: 'None expected: both browser-creation paths call `normalizeSession`, and the two entry paths above them end in one of those two.',
         config: {url: 'https://example.com/a.hic', figureMode: true},
     },
 
     {
         id: 'mini-mode-the-legacy-spelling-of-figure-mode',
         note: '`miniMode: true`, the backward-compatible spelling `HICBrowser` still reads at hicBrowser.js:103.',
-        divergence: '**Known divergence, and not between paths — between readers.** `setDefaults` tests `config.figureMode === true` only, so `miniMode` leaves the three display flags defaulted to `true` while `browser.figureMode` is `true`. Every path agrees, and every path is inconsistent with itself. The snapshot pins the resolved flags; `browser.figureMode` is snapshotted beside the config because that disagreement is invisible in the config alone. #536 is where the schema says which spelling wins.',
+        divergence: '**Known divergence, and not between paths — between readers.** `normalizeSession` tests `config.figureMode === true` only, so `miniMode` leaves the three display flags defaulted to `true` while `browser.figureMode` is `true`. Every path agrees, and every path is inconsistent with itself. The snapshot pins the resolved flags; `browser.figureMode` is snapshotted beside the config because that disagreement is invisible in the config alone. #536 is where the schema says which spelling wins.',
         config: {url: 'https://example.com/a.hic', miniMode: true},
     },
 
@@ -125,14 +126,14 @@ export const configFixtures = [
 
     {
         id: 'color-scale-as-a-string',
-        note: 'The colour scale in its wire spelling. `normalizeConfig` parses a string into a scale object in place, so the *host\'s own object* comes back holding a class instance where it put a string.',
+        note: 'The colour scale in its wire spelling. `normalizeSession` parses a string into a scale object in place, so the *host\'s own object* comes back holding a class instance where it put a string.',
         divergence: 'None expected between paths. Pinned because the in-place rewrite is observable to a host that reuses its config object, and because `browser.config.colorScale` is a class instance in the snapshot rather than the string the host wrote.',
         config: {url: 'https://example.com/a.hic', colorScale: '100,255,0,0'},
     },
 
     {
         id: 'background-color-as-a-string',
-        note: 'The other in-place string→object rewrite in `normalizeConfig`.',
+        note: 'The other in-place string→object rewrite in `normalizeSession`.',
         divergence: 'None expected between paths. Same reason as the colour scale.',
         config: {url: 'https://example.com/a.hic', backgroundColor: '255,255,255'},
     },
@@ -253,7 +254,7 @@ export const sessionFixtures = [
     {
         id: 'session-with-per-browser-divergent-flags',
         note: 'Two browsers whose configs disagree about the display flags — one in figure mode, one not.',
-        divergence: 'None expected: `normalizeConfig` is applied per browser, not per session. Pinned because a normalize stage lifted to the session level could quietly make one browser\'s flags win over the other\'s.',
+        divergence: 'None expected: `normalizeSession` normalizes per browser, not per session. Pinned because a normalize stage lifted to the session level could quietly make one browser\'s flags win over the other\'s.',
         session: {
             browsers: [
                 {url: 'https://example.com/a.hic', figureMode: true},

--- a/test/testNormalizeSession.js
+++ b/test/testNormalizeSession.js
@@ -21,7 +21,7 @@ import {normalizeSession} from '../js/normalizeSession.js'
 import ColorScale from '../js/colorScale.js'
 import RatioColorScale from '../js/ratioColorScale.js'
 
-const CHROME_FLAGS = ['showLocusGoto', 'showHicContactMapLabel', 'showChromosomeSelector']
+const WIDGET_FLAGS = ['showLocusGoto', 'showHicContactMapLabel', 'showChromosomeSelector']
 
 describe('the two session shapes', () => {
 
@@ -61,15 +61,32 @@ describe('the two session shapes', () => {
 
         expect(session.showLocusGoto).toBeUndefined()
     })
+
+    /**
+     * `createBrowser` is the one entry path that takes a browser config and
+     * *only* a browser config, so it wraps rather than handing its argument
+     * over: a member spelled `browsers` on a single browser config is an
+     * ordinary unread member, and reading it as a browser list would leave the
+     * object that becomes `browser.config` undefaulted.
+     */
+    test('a caller that knows it holds one browser config says so by wrapping it', () => {
+
+        const config = {url: 'a.hic', browsers: 'a member nothing reads'}
+
+        normalizeSession({browsers: [config]})
+
+        expect(config.showLocusGoto).toBe(true)
+        expect(config.browsers).toBe('a member nothing reads')
+    })
 })
 
-describe('the chrome-visibility defaults', () => {
+describe('the widget-visibility defaults', () => {
 
     test('the three flags default on', () => {
 
         const config = normalizeSession({})
 
-        for (const flag of CHROME_FLAGS) {
+        for (const flag of WIDGET_FLAGS) {
             expect(config[flag], flag).toBe(true)
         }
     })
@@ -87,7 +104,7 @@ describe('the chrome-visibility defaults', () => {
 
         const config = normalizeSession({figureMode: true, showLocusGoto: true})
 
-        for (const flag of CHROME_FLAGS) {
+        for (const flag of WIDGET_FLAGS) {
             expect(config[flag], flag).toBe(false)
         }
     })
@@ -99,7 +116,7 @@ describe('the chrome-visibility defaults', () => {
         // and pinned in the golden file; it is not this ticket's to close.
         const config = normalizeSession({miniMode: true})
 
-        for (const flag of CHROME_FLAGS) {
+        for (const flag of WIDGET_FLAGS) {
             expect(config[flag], flag).toBe(true)
         }
     })

--- a/test/testNormalizeSession.js
+++ b/test/testNormalizeSession.js
@@ -1,0 +1,200 @@
+/**
+ * `js/normalizeSession.js` — the normalize stage, driven from object literals.
+ * #532, candidate 9.
+ *
+ * The point of the extraction is that this file exists: normalization used to be
+ * two unexported functions inside the browser-creation module, so the only way
+ * to ask "what does a config resolve to?" was to build a browser and read it
+ * back. Nothing here stubs anything, and if that ever stops being true the
+ * extraction has leaked.
+ *
+ * `test/testConfigGolden.js` still owns "does the resolved config as a whole
+ * come back byte-identical?". This file owns "does each decision inside the
+ * stage behave as described?" — including the one property the golden file can
+ * only show by accident: **normalize rejects nothing**.
+ *
+ * @see js/normalizeSession.js
+ * @see docs/juicebox-punch-list.md — candidate 9
+ */
+import {describe, expect, test} from 'vitest'
+import {normalizeSession} from '../js/normalizeSession.js'
+import ColorScale from '../js/colorScale.js'
+import RatioColorScale from '../js/ratioColorScale.js'
+
+const CHROME_FLAGS = ['showLocusGoto', 'showHicContactMapLabel', 'showChromosomeSelector']
+
+describe('the two session shapes', () => {
+
+    test('a single-browser config is a session with its one browser inlined', () => {
+
+        const config = {url: 'a.hic'}
+
+        expect(normalizeSession(config)).toBe(config)
+        expect(config.showLocusGoto).toBe(true)
+    })
+
+    test('a session names its browsers, and every one of them is normalized', () => {
+
+        const session = {browsers: [{url: 'a.hic'}, {url: 'b.hic', figureMode: true}]}
+
+        normalizeSession(session)
+
+        expect(session.browsers[0].showChromosomeSelector).toBe(true)
+        expect(session.browsers[1].showChromosomeSelector).toBe(false)
+    })
+
+    test('the session document itself is left alone when it names browsers', () => {
+
+        const session = {browsers: [{url: 'a.hic'}], syncDatasets: false}
+
+        normalizeSession(session)
+
+        expect(session.showLocusGoto).toBeUndefined()
+        expect(session.syncDatasets).toBe(false)
+    })
+
+    test('an empty browser list normalizes nothing rather than treating the session as a browser', () => {
+
+        const session = {browsers: []}
+
+        normalizeSession(session)
+
+        expect(session.showLocusGoto).toBeUndefined()
+    })
+})
+
+describe('the chrome-visibility defaults', () => {
+
+    test('the three flags default on', () => {
+
+        const config = normalizeSession({})
+
+        for (const flag of CHROME_FLAGS) {
+            expect(config[flag], flag).toBe(true)
+        }
+    })
+
+    test('a host that asked for a flag off keeps it off', () => {
+
+        const config = normalizeSession({showLocusGoto: false, showHicContactMapLabel: false})
+
+        expect(config.showLocusGoto).toBe(false)
+        expect(config.showHicContactMapLabel).toBe(false)
+        expect(config.showChromosomeSelector).toBe(true)
+    })
+
+    test('figureMode forces all three off, overriding what the host asked for', () => {
+
+        const config = normalizeSession({figureMode: true, showLocusGoto: true})
+
+        for (const flag of CHROME_FLAGS) {
+            expect(config[flag], flag).toBe(false)
+        }
+    })
+
+    test('miniMode is not figureMode here — the browser reads it, normalize does not', () => {
+
+        // `HICBrowser` treats `miniMode` as a figure mode; this stage keys on
+        // `figureMode` alone, so the flags default on. The disagreement is real
+        // and pinned in the golden file; it is not this ticket's to close.
+        const config = normalizeSession({miniMode: true})
+
+        for (const flag of CHROME_FLAGS) {
+            expect(config[flag], flag).toBe(true)
+        }
+    })
+
+    test('only a literal true is figure mode', () => {
+
+        const config = normalizeSession({figureMode: 'yes'})
+
+        expect(config.showLocusGoto).toBe(true)
+    })
+})
+
+describe('the string coercions', () => {
+
+    test('a colorScale string becomes a ColorScale', () => {
+
+        const config = normalizeSession({colorScale: '2000,255,0,0'})
+
+        expect(config.colorScale).toBeInstanceOf(ColorScale)
+        expect(config.colorScale.threshold).toBe(2000)
+    })
+
+    test('a tagged colorScale string becomes the signed scale its tag names', () => {
+
+        const config = normalizeSession({colorScale: 'R:5:2000,255,0,0:2000,0,0,255'})
+
+        expect(config.colorScale).toBeInstanceOf(RatioColorScale)
+    })
+
+    test('a colorScale that is already an object is left as it is', () => {
+
+        const colorScale = new ColorScale({threshold: 17, r: 1, g: 2, b: 3})
+        const config = normalizeSession({colorScale})
+
+        expect(config.colorScale).toBe(colorScale)
+    })
+
+    test('a backgroundColor string becomes an {r, g, b}', () => {
+
+        const config = normalizeSession({backgroundColor: '10,20,30'})
+
+        expect(config.backgroundColor).toEqual({r: 10, g: 20, b: 30})
+    })
+
+    test('a backgroundColor that is already an object is left as it is', () => {
+
+        const backgroundColor = {r: 1, g: 2, b: 3}
+        const config = normalizeSession({backgroundColor})
+
+        expect(config.backgroundColor).toBe(backgroundColor)
+    })
+})
+
+/**
+ * The acceptance criterion candidate 9 repeats on every ticket that could
+ * violate it: the config object is the most-used public surface there is, so a
+ * normalize stage that tightened validation would reject configs that work
+ * today. These are the inputs a validating stage would be most tempted by.
+ */
+describe('normalize rejects nothing', () => {
+
+    const hostile = [
+        ['an empty config', {}],
+        ['a config with no url', {name: 'nameless'}],
+        ['unknown members', {url: 'a.hic', somethingNobodyReads: {deep: [1, 2]}}],
+        ['a null colorScale', {colorScale: null}],
+        ['a numeric url', {url: 42}],
+        ['a browsers list holding an empty config', {browsers: [{}]}],
+        ['browsers alongside inline browser members', {browsers: [{url: 'a.hic'}], url: 'b.hic'}],
+    ]
+
+    for (const [caption, input] of hostile) {
+        test(caption, () => {
+            expect(() => normalizeSession(input)).not.toThrow()
+        })
+    }
+
+    test('a malformed colorScale string coerces to whatever the parser makes of it, and does not throw', () => {
+        expect(() => normalizeSession({colorScale: 'not-a-color-scale'})).not.toThrow()
+    })
+})
+
+/**
+ * Running the stage twice must be the identity — #535 will move the call to the
+ * entry, and until then both a host's `init` and the restore it drives can reach
+ * the same document.
+ */
+test('normalizing an already-normalized session changes nothing further', () => {
+
+    const once = normalizeSession({url: 'a.hic', colorScale: '2000,255,0,0', backgroundColor: '10,20,30'})
+    const snapshot = {...once, colorScale: once.colorScale, backgroundColor: once.backgroundColor}
+
+    normalizeSession(once)
+
+    expect(once).toEqual(snapshot)
+    expect(once.colorScale).toBe(snapshot.colorScale)
+    expect(once.backgroundColor).toBe(snapshot.backgroundColor)
+})


### PR DESCRIPTION
Closes #532. Candidate 9, ticket 1 of 5 — parent #466.

## What changed

Browser-level normalization had no name and no module: two unexported functions inside `createBrowser.js`, called once per browser, so the only way to ask what a config resolves to was to build a browser and read it back.

`js/normalizeSession.js` now holds it — the chrome-visibility defaults (with the `figureMode` special case) and the `colorScale`/`backgroundColor` coercions, moved **verbatim** behind one session-shaped entry point. It walks `session.browsers || [session]`, the same shape convention `expandSessionUrlShortcuts` uses, so a single-browser config is a session with its one browser inlined. Both browser-creation entry points delegate to it, and `createBrowserList` now normalizes the document once rather than each config inside its loop.

## Two decisions worth reviewing

**`createBrowser` wraps rather than relies on the shape convention.** It handed its argument straight to the session-shaped stage, so a browser config carrying a member spelled `browsers` would have had its children normalized and itself left undefaulted — on the one entry path that takes a browser config and only a browser config, and whose `browser.config` juicebox-web reads back (ADR-0003). It now says what it knows: `normalizeSession({browsers: [config]})`. The shape convention is a reading of a *document*, not a test an object passes.

**"Pure" means free of the world, not free of mutation.** The stage rewrites the host's own object and returns it, because `browser.config` *is* the object the host passed. Copying instead would move `sameObjectAsInput` in #531's golden file — a consumer-visible change, and not this ticket's to make.

Also in the second commit: `setChromeDefaults` → `setWidgetVisibilityDefaults` (CONTEXT.md calls these things widgets); dropped an unused default export; `test/data/configEntryPathCorpus.js` no longer names `normalizeConfig` and `setDefaults`, which don't exist.

## What did not move

Nothing crosses the decode/normalize seam here. `fixDefaults`, the `selectedGene` reconciliation and the second shortcut expansion are still on the decoder's side — #533 and #534.

## Verification

- **#531's snapshots come back byte-identical.** None was updated. That is the acceptance test for this candidate: normalization changes are exactly the kind that move resolved output, so an unmoved snapshot is the evidence that this extraction changed nothing.
- `test/testNormalizeSession.js` — 23 tests driven from object literals: no browser, no DOM, no network, nothing stubbed. Including the criterion the golden file can only show by accident, that normalize rejects nothing.
- Full suite green: **820 tests, 39 files**.

## Acceptance criteria (#532)

- [x] Normalization lives in its own module as a pure function over a session document
- [x] Both browser-creation entry points delegate to it; no other behaviour changes
- [x] It handles the single-browser-config and multi-browser-session shapes alike
- [x] Unit tests drive it with plain object literals — no browser, no DOM, no network
- [x] It applies no validation and rejects nothing
- [x] #531's snapshots come back byte-identical
- [x] Full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)