### PR TITLE
Normalize once, at the entry (#535)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -170,10 +170,18 @@ applying defaults, expanding URL shortcuts, reconciling a selected gene — and 
 reached by every entry path, including a session handed straight to
 `restoreSession`. Format knowledge never crosses into normalize.
 
-**Entry path** — one of the four doors a config comes in by: `hic.init`,
-`hic.restoreSession`, `createBrowser` and `createBrowserList`. All four accept a
-single browser config, since `createBrowserList` reads `session.browsers ||
-[session]`; the query/URL form reaches `HICBrowser` through `init`.
+**Entry path** — one of the doors a config comes in by: `hic.init`,
+`hic.restoreSession`, `BrowserRegistry.restoreSession` and `createBrowser`. The
+query/URL form reaches `HICBrowser` through `init`, and the three session-shaped
+doors all arrive at `BrowserRegistry.restoreSession`, so there are two places a
+session is resolved and no path meets both (#535). All of them accept a single
+browser config, since a session with its one browser inlined is the shape
+`session.browsers || [session]` reads.
+
+`createBrowserList` was a fifth door until #535 and is now *below* the seam: it
+builds an embed's browsers from a session its caller has already resolved.
+`test/testConfigGolden.js` still snapshots it as a column, because what it hands
+a browser is where the other columns end too.
 
 **Resolved config** — a browser config *after* every normalizer upstream of
 `HICBrowser` has had it, which is the object `browser.config` then holds. Not a

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -185,9 +185,12 @@ pins the disagreements (#531, candidate 9). Four of them are closed: #533 moved
 track defaults, the selected-gene hoist and the `syncDatasets` resolution behind
 the shared normalize stage, and #534 collapsed the URL-shortcut expansion — it
 was written twice, in the decoder and in `restoreSession`, and is written once,
-in normalize, now. What is left is *when* the stage runs: every entry path meets
-it, but `restoreSession` and `createBrowserList` each call it on the same
-document (#535), and `HICBrowser` still defaults fields inline (#536).
+in normalize, now. #535 settled *when* the stage runs: once per session, at the
+entry — `BrowserRegistry.restoreSession` for a session, `createBrowser` for a
+single browser config — and browser creation below them normalizes nothing.
+`test/testNormalizeOnceAtTheEntry.js` counts the calls, since a second one is
+invisible in the result. What is left is that `HICBrowser` still defaults fields
+inline (#536).
 
 **Dispose** vs **reset** vs **clear dataset** — the three teardown verbs, in
 descending order of how much they destroy. See `docs/adr/0005`.

--- a/docs/architecture-map.html
+++ b/docs/architecture-map.html
@@ -322,7 +322,7 @@ flowchart TB
         <article class="rounded-lg border-4 border-amber-600 bg-white overflow-hidden">
           <div class="bg-amber-50 px-5 py-3 border-b-4 border-amber-600 flex flex-wrap items-baseline gap-x-4">
             <h3 class="font-serif text-2xl">normalizeSession / normalizeConfig</h3>
-            <span class="text-xs uppercase tracking-wider text-amber-900 font-semibold">Underway — you are here · candidate 9 · #531–#534 landed, #535–#536 open</span>
+            <span class="text-xs uppercase tracking-wider text-amber-900 font-semibold">Underway — you are here · candidate 9 · #531–#535 landed, #536 open</span>
           </div>
           <div class="p-5 space-y-4 text-sm">
             <p class="font-mono text-xs text-slate-500">js/normalizeSession.js · still to draw from js/hicBrowser.js (constructor, init), js/dataLoader.js</p>
@@ -334,14 +334,14 @@ flowchart TB
                 <div class="text-xs uppercase tracking-wider text-rose-900">Today — several readers, no schema</div>
                 <p><s><span class="font-mono">syncDatasets</span> is honoured by <span class="font-mono">createBrowserList</span> and absent from <span class="font-mono">createBrowser</span>.</s> Resolved at session level in normalize — <strong>#533</strong>.</p>
                 <p><s><span class="font-mono">fixDefaults</span> runs on the URL path only — <span class="font-mono">restoreSession</span> skips it.</s> Moved to <span class="font-mono">normalizeSession.applyTrackDefaults</span>, which every door meets — <strong>#533</strong>. What <strong>#525</strong> still asks is whether forcing every track to <span class="font-mono">COLLAPSED</span> is right at all; it is no longer a disagreement between paths.</p>
-                <p>Normalization is applied at <span class="font-mono">init:156</span> and re-validated at <span class="font-mono">:176</span>.</p>
+                <p><s>Normalization runs inside browser creation, and the same document meets the stage twice — once in <span class="font-mono">restoreSession</span>, again in <span class="font-mono">createBrowserList</span>.</s> Lifted to the entry: two doors, <span class="font-mono">BrowserRegistry.restoreSession</span> and <span class="font-mono">createBrowser</span>, and nothing below them normalizes — <strong>#535</strong>.</p>
                 <p><s>URL-shortcut expansion runs <strong>twice</strong> — once on the URL path, again in <span class="font-mono">restoreSession</span>.</s> Both copies deleted; the survivor is <span class="font-mono">normalizeSession.expandUrlShortcuts</span>, so the two doors that never expanded now do — <strong>#534</strong>.</p>
               </div>
               <div class="rounded border border-emerald-400 bg-emerald-50 p-4 space-y-2">
                 <div class="text-xs uppercase tracking-wider text-emerald-800">Target — normalize once, at the entry</div>
                 <p class="font-mono text-xs">normalizeConfig(raw) → resolved config</p>
                 <p>Pure. Every default in one place, one schema, testable with object literals. Downstream consumers <em>read fields</em> — none of them default, none of them validate (<strong>#536</strong>).</p>
-                <p>All four entry paths — <span class="font-mono">hic.init</span>, <span class="font-mono">restoreSession</span>, <span class="font-mono">createBrowser</span>, <span class="font-mono">createBrowserList</span> — pass through it and agree.</p>
+                <p>Every entry path — <span class="font-mono">hic.init</span>, the query path, <span class="font-mono">restoreSession</span>, <span class="font-mono">createBrowser</span> — passes through it <em>exactly once</em>, and they agree. <span class="font-mono">createBrowserList</span> is no longer one of them: it builds browsers from a session its caller resolved (<strong>#535</strong>).</p>
               </div>
             </div>
 

--- a/docs/juicebox-punch-list.md
+++ b/docs/juicebox-punch-list.md
@@ -61,7 +61,7 @@ Each card carries a Consumer impact block; read it before filing anything.
 
 | Candidate | Status |
 |---|---|
-| **9 · Give the config schema one reader** | **filed — #531–#536**; #531–#534 landed, frontier is #535. Seam already drawn by ADR-0006 decision 8; no ADR opened |
+| **9 · Give the config schema one reader** | **filed — #531–#536**; #531–#535 landed, frontier is #536. Seam already drawn by ADR-0006 decision 8; no ADR opened |
 | **11 · Give the track tile one owner** | ⚠️ breaking |
 | **6 · Fold StateManager into State, and make restore use the chokepoint** | watch |
 | **7 · Move the gesture state machines behind InteractionHandler** | watch |
@@ -94,8 +94,8 @@ next free number.
 | #532 | Extract `normalizeSession`: a pure, session-shaped normalize stage | #531 — **landed** |
 | #533 | Move the remaining normalization across the seam | #532 — **landed** |
 | #534 | Delete the duplicate URL-shortcut expansion | #533 — **landed** |
-| #535 | Normalize once, at the entry | #533 — **frontier** |
-| #536 | Downstream readers stop defaulting, and the schema is written down | #535 |
+| #535 | Normalize once, at the entry | #533 — **landed** |
+| #536 | Downstream readers stop defaulting, and the schema is written down | #535 — **frontier** |
 
 #534 and #535 run in parallel after #533. **#533 and #534 are the two tickets that deliberately move
 snapshots.** #533 closes three divergences at once: track defaults skipped by `restoreSession`, the

--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -320,13 +320,20 @@ class BrowserRegistry {
 
         this.deleteAll()
 
-        // Normalized here as well as inside `createBrowserList`, because this
-        // method reads a session-level member -- the selected gene -- that the
-        // stage resolves: a document naming a gene only inside one of its
+        // The session-shaped entry, and since #535 the only place a restored
+        // session is normalized: `createBrowserList` below used to do it again,
+        // over a document this line had already resolved. Every session-shaped
+        // door arrives here -- `hic.init`, the query path it delegates to,
+        // `hic.restoreSession`, and this method reached directly off a registry
+        // -- so one call here is one call per session, and everything past it
+        // reads a resolved config rather than re-interpreting a raw one.
+        //
+        // It has to run before the next line rather than inside the creation it
+        // drives, because this method *reads* a session-level member the stage
+        // resolves: a document naming a selected gene only inside one of its
         // browsers has to have been hoisted before the line below looks for one
-        // (#533, #481). The stage is idempotent and rewrites the caller's own
-        // object, so the second call inside `createBrowserList` finds its work
-        // done; #535 collapses the two into one call at the entry.
+        // (#533, #481). Resolving the session and then reading it is the order
+        // the seam is for.
         //
         // This one call is also what expands the URL shortcuts a session may
         // carry. That was a second `expandSessionUrlShortcuts(session)` line

--- a/js/createBrowser.js
+++ b/js/createBrowser.js
@@ -20,6 +20,24 @@ const defaultSize = { width: 640, height: 640 };
  * `docs/adr/0004-browser-registry-per-container.md`.
  */
 
+/**
+ * The published single-browser door, and one of the two places a session is
+ * resolved. #535.
+ *
+ * The two lines below are the seam: **above it a config is decided, below it a
+ * config is read.** `buildBrowser` and `createBrowserList` are the below half --
+ * neither normalizes, because by the time either runs the document it is handed
+ * has been through the stage exactly once. The other door is
+ * `BrowserRegistry.restoreSession`, which every session-shaped entry reaches:
+ * `hic.init`, the query path it delegates to, and `hic.restoreSession`.
+ *
+ * ## Why the entry has two doors rather than one function
+ *
+ * Both are published surface (`js/publicApi.js`), so neither can be hidden
+ * behind the other, and they take different shapes: a session for the restore, a
+ * single browser config here. Two calls, one stage, and no path reaching both --
+ * `createBrowser` adds a browser to a registry, it does not restore an embed.
+ */
 async function createBrowser(hicContainer, config, callback) {
 
     // A single browser config *is* a session with its one browser inlined, and
@@ -38,11 +56,19 @@ async function createBrowser(hicContainer, config, callback) {
     // So a session-level rule that writes *down* onto the browsers reaches
     // `config` -- `syncDatasets` does -- and one that writes *up* onto the
     // session lands on the discarded copy. Only the selected-gene hoist writes
-    // up, and this door has no registry to give it to: `createBrowser` adds a
-    // browser to a registry rather than restoring an embed's session, and it is
+    // up, and this door has no registry to give it to: it is
     // `BrowserRegistry.restoreSession` that owns the gene. Nothing is lost here
     // that anything reads.
     normalizeSession({...config, browsers: [config]});
+
+    return buildBrowser(hicContainer, config, callback);
+}
+
+/**
+ * Build one browser from a config that has already been resolved, and register
+ * it. Below the seam: it reads the config, it does not decide it.
+ */
+async function buildBrowser(hicContainer, config, callback) {
 
     const browser = new HICBrowser(hicContainer, config);
     await browser.init(config);
@@ -54,17 +80,19 @@ async function createBrowser(hicContainer, config, callback) {
     return browser;
 }
 
+/**
+ * Build an embed's browsers from a session that has already been resolved.
+ *
+ * Below the seam, and internal: this is not exported from `js/index.js`, and its
+ * one caller is `BrowserRegistry.restoreSession`, which is where the session
+ * this walks was normalized. It used to normalize too -- a second call over a
+ * document the restore had already resolved, harmless only because the stage is
+ * idempotent -- and #535 is the ticket that removed it. What is left is a loop
+ * that reads `browsers || [session]` and nothing that interprets a field.
+ */
 async function createBrowserList(hicContainer, session) {
 
     const registry = registryForContainer(hicContainer);
-
-    // One call for the whole document: the stage walks the same
-    // `browsers || [session]` shape this loop does, and since #533 it resolves
-    // the session-level members too -- `syncDatasets` was translated into a
-    // per-browser `synchable` here, which is why the same document opted out of
-    // the sync group through this door and not through `createBrowser`.
-    // See js/normalizeSession.js.
-    normalizeSession(session);
 
     const configList = session.browsers || [session];
     const initPromises = [];

--- a/js/createBrowser.js
+++ b/js/createBrowser.js
@@ -67,6 +67,13 @@ async function createBrowser(hicContainer, config, callback) {
 /**
  * Build one browser from a config that has already been resolved, and register
  * it. Below the seam: it reads the config, it does not decide it.
+ *
+ * `createBrowserList` does not call this, and the near-repetition is deliberate:
+ * it registers each browser *before* initializing it, because loading a dataset
+ * consults the registry, and it initializes the whole list in parallel. This one
+ * adds an initialized browser to a registry that already has browsers in it.
+ * Folding them together would mean parameterizing the order of two calls, which
+ * is how a two-line difference becomes a flag.
  */
 async function buildBrowser(hicContainer, config, callback) {
 

--- a/js/normalizeSession.js
+++ b/js/normalizeSession.js
@@ -40,13 +40,25 @@
  * members, so a session-level rule reaches a one-browser document handed in at
  * that door exactly as it reaches a document naming `browsers`.
  *
+ * ## Where it is called, and how often
+ *
+ * Once per session, at the entry, which is #535. There are two doors and they do
+ * not nest: `BrowserRegistry.restoreSession` for a session -- every
+ * session-shaped path arrives there, `hic.init`, the query path and
+ * `hic.restoreSession` alike -- and `createBrowser` for a single browser config.
+ * Browser creation below them normalizes nothing. `test/testNormalizeOnceAtTheEntry.js`
+ * counts the calls, because a second one is invisible in the result.
+ *
  * ## Running it twice is the identity
  *
- * `BrowserRegistry.restoreSession` normalizes -- it reads a session member the
- * stage resolves -- and then `createBrowserList` normalizes the same document
- * again on its way to the browsers. Every rule here is therefore idempotent, and
- * `test/testNormalizeSession.js` asserts it. #535 collapses the two calls into
- * one at the entry; until then the property is load-bearing.
+ * Invisible because every rule here is idempotent, which
+ * `test/testNormalizeSession.js` asserts. That property was load-bearing until
+ * #535 -- the restore normalized and then `createBrowserList` normalized the
+ * same document again -- and it is kept deliberately now that nothing in this
+ * repo depends on it: a host is free to hand the same object to `init` twice, or
+ * to `createBrowser` after `restoreSession`, and the mutation is in place, so a
+ * stage that drifted on a second pass would rewrite an object the host still
+ * holds.
  *
  * ## "Pure" here means free of the world, not free of mutation
  *

--- a/test/data/configEntryPathCorpus.js
+++ b/test/data/configEntryPathCorpus.js
@@ -91,7 +91,7 @@ export const configFixtures = [
     {
         id: 'url-shortcuts-in-map-control-and-track',
         note: 'The `*s3/` and `*enc/` shortcuts, in all three places a session can carry one.',
-        divergence: '**Closed by #534.** Expansion happened in `BrowserRegistry.restoreSession`, so the two paths that go through a registry restore expanded and the two browser-creation paths reached directly did not — a host calling `hic.createBrowser` with a shortcut URL handed an unexpanded `*s3/…` straight to the loader. Both copies of the expansion are gone and `normalizeSession` is the survivor, so all four doors expand; the two that did not are the snapshot movement logged in `testConfigGolden.js`. #535 moves the normalize call itself to the entry.',
+        divergence: '**Closed by #534.** Expansion happened in `BrowserRegistry.restoreSession`, so the two paths that go through a registry restore expanded and the two browser-creation paths reached directly did not — a host calling `hic.createBrowser` with a shortcut URL handed an unexpanded `*s3/…` straight to the loader. Both copies of the expansion are gone and `normalizeSession` is the survivor, so all four doors expand; the two that did not are the snapshot movement logged in `testConfigGolden.js`. #535 then moved the normalize call itself to the entry, without moving this fixture: `createBrowserList` is below the seam now and its driver resolves the session the way its one production caller does.',
         config: {
             url: '*s3/hiseq/gm12878/in-situ/HIC009.hic',
             controlUrl: '*s3e_/wapl_hic/WT.hic',

--- a/test/data/configEntryPathCorpus.js
+++ b/test/data/configEntryPathCorpus.js
@@ -18,7 +18,7 @@
  * `test/testConfigGolden.js`, snapshots what each entry path actually produces.
  *
  * Every fixture is a *single browser config*, deliberately, because all four
- * entry paths accept that shape: `createBrowserList` reads `session.browsers ||
+ * columns accept that shape: the session-shaped ones read `session.browsers ||
  * [session]`, so a bare config is a one-browser session. That is what lets one
  * snapshot hold all four paths side by side and makes a divergence a visible
  * difference between columns rather than a claim in a comment. Fixtures that are

--- a/test/testConfigGolden.js
+++ b/test/testConfigGolden.js
@@ -68,6 +68,7 @@ import DataLoader from '../js/dataLoader.js'
 import {init} from '../js/init.js'
 import {restoreSession} from '../js/session.js'
 import {createBrowser, createBrowserList} from '../js/createBrowser.js'
+import {normalizeSession} from '../js/normalizeSession.js'
 import {registryForContainer} from '../js/browserRegistry.js'
 import {withContainers} from './utils/browserFixture.js'
 import {withStubbedLoads} from './utils/stubbedLoads.js'
@@ -170,7 +171,12 @@ function describeBrowser(browser, input) {
 }
 
 /**
- * The four doors a config can come in by.
+ * The four ways a config reaches a browser.
+ *
+ * Three are doors -- published entry points a host calls. The fourth,
+ * `createBrowserList`, stopped being one at #535 and is now the builder the
+ * session-shaped doors end in; see its note below for why it stays in the table
+ * and what its driver has to do that the others do not.
  *
  * All four take a single browser config: `createBrowserList` reads
  * `session.browsers || [session]`, so a bare config is a one-browser session,
@@ -214,8 +220,20 @@ const ENTRY_PATHS = [
     {
         name: 'createBrowserList(container, session)',
         sessionShaped: true,
+        // **Below the seam since #535**, and the one column here that is not a
+        // door: `createBrowserList` is internal, and it no longer normalizes --
+        // its one production caller, `BrowserRegistry.restoreSession`, does that
+        // before calling it. So the driver does what that caller does, and the
+        // column goes on characterizing what it always characterized: the config
+        // the *builder* hands a browser, which is where the other three columns
+        // end too. That is why these snapshots did not move when the call did.
+        //
+        // The normalize call belongs to the driver rather than to the path list
+        // because it is not part of what is being measured. `testNormalizeOnceAtTheEntry.js`
+        // is where the count lives, and it asserts this function normalizes
+        // nothing.
         run: async (container, config) => {
-            await createBrowserList(container, config)
+            await createBrowserList(container, normalizeSession(config))
         },
     },
 ]

--- a/test/testNormalizeOnceAtTheEntry.js
+++ b/test/testNormalizeOnceAtTheEntry.js
@@ -1,0 +1,201 @@
+/**
+ * The normalize stage runs once per session, at the entry. #535.
+ *
+ * `test/testNormalizeSession.js` drives the stage itself and `testConfigGolden.js`
+ * pins what it produces. Neither can say *how many times* it ran: the stage is
+ * idempotent, so a second call is invisible in the result. That is exactly why
+ * this file exists -- the claim #535 makes is about the shape of the pipeline,
+ * not about a value, and the only way to see it is to count.
+ *
+ * ## What it counts, and why the stage is mocked to do it
+ *
+ * The module is replaced by a counting wrapper over the real thing, so every
+ * importer -- `browserRegistry.js`, `createBrowser.js` -- is counted whichever
+ * one of them happens to call. Spying on an export after the fact would not
+ * work: the importers hold the binding they imported.
+ *
+ * The wrapper delegates to the actual implementation rather than stubbing it, so
+ * these tests drive a real, resolved config all the way to a browser. A count
+ * taken over a stub would be a count over a pipeline that no longer works.
+ *
+ * ## The doors
+ *
+ * Every published way a config or session gets in is here, plus the query path,
+ * which is `init` with the URL in charge. `createBrowserList` is deliberately
+ * absent: since #535 it is *below* the seam -- it builds browsers from a session
+ * its caller has already resolved -- and the one thing this file would assert
+ * about it is that it does **not** normalize, which is the `zero` case at the
+ * end.
+ *
+ * @see js/normalizeSession.js
+ * @see test/testConfigGolden.js -- what the resolved config is
+ */
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+const {calls} = vi.hoisted(() => ({calls: []}))
+
+vi.mock('../js/normalizeSession.js', async importOriginal => {
+
+    const actual = await importOriginal()
+
+    return {
+        ...actual,
+        normalizeSession: session => {
+            calls.push(session)
+            return actual.normalizeSession(session)
+        },
+    }
+})
+
+import {createBrowser, createBrowserList} from '../js/createBrowser.js'
+import {init} from '../js/init.js'
+import {restoreSession} from '../js/session.js'
+import {registryForContainer} from '../js/browserRegistry.js'
+import {withContainers} from './utils/browserFixture.js'
+import {withStubbedLoads} from './utils/stubbedLoads.js'
+import {selfContained} from './data/wireFormatCorpus.js'
+
+/**
+ * A published link, taken from the wire-format corpus rather than written here,
+ * so the query column is driven by a URL that is known to decode.
+ */
+const QUERY_URL = selfContained.find(fixture => fixture.id === 'harvested-query-wapl-wt').input
+
+/**
+ * A host-shaped config with something to normalize in every stage: a shortcut to
+ * expand, a string to coerce, a track to default, and a session member to
+ * resolve. If a door skipped the stage, this is the config that would show it.
+ */
+function hostConfig() {
+    return {
+        url: '*s3/aidenlab/hic/GM12878.hic',
+        name: 'GM12878',
+        colorScale: '2000,255,0,0',
+        tracks: [{url: '*s3e/GM12878_CTCF.bed', name: 'CTCF', color: 'rgb(22, 129, 198)'}],
+    }
+}
+
+function sessionDocument() {
+    return {browsers: [hostConfig(), {url: 'https://example.org/b.hic', name: 'B'}]}
+}
+
+/**
+ * Everything a resolved config carries that an unresolved one does not, asserted
+ * beside the count so that "exactly once" cannot be satisfied by "not at all".
+ */
+function expectResolved(browser) {
+    expect(browser.config.showLocusGoto).toBe(true)
+    expect(browser.config.url).toBe('https://hicfiles.s3.amazonaws.com/aidenlab/hic/GM12878.hic')
+    expect(typeof browser.config.colorScale).not.toBe('string')
+    expect(browser.config.tracks[0].color).toBeUndefined()
+}
+
+describe('every entry path normalizes exactly once', () => {
+
+    const dom = withContainers()
+    withStubbedLoads()
+
+    beforeEach(() => {
+        calls.length = 0
+    })
+
+    test('hic.init(container, config)', async () => {
+
+        dom.navigate('http://localhost/host.html')
+        await init(dom.another(), hostConfig())
+
+        expect(calls).toHaveLength(1)
+    })
+
+    test('hic.init(container, {}) with the URL in charge', async () => {
+
+        dom.navigate(QUERY_URL)
+        await init(dom.another(), {})
+
+        expect(calls).toHaveLength(1)
+    })
+
+    test('hic.restoreSession(container, session)', async () => {
+
+        await restoreSession(dom.another(), sessionDocument())
+
+        expect(calls).toHaveLength(1)
+    })
+
+    test('registry.restoreSession(session) reached directly', async () => {
+
+        await registryForContainer(dom.another()).restoreSession(sessionDocument())
+
+        expect(calls).toHaveLength(1)
+    })
+
+    test('hic.createBrowser(container, config)', async () => {
+
+        await createBrowser(dom.another(), hostConfig())
+
+        expect(calls).toHaveLength(1)
+    })
+
+    /**
+     * The Spacewalk sequence -- `init(container, {})` and then a restore into the
+     * same embed -- is two entries, and so two normalizations of two different
+     * documents. Counted here because "once per session" is the claim, not "once
+     * per page".
+     */
+    test('a restore into a live embed is a second entry, not a second pass over the first', async () => {
+
+        const container = dom.another()
+
+        dom.navigate('http://localhost/host.html')
+        await init(container, {})
+        expect(calls).toHaveLength(1)
+
+        const session = sessionDocument()
+        await restoreSession(container, session)
+
+        expect(calls).toHaveLength(2)
+        expect(calls[1]).toBe(session)
+    })
+
+    test('the config a browser is built from is the resolved one', async () => {
+
+        const browser = await createBrowser(dom.another(), hostConfig())
+
+        expectResolved(browser)
+    })
+
+    test('and so is every browser of a restored session', async () => {
+
+        const container = dom.another()
+        await restoreSession(container, sessionDocument())
+
+        expectResolved(registryForContainer(container).browsers[0])
+    })
+})
+
+/**
+ * The other half of "at the entry": the browser-building step below the seam
+ * does not normalize, so nothing downstream re-interprets a config that has
+ * already been resolved.
+ *
+ * `createBrowserList` is internal -- it is not in `js/index.js` and its one
+ * production caller is `BrowserRegistry.restoreSession`, which is the door. It
+ * is driven here rather than described, because "the stage moved up" and "the
+ * stage was copied up" look identical from every other test in the repo.
+ */
+describe('browser creation does not normalize', () => {
+
+    const dom = withContainers()
+    withStubbedLoads()
+
+    beforeEach(() => {
+        calls.length = 0
+    })
+
+    test('createBrowserList takes a session its caller has already resolved', async () => {
+
+        await createBrowserList(dom.another(), sessionDocument())
+
+        expect(calls).toHaveLength(0)
+    })
+})

--- a/test/testNormalizeOnceAtTheEntry.js
+++ b/test/testNormalizeOnceAtTheEntry.js
@@ -83,6 +83,17 @@ function sessionDocument() {
  * Everything a resolved config carries that an unresolved one does not, asserted
  * beside the count so that "exactly once" cannot be satisfied by "not at all".
  */
+/**
+ * A resolved config as comparable data: the members the stage writes, and the
+ * tracks it defaults, flattened one level so a second pass shows as a diff.
+ */
+function resolvedShape(config) {
+    return {
+        ...config,
+        tracks: config.tracks.map(track => ({...track})),
+    }
+}
+
 function expectResolved(browser) {
     expect(browser.config.showLocusGoto).toBe(true)
     expect(browser.config.url).toBe('https://hicfiles.s3.amazonaws.com/aidenlab/hic/GM12878.hic')
@@ -156,6 +167,46 @@ describe('every entry path normalizes exactly once', () => {
         expect(calls).toHaveLength(2)
         expect(calls[1]).toBe(session)
     })
+
+    /**
+     * "Exactly once" is a claim about this repo's pipeline; a host has its own,
+     * and nothing stops it handing the same object through two doors. That is
+     * the case idempotence is actually kept for now that no internal caller
+     * needs it (`js/normalizeSession.js`), and it is asserted over a real object
+     * driven through real doors rather than over a literal, because the stage
+     * rewrites the host's own object *in place* -- the second pass is a rewrite
+     * of something the host still holds.
+     *
+     * `resolvedShape` is compared rather than the object itself because a
+     * browser's `init` writes to a config too, and what is being asserted is
+     * that the second trip through the stage leaves what the first one produced.
+     */
+    const sequences = [
+        ['init twice into the same embed', async (dom, config) => {
+            const container = dom.another()
+            dom.navigate('http://localhost/host.html')
+            await init(container, config)
+            return async () => { await init(container, config) }
+        }],
+        ['restoreSession, then createBrowser with the same object', async (dom, config) => {
+            await restoreSession(dom.another(), config)
+            return async () => { await createBrowser(dom.another(), config) }
+        }],
+    ]
+
+    for (const [caption, drive] of sequences) {
+        test(`a host reaching two doors with one object does not drift — ${caption}`, async () => {
+
+            const config = hostConfig()
+            const again = await drive(dom, config)
+
+            const afterFirst = resolvedShape(config)
+            await again()
+
+            expect(resolvedShape(config)).toEqual(afterFirst)
+            expect(config.colorScale).toBe(afterFirst.colorScale)
+        })
+    }
 
     test('the config a browser is built from is the resolved one', async () => {
 

--- a/test/testNormalizeSession.js
+++ b/test/testNormalizeSession.js
@@ -450,9 +450,15 @@ describe('normalize rejects nothing', () => {
 })
 
 /**
- * Running the stage twice must be the identity — #535 will move the call to the
- * entry, and until then both a host's `init` and the restore it drives can reach
- * the same document.
+ * Running the stage twice must be the identity.
+ *
+ * #535 moved the call to the entry, so nothing in this repo normalizes the same
+ * document twice any more — `test/testNormalizeOnceAtTheEntry.js` counts the
+ * calls and holds that line. The property is kept for the caller this file
+ * cannot see: a host may hand the same object to `init` twice, or to
+ * `createBrowser` after a restore, and the stage rewrites the host's own object,
+ * so drift on a second pass would be a rewrite of something the host still
+ * holds.
  */
 test('normalizing an already-normalized session changes nothing further', () => {
 
@@ -467,10 +473,14 @@ test('normalizing an already-normalized session changes nothing further', () => 
 })
 
 /**
- * The same property over what #533 moved in, and it is load-bearing rather than
- * decorative: `BrowserRegistry.restoreSession` normalizes so that the gene it
- * reads has been hoisted, and then `createBrowserList` normalizes the same
- * document again on its way to the browsers.
+ * The same property over what #533 moved in — the gene hoist, the `syncDatasets`
+ * resolution and the track defaults, all of which write rather than merely
+ * default, and so are where a second pass would be most likely to show.
+ *
+ * This was the load-bearing case until #535: the restore normalized so that the
+ * gene it reads had been hoisted, and `createBrowserList` normalized the same
+ * document again on its way to the browsers. The second call is gone; the
+ * property is kept for the same reason as the one above.
  */
 test('normalizing an already-normalized session document changes nothing further', () => {
 


### PR DESCRIPTION
Closes #535. Candidate 9 (#466), and the last ticket before #536.

## What moved

The normalize stage ran inside browser creation, and the same document met it twice: `BrowserRegistry.restoreSession` normalized so it could read the selected gene it hoists, then `createBrowserList` normalized the same session again on its way to the browsers. Harmless only because every rule in the stage is idempotent.

It runs once per session now, at the entry. **Two doors, and they do not nest:**

- `BrowserRegistry.restoreSession` — every session-shaped path arrives there: `hic.init`, the query path it delegates to, and `hic.restoreSession`
- `createBrowser` — the single browser config door

Both are published surface (`js/publicApi.js`), so neither can hide behind the other, and no path reaches both. Below them, `createBrowserList` and the extracted `buildBrowser` read a resolved config rather than deciding one — which is the seam the candidate is for: above it one place decides what a config means, below it consumers read fields.

## The snapshots did not move

`testConfigGolden.js` comes back byte-identical, `browser.config` read back off the instance included — there is no `.snap` in this diff. Nothing about what a config resolves to changed, and nothing is rejected that was accepted before.

Its fourth column drives `createBrowserList`, which stopped being a door here. The driver now resolves the session first, the way that function's one production caller does, so the column goes on characterizing what the *builder* hands a browser — which is where the other three columns end too. The cost, named rather than hidden: that column now largely duplicates the registry-restore column, and the seam's real guard is the new zero-count test.

## The new test is the only thing that can see this change

The stage is idempotent, so a second call is invisible in the result — the claim is about the shape of the pipeline, not about a value. `test/testNormalizeOnceAtTheEntry.js` mocks the module with a counting wrapper over the real implementation and asserts one call per door, zero for `createBrowserList`, and that what reaches a browser is resolved.

Idempotence is kept rather than retired with its last internal caller: the stage mutates the host's own object, so drift on a second pass would rewrite something a host still holds. Two sequences now drive one real config through two real doors — `init` twice, and `restoreSession` then `createBrowser` — instead of claiming the property in a comment. Mutation-checked: a non-idempotent rule in `normalizeBrowserConfig` fails both.

## Review

`/code-review`, two axes. Standards found one hard violation — `CONTEXT.md`'s **entry path** glossary entry still said four doors, which `docs/agents/domain.md` makes the vocabulary the rest of the repo uses. Fixed, with the corpus header that named the columns entry paths. Spec found idempotence across doors asserted in prose only; that is what the two sequences cover. Spec judged the `createBrowserList` driver change a faithful reading rather than a dodge — driving it raw would have moved that column to record a state no host can reach.

Left as reviewed: `ENTRY_PATHS` keeps its name, where the column's own comment says it is not a door.

Full suite: 40 files, 863 tests, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)