### PR TITLE
Fix #510: State.default supplies all seven constructor arguments

### DIFF
--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -116,11 +116,11 @@ class DataLoader {
 
             let state;
             if (config.locus) {
-                state = State.default(config);
+                state = State.default();
                 this.browser.setActiveDataset(dataset, state);
                 await this.browser.parseGotoInput(config.locus);
             } else if (config.state) {
-                state = decodeState(config.state, config, reportUnknownStateType);
+                state = decodeState(config.state, reportUnknownStateType);
 
                 this.browser.setActiveDataset(dataset, state);
                 await this.browser.setState(state);
@@ -132,7 +132,7 @@ class DataLoader {
                     this.browser.setActiveDataset(dataset, state);
                 }
             } else {
-                state = State.default(config);
+                state = State.default();
                 this.browser.setActiveDataset(dataset, state);
                 await this.browser.setState(state);
             }
@@ -254,7 +254,7 @@ class DataLoader {
             // differently here and had lost the unknown-type rung, so a numeric
             // `state` crashed in `State.parse` on this path and opened the
             // default view on the other. #504.
-            const state = decodeState(config.state, config, reportUnknownStateType);
+            const state = decodeState(config.state, reportUnknownStateType);
 
             this.browser.setActiveDataset(dataset, state);
             await this.browser.setState(state);

--- a/js/hicState.js
+++ b/js/hicState.js
@@ -536,8 +536,25 @@ class State {
         );
     }
 
-    static default(configOrUndefined) {
-        return new State(0, 0, 0, 0, 1, "NONE")
+    /**
+     * The fall-back view: the whole genome at the origin, one pixel per bin,
+     * unnormalized. It does not vary with the config, so it takes no argument.
+     *
+     * Every parameter is supplied explicitly because the previous form passed
+     * six arguments and the constructor's coercions hid the shift entirely —
+     * see #510 for the defect and ADR-0009's sequencing for why it landed
+     * before candidate 6's gate.
+     */
+    static default() {
+        return new State(
+            0,                      // chr1: whole genome
+            0,                      // chr2: whole genome
+            0,                      // zoom: coarsest resolution index
+            0,                      // x: bin origin
+            0,                      // y: bin origin
+            DEFAULT_PIXEL_SIZE,     // one pixel per bin, the browser-wide default
+            'NONE'                  // normalization
+        )
     }
 
 }

--- a/js/sessionCodec.js
+++ b/js/sessionCodec.js
@@ -346,22 +346,22 @@ export function encodeSession(session) {
  * original copy raised an `alert`, which is exactly the kind of thing that
  * makes a decoder untestable.
  *
+ * The default view is config-independent, so nothing about the config reaches
+ * it. The `config` this used to take and thread through to `State.default` was
+ * ignored there, and is gone from both (#510).
+ *
  * @param {string|object|undefined} value - `config.state`. Absent or empty
  *   yields the default view, which is the truthiness guard both call sites
  *   wrote around the ladder; delegating it here keeps `''` and `0` out of
  *   `State.parse`, where they decode to a view of `NaN`.
- * @param {object} [config] - passed through to `State.default`, which **ignores
- *   it** — a known defect (`hicState.js`, `State.default(configOrUndefined)`),
- *   filed separately per ADR-0006's consequences. Threaded anyway so that
- *   fixing it there fixes it for both call sites at once.
  * @param {function(*): void} [onUnknownType] - called with `value` when it is
  *   neither a string nor an object; the default view is returned either way
  * @returns {State}
  */
-export function decodeState(value, config, onUnknownType = () => {}) {
+export function decodeState(value, onUnknownType = () => {}) {
 
     if (!value) {
-        return State.default(config)
+        return State.default()
     }
 
     if (typeof value === 'string') {
@@ -374,7 +374,7 @@ export function decodeState(value, config, onUnknownType = () => {}) {
 
     onUnknownType(value)
 
-    return State.default(config)
+    return State.default()
 }
 
 // ---------------------------------------------------------------------------

--- a/test/testDefaultViewOrigin.js
+++ b/test/testDefaultViewOrigin.js
@@ -1,0 +1,91 @@
+/**
+ * A map opened with neither a locus nor a state falls back to the default view.
+ * That is the ordinary path for opening a map, and #510 had it opening one bin
+ * below the origin on the y axis — a shifted argument list that the
+ * constructor's coercions turned into a valid state rather than a crash.
+ *
+ * testState.js pins `State.default()`'s fields directly. This pins the door:
+ * the state `loadHicFile` actually hands the browser when the config names
+ * neither.
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+import State from '../js/hicState.js'
+import { DEFAULT_PIXEL_SIZE } from '../js/hicBrowser.js'
+
+const loadDataset = vi.fn()
+
+vi.mock('../js/hicDataset.js', () => ({
+    default: { loadDataset: (...args) => loadDataset(...args) },
+    HiCDataset: class {}
+}))
+
+const { default: DataLoader } = await import('../js/dataLoader.js')
+
+function stubDataset() {
+    return {
+        genomeId: 'hg19',
+        chromosomes: [
+            { name: 'All', size: 1000, index: 0 },
+            { name: 'chr1', size: 1000, index: 1 }
+        ],
+        datasetType: 'hic',
+        isCompatible: () => false
+    }
+}
+
+function stubBrowser(recorded) {
+    const browser = {
+        genome: undefined,
+        dataset: undefined,
+        clearDataset: () => undefined,
+        stopSpinner: () => undefined,
+        contactMatrixView: { startSpinner: () => undefined },
+        contactMapLabel: { textContent: '', title: '' },
+        userInteractionShield: { style: {} },
+        controlDataset: undefined,
+        coordinator: {
+            onNormalizationExternalChange: () => undefined,
+            onGenomeChange: () => undefined,
+            onNormVectorIndexLoad: () => undefined,
+            onMapLoaded: () => undefined
+        },
+        registry: { presentAlert: () => undefined, sync: () => undefined, browsers: [] },
+        setActiveDataset: (dataset, state) => {
+            browser.dataset = dataset
+            recorded.push(state)
+        },
+        setState: async () => undefined,
+        parseGotoInput: async () => undefined,
+        canBeSynched: () => false,
+        syncState: async () => undefined
+    }
+    return browser
+}
+
+describe('the default view a map opens at when the config names neither locus nor state', () => {
+
+    beforeEach(() => {
+        loadDataset.mockReset()
+        loadDataset.mockResolvedValue(stubDataset())
+    })
+
+    test('its y origin is zero, and every other field is the default', async () => {
+        const recorded = []
+        const dataLoader = new DataLoader(stubBrowser(recorded))
+
+        await dataLoader.loadHicFile({ url: 'https://example.org/a.hic' }, true)
+
+        expect(recorded).toHaveLength(1)
+
+        const [state] = recorded
+        expect(state.y).toBe(0)          // #510: this was 1
+        expect(state.x).toBe(0)
+        expect(state.chr1).toBe(0)
+        expect(state.chr2).toBe(0)
+        expect(state.zoom).toBe(0)
+        expect(state.pixelSize).toBe(DEFAULT_PIXEL_SIZE)
+        expect(state.normalization).toBe('NONE')
+        expect(state.toJSON()).toEqual(State.default().toJSON())
+    })
+})

--- a/test/testSessionCodec.js
+++ b/test/testSessionCodec.js
@@ -217,15 +217,15 @@ describe('decodeState', () => {
 
         test('the caller is told, and is handed the offending value', () => {
             const seen = []
-            decodeState(42, undefined, value => seen.push(value))
+            decodeState(42, value => seen.push(value))
             expect(seen).toEqual([42])
         })
 
         test('the reporter is not called for the types the ladder handles', () => {
             const seen = []
-            decodeState('1,2,4,10,20,3', undefined, v => seen.push(v))
-            decodeState({chr1: 0, chr2: 0}, undefined, v => seen.push(v))
-            decodeState(undefined, undefined, v => seen.push(v))
+            decodeState('1,2,4,10,20,3', v => seen.push(v))
+            decodeState({chr1: 0, chr2: 0}, v => seen.push(v))
+            decodeState(undefined, v => seen.push(v))
             expect(seen).toEqual([])
         })
     })

--- a/test/testState.js
+++ b/test/testState.js
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'vitest'
 import State from '../js/hicState.js'
 import InteractionHandler from '../js/interactionHandler.js'
+import {DEFAULT_PIXEL_SIZE} from '../js/hicBrowser.js'
 
 /**
  * Mock helpers for State characterization tests.
@@ -1163,5 +1164,33 @@ describe('Wire format — the `state` query parameter (docs/url.md)', () => {
 
         expect(State.parse('5,3,6,100,200,0,0,2,KR').toJSON())
             .toEqual(State.parse('3,5,6,200,100,0,0,2,KR').toJSON())
+    })
+})
+
+describe('State.default — the fall-back view', () => {
+
+    // The constructor takes seven parameters and coerces most of them, so an
+    // argument list that is one short still yields a valid State — it is just
+    // the wrong one. #510: six arguments shifted everything right of the zoom,
+    // and the default view opened one bin below the origin on the y axis with
+    // no test to notice. These assertions name every field, so a future shift
+    // fails loudly instead of being absorbed by the coercions.
+
+    test('every field of the default state has its intended value', () => {
+        const state = State.default()
+
+        expect(state.chr1).toBe(0)
+        expect(state.chr2).toBe(0)
+        expect(state.zoom).toBe(0)
+        expect(state.x).toBe(0)
+        expect(state.y).toBe(0)
+        expect(state.pixelSize).toBe(DEFAULT_PIXEL_SIZE)
+        expect(state.normalization).toBe('NONE')
+    })
+
+    test('the default pixel size is the browser-wide DEFAULT_PIXEL_SIZE', () => {
+        // Stated, not inferred: one pixel per bin is the whole-genome starting
+        // scale hicBrowser already names, not a value the shift left behind.
+        expect(State.default().pixelSize).toBe(DEFAULT_PIXEL_SIZE)
     })
 })

--- a/test/utils/stubbedLoads.js
+++ b/test/utils/stubbedLoads.js
@@ -26,7 +26,7 @@ export function withStubbedLoads() {
         vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
         vi.spyOn(DataLoader.prototype, 'loadHicFile').mockImplementation(async function (config) {
             this.browser.dataset = stubDataset(config)
-            this.browser.state = config.state ? State.fromJSON(config.state) : State.default(config)
+            this.browser.state = config.state ? State.fromJSON(config.state) : State.default()
         })
         vi.spyOn(DataLoader.prototype, 'loadTracks').mockImplementation(async () => undefined)
     })


### PR DESCRIPTION
Closes #510.

## The defect

`State.default()` passed six arguments to a seven-parameter constructor:

```js
return new State(0, 0, 0, 0, 1, "NONE")
```

Everything right of `x` shifted one place left — `y` took the pixel size, `pixelSize` took the normalization string, and `normalization` arrived undefined. The constructor's coercions then hid it completely: `"NONE"` parsed to `NaN` and clamped to a valid pixel size, and the undefined normalization defaulted to `NONE`. The resulting state was valid; it was just wrong. **Every default view opened one bin below the origin on the y axis.**

It is reached from four call sites — the fall-back whenever a config names neither a locus nor a state, which is the ordinary path for opening a map.

## The fix

Every parameter is now supplied explicitly and commented by name, with the pixel size stated as `DEFAULT_PIXEL_SIZE` rather than left as whatever the shift produced. One pixel per bin is confirmed intentional: it is the same constant `hicBrowser` already names as the starting scale.

`State.default(configOrUndefined)` also ignored its argument entirely. The default view is config-independent, so the parameter is gone — and with it the `config` that `decodeState` threaded through solely to reach it, whose own docstring said it was ignored. The call sites in `dataLoader.js` and `stubbedLoads.js` no longer imply the default varies with the config.

## Tests

- `testState.js` asserts every field of `State.default()` directly, so a future shift fails loudly rather than being absorbed by coercion.
- `testDefaultViewOrigin.js` (new) pins the door itself: the state `loadHicFile` hands the browser when the config names neither a locus nor a state.

Both were confirmed to fail against the old six-argument form before being kept. Full suite: 906 passing, build clean.

## Acceptance criteria

- [x] Every constructor parameter is supplied explicitly
- [x] A map opened with no locus and no state has a y origin of zero
- [x] A test asserts the default state's field values directly
- [x] The intended default pixel size is confirmed and stated, not inferred

## Sequencing

[ADR-0009](https://github.com/aidenlab/juicebox.js/blob/master/docs/adr/0009-restore-is-a-translator.md) puts this **before** candidate 6's gate (#557), which snapshots the resolved `State` through all five restore doors. Snapshotting a y-origin of `1` would have baked the defect into the golden. Same rule as #499/#500 before #503 and #531 before #532: the fixes that legitimately move output land before the characterization.

`docs/adr/` is append-only and `architecture-review.html` is frozen, so neither is revised here. The punch list's frontier move to #557 rides with #564, where that file's #557 content lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)