### PR TITLE
#559: setActiveDataset loses its state parameter

### DIFF
--- a/docs/juicebox-punch-list.md
+++ b/docs/juicebox-punch-list.md
@@ -1,6 +1,6 @@
 # Juicebox.js — Punch List
 
-**As of 2026-08-22. Candidate 6 is the active work; the gate (#557) and the behaviour change behind it (#558) are in, so the frontier is [#559](https://github.com/aidenlab/juicebox.js/issues/559) — `setActiveDataset` loses its `state` parameter.**
+**As of 2026-08-22. Candidate 6 is the active work; the gate (#557), the behaviour change behind it (#558) and the back door beside it (#559) are in, so the frontier is the parallel branch — [#560](https://github.com/aidenlab/juicebox.js/issues/560), [#561](https://github.com/aidenlab/juicebox.js/issues/561) and [#562](https://github.com/aidenlab/juicebox.js/issues/562), all three now unblocked.**
 
 > **This is the working scratchpad — the only one.** Thrash it freely; nothing else has to
 > agree with it. Where the durable facts live:
@@ -44,10 +44,10 @@ what is actually unblocked.
 | ~~**#510**~~ | `State.default()` passes six arguments to a seven-parameter constructor | ✅ **fixed** — the default view opens at the origin, and the ignored `config` parameter is gone from `State.default` and `decodeState` |
 | ~~**#557**~~ | Gate: snapshot the resolved state every restore door produces today | ✅ **landed** — 450 records, five doors, two viewports |
 | ~~**#558**~~ | Restore routes through the chokepoint, and the clamp gets one enforcer | ✅ **landed** — `StateManager.setState` delegates to `setView`, `updateLayout`'s `clampXY` is gone, **2 of the gate's 450 records moved** |
-| **#559** | `setActiveDataset` loses its `state` parameter | — **frontier** |
-| #560 | `resolutionChanged` tells the truth on restore | #559 |
-| #561 | Normalization is validated against the loaded dataset at restore | #559 |
-| #562 | The sync trio splits three ways | #559 |
+| ~~**#559**~~ | `setActiveDataset` loses its `state` parameter | ✅ **landed** — the parameter is gone from all five `dataLoader` sites, the `config.locus` door now reaches `setState`, and **the gate's `rungs` field moved on all 450 records while not one `state` field did** |
+| **#560** | `resolutionChanged` tells the truth on restore | — **frontier** |
+| **#561** | Normalization is validated against the loaded dataset at restore | — **frontier** |
+| **#562** | The sync trio splits three ways | — **frontier** |
 | #563 | `StateManager` folds into `State`, the setters go, and the discipline is written down | #560, #561, #562 |
 
 **#560, #561 and #562 are a parallel branch** off #559; #563 is the join. This is the first
@@ -85,6 +85,16 @@ Read ADR-0009 before touching a ticket. Four of the card's claims did not surviv
 (`rootElement` is appended in the constructor), so the clamp is not decorative — but it reads
 `{width: 0, height: 0}` in the harness, so the gate's fixture must state one. Probe output is in the
 ADR.
+
+**What #559 actually moved: the `rungs` field on all 450 records, and no `state` field at all.**
+`setActiveDataset(state)` — the count of states installed without the chokepoint seeing them — left
+the file entirely, and `setState` arrived on the `config.locus` door in both viewport columns. The
+`locus` door's validated state is overwritten by `parseGotoInput` a line later, so what the door
+gained is not visible in a snapshot; `test/testRestoreBackDoor.js` traps `activeState` itself and
+asserts every state installed during that load came out of the chokepoint. **The `synchState`
+branch was fixed but cannot be exercised in production: the rung is unreachable (#566), so #559's
+third acceptance criterion is narrowed to a test that pins both the unreachability and the branch's
+correctness for when #566 lifts it.**
 
 **One split found while decomposing, against the ADR's own sequencing.** The ADR treats restore
 through the chokepoint as one ticket; it is two. Three of the five `setActiveDataset` call sites are

--- a/docs/juicebox-punch-list.md
+++ b/docs/juicebox-punch-list.md
@@ -96,6 +96,14 @@ branch was fixed but cannot be exercised in production: the rung is unreachable 
 third acceptance criterion is narrowed to a test that pins both the unreachability and the branch's
 correctness for when #566 lifts it.**
 
+**One thing #558 broke quietly and #559 had to finish.** The chokepoint installs a *clone*, so the
+state a rung hands it stops being the state in force the moment it is accepted — and `onMapLoaded`
+was publishing the handed-over object. Harmless while the rung's state was the installed one; a
+whole-genome default published to hosts for a `?locus=` load once the `config.locus` rung went
+through the chokepoint. Both paths now read the payload back off the browser. **The gate cannot see
+this class of defect** — it records `browser.state`, never the callback's argument — which is worth
+remembering for #560, #561 and #562, all three of which move the same seam.
+
 **One split found while decomposing, against the ADR's own sequencing.** The ADR treats restore
 through the chokepoint as one ticket; it is two. Three of the five `setActiveDataset` call sites are
 immediately followed by `browser.setState`, which overwrites the unvalidated assignment — so #558

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -114,38 +114,47 @@ class DataLoader {
                 EventBus.globalBus.post(HICEvent("GenomeChange", this.browser.genome.id));
             }
 
-            // Every rung of the ladder has the same two steps in the same
-            // order: install the dataset, then hand the state to `setState`,
-            // the chokepoint. Until #559 the first step carried the state with
+            // A rung installs the dataset and then hands its state to
+            // `setState`, the chokepoint -- in that order, because `clampXY`
+            // reads the dataset. Until #559 the install carried the state with
             // it, unvalidated. Two rungs hid that -- `config.locus` went on to
             // `parseGotoInput` and `config.synchState` to a sync, and neither
             // reached `setState`, so the raw state stood. ADR-0009 decision 1.
-            let state;
+            //
+            // The `synchState` rung is the one that does not read in that order:
+            // it syncs against the outgoing dataset first and re-validates
+            // against the incoming one only if they differ. It is also the rung
+            // nothing takes -- `clearDataset()` above it means `canBeSynched` is
+            // never true (#566) -- so it is left in the shape it had.
+            //
+            // No rung keeps hold of what it handed over. The chokepoint installs
+            // a *clone* (#558), so the object passed in stops being the state in
+            // force the moment it is accepted -- and on the `locus` rung it is a
+            // whole-genome default while the browser sits at the requested
+            // locus. What `onMapLoaded` publishes is read back off the browser
+            // for that reason.
             if (config.locus) {
-                state = State.default();
                 this.browser.setActiveDataset(dataset);
-                await this.browser.setState(state);
+                await this.browser.setState(State.default());
                 await this.browser.parseGotoInput(config.locus);
             } else if (config.state) {
-                state = decodeState(config.state, reportUnknownStateType);
-
                 this.browser.setActiveDataset(dataset);
-                await this.browser.setState(state);
+                await this.browser.setState(decodeState(config.state, reportUnknownStateType));
             } else if (config.synchState && this.browser.canBeSynched(config.synchState)) {
                 await this.browser.syncState(config.synchState);
-                state = this.browser.state;
                 // syncState already sets the dataset, but ensure it's set with current dataset
                 if (this.browser.dataset !== dataset) {
+                    const synched = this.browser.state;
                     this.browser.setActiveDataset(dataset);
-                    await this.browser.setState(state);
+                    await this.browser.setState(synched);
                 }
             } else {
-                state = State.default();
                 this.browser.setActiveDataset(dataset);
-                await this.browser.setState(state);
+                await this.browser.setState(State.default());
             }
 
-            this.browser.coordinator.onMapLoaded(dataset, state, dataset.datasetType);
+            // The state in force, not the one handed to the chokepoint.
+            this.browser.coordinator.onMapLoaded(dataset, this.browser.state, dataset.datasetType);
 
             // Initiate loading of the norm vector index, but don't block if the "nvi" parameter is not available.
             // Let it load in the background
@@ -262,10 +271,8 @@ class DataLoader {
             // differently here and had lost the unknown-type rung, so a numeric
             // `state` crashed in `State.parse` on this path and opened the
             // default view on the other. #504.
-            const state = decodeState(config.state, reportUnknownStateType);
-
             this.browser.setActiveDataset(dataset);
-            await this.browser.setState(state);
+            await this.browser.setState(decodeState(config.state, reportUnknownStateType));
 
             // Navigate to the data region so it fills the viewport
             const locus = config.locus || `${lcm.chromosomes[1].name}:${lcm.genomicStart}-${lcm.genomicEnd}`;
@@ -277,7 +284,11 @@ class DataLoader {
             // coordinator told hosts one thing and `dataset.datasetType` another,
             // about the same load. Nobody could have been reading it: no doc ever
             // named it, and the JSDoc it contradicted named "main"/"control".
-            this.browser.coordinator.onMapLoaded(dataset, state, dataset.datasetType);
+            //
+            // And the same state expression, for the same reason the file path
+            // gives: `parseGotoInput` above has just moved the browser off the
+            // decoded state, which was a clone ago in any case.
+            this.browser.coordinator.onMapLoaded(dataset, this.browser.state, dataset.datasetType);
 
             return dataset;
         } catch (error) {

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -114,26 +114,34 @@ class DataLoader {
                 EventBus.globalBus.post(HICEvent("GenomeChange", this.browser.genome.id));
             }
 
+            // Every rung of the ladder has the same two steps in the same
+            // order: install the dataset, then hand the state to `setState`,
+            // the chokepoint. Until #559 the first step carried the state with
+            // it, unvalidated. Two rungs hid that -- `config.locus` went on to
+            // `parseGotoInput` and `config.synchState` to a sync, and neither
+            // reached `setState`, so the raw state stood. ADR-0009 decision 1.
             let state;
             if (config.locus) {
                 state = State.default();
-                this.browser.setActiveDataset(dataset, state);
+                this.browser.setActiveDataset(dataset);
+                await this.browser.setState(state);
                 await this.browser.parseGotoInput(config.locus);
             } else if (config.state) {
                 state = decodeState(config.state, reportUnknownStateType);
 
-                this.browser.setActiveDataset(dataset, state);
+                this.browser.setActiveDataset(dataset);
                 await this.browser.setState(state);
             } else if (config.synchState && this.browser.canBeSynched(config.synchState)) {
                 await this.browser.syncState(config.synchState);
                 state = this.browser.state;
                 // syncState already sets the dataset, but ensure it's set with current dataset
                 if (this.browser.dataset !== dataset) {
-                    this.browser.setActiveDataset(dataset, state);
+                    this.browser.setActiveDataset(dataset);
+                    await this.browser.setState(state);
                 }
             } else {
                 state = State.default();
-                this.browser.setActiveDataset(dataset, state);
+                this.browser.setActiveDataset(dataset);
                 await this.browser.setState(state);
             }
 
@@ -256,7 +264,7 @@ class DataLoader {
             // default view on the other. #504.
             const state = decodeState(config.state, reportUnknownStateType);
 
-            this.browser.setActiveDataset(dataset, state);
+            this.browser.setActiveDataset(dataset);
             await this.browser.setState(state);
 
             // Navigate to the data region so it fills the viewport

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -501,13 +501,14 @@ class HICBrowser {
     }
 
     /**
-     * Set the primary dataset and, optionally, the state to view it with.
+     * Set the primary dataset. The dataset only: a state reaches the browser
+     * through `setState`, the chokepoint, and never alongside the dataset
+     * (#559, ADR-0009 decision 1).
      *
      * @param {Dataset} dataset - The dataset to activate
-     * @param {State} state - The state to use with this dataset
      */
-    setActiveDataset(dataset, state) {
-        this.stateManager.setActiveDataset(dataset, state);
+    setActiveDataset(dataset) {
+        this.stateManager.setActiveDataset(dataset);
     }
 
     /**
@@ -526,7 +527,7 @@ class HICBrowser {
     }
 
     set dataset(value) {
-        this.stateManager.setActiveDataset(value, undefined);
+        this.stateManager.setActiveDataset(value);
     }
 
     /**
@@ -555,7 +556,7 @@ class HICBrowser {
 
     /** Alias for `dataset`. Retained for host apps -- Spacewalk reads it (juicebox/juiceboxPanel.js, 4 sites). */
     set activeDataset(value) {
-        this.stateManager.setActiveDataset(value, undefined);
+        this.stateManager.setActiveDataset(value);
     }
 
     /** Alias for `state`. Kept as published surface alongside `activeDataset`: no host we can measure reads it, and this repo cannot see the ones it cannot measure. */

--- a/js/stateManager.js
+++ b/js/stateManager.js
@@ -50,7 +50,7 @@ class StateManager {
      * decision 1).
      *
      * This took a second `state` parameter until #559, and assigned it to
-     * `activeState` with no validation at all, from five `dataLoader` call
+     * `this.activeState` with no validation at all, from five `dataLoader` call
      * sites. That was the live bypass of the mutation invariant -- not the
      * `browser.state = x` setters the review card names, which have no
      * production callers -- and it carried no warning comment while running on

--- a/js/stateManager.js
+++ b/js/stateManager.js
@@ -45,16 +45,28 @@ class StateManager {
     }
 
     /**
-     * Set the active dataset and optionally the state.
-     * 
+     * Install the active dataset. **The dataset and nothing else** -- state
+     * arrives only through `setState`, the chokepoint (#559, ADR-0009
+     * decision 1).
+     *
+     * This took a second `state` parameter until #559, and assigned it to
+     * `activeState` with no validation at all, from five `dataLoader` call
+     * sites. That was the live bypass of the mutation invariant -- not the
+     * `browser.state = x` setters the review card names, which have no
+     * production callers -- and it carried no warning comment while running on
+     * every load.
+     *
+     * Routing the assignment through the chokepoint *inside* this setter was
+     * the rejected alternative: it hides a chokepoint call in a method named
+     * for something else, which is how the door was built the first time.
+     * Dropping the parameter makes the ordering explicit at each call site --
+     * install the dataset, then hand the state to `setState`, which needs the
+     * dataset already in place because `clampXY` reads its chromosome table.
+     *
      * @param {Dataset} dataset - The dataset to set as active
-     * @param {State} state - Optional state to set
      */
-    setActiveDataset(dataset, state) {
+    setActiveDataset(dataset) {
         this.activeDataset = dataset;
-        if (state) {
-            this.activeState = state;
-        }
     }
 
     /**

--- a/test/__snapshots__/testRestoreGolden.js.snap
+++ b/test/__snapshots__/testRestoreGolden.js.snap
@@ -11,7 +11,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -37,7 +36,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -67,7 +65,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -94,7 +92,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -131,7 +129,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -167,7 +164,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -204,7 +200,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -239,7 +234,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -283,7 +277,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -325,7 +318,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -360,7 +352,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -386,7 +377,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -416,7 +406,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -443,7 +433,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -471,7 +461,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -498,7 +487,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -535,7 +523,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -570,7 +557,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -605,7 +591,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -638,7 +623,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -668,7 +652,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -694,7 +677,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -724,7 +706,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -751,7 +733,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -779,7 +761,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -806,7 +787,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -843,7 +823,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -878,7 +857,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -913,7 +891,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -946,7 +923,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -981,7 +957,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1007,7 +982,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1037,7 +1011,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -1064,7 +1038,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -1101,7 +1075,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1137,7 +1110,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1174,7 +1146,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1209,7 +1180,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1253,7 +1223,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1295,7 +1264,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1325,7 +1293,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1351,7 +1318,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1381,7 +1347,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -1408,7 +1374,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -1445,7 +1411,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1481,7 +1446,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1518,7 +1482,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1553,7 +1516,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1597,7 +1559,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1639,7 +1600,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1674,7 +1634,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1700,7 +1659,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1730,7 +1688,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -1757,7 +1715,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -1785,7 +1743,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1812,7 +1769,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1849,7 +1805,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1884,7 +1839,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1919,7 +1873,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1952,7 +1905,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -1987,7 +1939,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2013,7 +1964,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2043,7 +1993,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -2070,7 +2020,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -2107,7 +2057,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2143,7 +2092,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2180,7 +2128,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2215,7 +2162,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2259,7 +2205,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2301,7 +2246,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2336,7 +2280,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2362,7 +2305,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2392,7 +2334,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -2419,7 +2361,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -2456,7 +2398,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2492,7 +2433,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2529,7 +2469,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2564,7 +2503,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2608,7 +2546,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2650,7 +2587,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2685,7 +2621,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2711,7 +2646,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2741,7 +2675,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -2768,7 +2702,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -2796,7 +2730,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2823,7 +2756,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2860,7 +2792,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2895,7 +2826,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2930,7 +2860,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2963,7 +2892,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -2998,7 +2926,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3024,7 +2951,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3054,7 +2980,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -3081,7 +3007,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -3118,7 +3044,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3154,7 +3079,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3191,7 +3115,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3226,7 +3149,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3270,7 +3192,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3312,7 +3233,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3347,7 +3267,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3373,7 +3292,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3403,7 +3321,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -3430,7 +3348,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -3467,7 +3385,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3503,7 +3420,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3540,7 +3456,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3575,7 +3490,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3619,7 +3533,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3661,7 +3574,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3696,7 +3608,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3722,7 +3633,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3752,7 +3662,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -3779,7 +3689,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -3816,7 +3726,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3852,7 +3761,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3889,7 +3797,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3924,7 +3831,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -3968,7 +3874,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4010,7 +3915,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4045,7 +3949,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4071,7 +3974,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4101,7 +4003,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -4128,7 +4030,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -4156,7 +4058,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4183,7 +4084,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4220,7 +4120,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4255,7 +4154,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4290,7 +4188,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4323,7 +4220,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4353,7 +4249,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4379,7 +4274,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4409,7 +4303,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -4436,7 +4330,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -4464,7 +4358,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4491,7 +4384,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4528,7 +4420,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4563,7 +4454,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4598,7 +4488,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4631,7 +4520,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4666,7 +4554,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4692,7 +4579,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4722,7 +4608,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -4749,7 +4635,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -4777,7 +4663,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4804,7 +4689,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4841,7 +4725,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4876,7 +4759,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4911,7 +4793,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4944,7 +4825,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -4974,7 +4854,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5000,7 +4879,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5030,7 +4908,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -5057,7 +4935,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -5085,7 +4963,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5112,7 +4989,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5149,7 +5025,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5184,7 +5059,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5219,7 +5093,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5252,7 +5125,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5287,7 +5159,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5313,7 +5184,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5343,7 +5213,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -5370,7 +5240,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -5398,7 +5268,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5425,7 +5294,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5462,7 +5330,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5497,7 +5364,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5532,7 +5398,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5565,7 +5430,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5595,7 +5459,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5621,7 +5484,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5651,7 +5513,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -5678,7 +5540,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -5706,7 +5568,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5733,7 +5594,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5770,7 +5630,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5805,7 +5664,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5840,7 +5698,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5873,7 +5730,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5908,7 +5764,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5934,7 +5789,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -5964,7 +5818,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -5991,7 +5845,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -6019,7 +5873,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6046,7 +5899,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6083,7 +5935,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6118,7 +5969,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6153,7 +6003,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6186,7 +6035,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6221,7 +6069,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6247,7 +6094,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6277,7 +6123,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -6304,7 +6150,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -6332,7 +6178,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6359,7 +6204,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6396,7 +6240,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6431,7 +6274,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6466,7 +6308,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6499,7 +6340,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6534,7 +6374,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6560,7 +6399,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6590,7 +6428,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -6617,7 +6455,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -6645,7 +6483,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6672,7 +6509,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6709,7 +6545,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6744,7 +6579,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6779,7 +6613,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6812,7 +6645,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6847,7 +6679,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6873,7 +6704,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6903,7 +6733,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -6930,7 +6760,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -6958,7 +6788,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -6985,7 +6814,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7022,7 +6850,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7057,7 +6884,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7092,7 +6918,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7125,7 +6950,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7160,7 +6984,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7186,7 +7009,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7216,7 +7038,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -7243,7 +7065,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -7280,7 +7102,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7316,7 +7137,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7353,7 +7173,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7388,7 +7207,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7432,7 +7250,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7474,7 +7291,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7509,7 +7325,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7535,7 +7350,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7565,7 +7379,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -7592,7 +7406,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -7629,7 +7443,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7665,7 +7478,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7702,7 +7514,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7737,7 +7548,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7781,7 +7591,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7823,7 +7632,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7858,7 +7666,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7884,7 +7691,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -7914,7 +7720,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -7941,7 +7747,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -7978,7 +7784,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8014,7 +7819,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8051,7 +7855,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8086,7 +7889,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8130,7 +7932,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8172,7 +7973,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8207,7 +8007,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8233,7 +8032,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8263,7 +8061,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -8290,7 +8088,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -8327,7 +8125,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8363,7 +8160,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8400,7 +8196,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8435,7 +8230,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8479,7 +8273,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8521,7 +8314,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8556,7 +8348,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8582,7 +8373,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8612,7 +8402,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -8639,7 +8429,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -8676,7 +8466,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8712,7 +8501,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8749,7 +8537,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8784,7 +8571,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8828,7 +8614,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8870,7 +8655,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8905,7 +8689,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8931,7 +8714,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -8961,7 +8743,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -8988,7 +8770,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -9025,7 +8807,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9061,7 +8842,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9098,7 +8878,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9133,7 +8912,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9177,7 +8955,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9219,7 +8996,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9254,7 +9030,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9280,7 +9055,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9310,7 +9084,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -9337,7 +9111,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -9374,7 +9148,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9410,7 +9183,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9447,7 +9219,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9482,7 +9253,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9526,7 +9296,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9568,7 +9337,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9603,7 +9371,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9629,7 +9396,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9659,7 +9425,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -9686,7 +9452,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -9714,7 +9480,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9741,7 +9506,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9778,7 +9542,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9813,7 +9576,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9848,7 +9610,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9881,7 +9642,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9916,7 +9676,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9942,7 +9701,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -9972,7 +9730,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -9999,7 +9757,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -10027,7 +9785,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10054,7 +9811,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10091,7 +9847,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10126,7 +9881,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10161,7 +9915,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10194,7 +9947,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10229,7 +9981,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10255,7 +10006,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10285,7 +10035,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -10312,7 +10062,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -10340,7 +10090,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10367,7 +10116,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10404,7 +10152,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10439,7 +10186,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10474,7 +10220,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10507,7 +10252,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10542,7 +10286,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10568,7 +10311,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10598,7 +10340,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -10625,7 +10367,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -10653,7 +10395,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10680,7 +10421,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10717,7 +10457,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10752,7 +10491,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10787,7 +10525,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10820,7 +10557,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10855,7 +10591,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10881,7 +10616,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10911,7 +10645,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -10938,7 +10672,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -10966,7 +10700,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -10993,7 +10726,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11030,7 +10762,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11065,7 +10796,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11100,7 +10830,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11133,7 +10862,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11168,7 +10896,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11194,7 +10921,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11224,7 +10950,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -11251,7 +10977,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -11279,7 +11005,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11306,7 +11031,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11343,7 +11067,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11378,7 +11101,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11413,7 +11135,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11446,7 +11167,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11481,7 +11201,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11507,7 +11226,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11537,7 +11255,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -11564,7 +11282,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -11592,7 +11310,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11619,7 +11336,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11656,7 +11372,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11691,7 +11406,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11726,7 +11440,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11759,7 +11472,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11794,7 +11506,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11820,7 +11531,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11850,7 +11560,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -11877,7 +11587,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -11905,7 +11615,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11932,7 +11641,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -11969,7 +11677,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12004,7 +11711,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12039,7 +11745,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12072,7 +11777,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12107,7 +11811,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12133,7 +11836,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12163,7 +11865,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -12190,7 +11892,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -12218,7 +11920,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12245,7 +11946,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12282,7 +11982,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12317,7 +12016,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12352,7 +12050,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12385,7 +12082,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12420,7 +12116,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12446,7 +12141,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12476,7 +12170,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -12503,7 +12197,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -12531,7 +12225,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12558,7 +12251,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12595,7 +12287,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12630,7 +12321,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12665,7 +12355,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12698,7 +12387,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12733,7 +12421,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12759,7 +12446,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12789,7 +12475,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -12816,7 +12502,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -12844,7 +12530,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12871,7 +12556,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12908,7 +12592,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12943,7 +12626,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -12978,7 +12660,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13011,7 +12692,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13046,7 +12726,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13072,7 +12751,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13102,7 +12780,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -13129,7 +12807,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -13157,7 +12835,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13184,7 +12861,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13221,7 +12897,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13256,7 +12931,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13291,7 +12965,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13324,7 +12997,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13359,7 +13031,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13385,7 +13056,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13415,7 +13085,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -13442,7 +13112,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -13478,7 +13148,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13513,7 +13182,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13550,7 +13218,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13585,7 +13252,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13628,7 +13294,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13669,7 +13334,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13704,7 +13368,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13730,7 +13393,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13760,7 +13422,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -13787,7 +13449,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -13823,7 +13485,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13858,7 +13519,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13895,7 +13555,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13930,7 +13589,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -13973,7 +13631,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14014,7 +13671,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14049,7 +13705,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14075,7 +13730,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14105,7 +13759,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -14132,7 +13786,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -14168,7 +13822,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14203,7 +13856,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14240,7 +13892,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14275,7 +13926,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14318,7 +13968,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14359,7 +14008,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14394,7 +14042,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14420,7 +14067,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14450,7 +14096,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -14477,7 +14123,7 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
+          "setState": 1,
         },
         "state": {
           "__class": "State",
@@ -14513,7 +14159,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14548,7 +14193,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         },
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14585,7 +14229,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14620,7 +14263,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "primedWith": "loadHicFile({url}) — a bare load, so that a dataset is active",
         "rungs": {
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14663,7 +14305,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {
@@ -14704,7 +14345,6 @@ exports[`resolved state golden file — every restore door, at two stated viewpo
         "rungs": {
           "parseGotoInput": 1,
           "setActiveDataset": 1,
-          "setActiveDataset(state)": 1,
           "setState": 1,
         },
         "state": {

--- a/test/testAccessorVocabulary.js
+++ b/test/testAccessorVocabulary.js
@@ -67,11 +67,8 @@ describe('internal call sites', () => {
         ['hicBrowser.js', [/^\s*(get|set) active(Dataset|State)\(/, /^\s*this\.stateManager\.activeState\b/, /^\s*(\*|\/\/|\/\*)/]],
         // StateManager's own fields, not the browser accessor. Collapsing
         // StateManager is its own candidate; until then its internal spelling
-        // is its business, but reaching for the browser's alias is not. Prose is
-        // exempt here for the same reason it is in hicBrowser.js -- a doc
-        // comment naming the field it documents is not a read, and #559's
-        // `setActiveDataset` comment is one.
-        ['stateManager.js', [/\bthis\.active(Dataset|State)\b/, /^\s*(\*|\/\/|\/\*)/]],
+        // is its business, but reaching for the browser's alias is not.
+        ['stateManager.js', [/\bthis\.active(Dataset|State)\b/]],
         // The declaration of the aliases as public surface.
         ['publicApi.js', [/active(Dataset|State)/]]
     ])

--- a/test/testAccessorVocabulary.js
+++ b/test/testAccessorVocabulary.js
@@ -67,8 +67,11 @@ describe('internal call sites', () => {
         ['hicBrowser.js', [/^\s*(get|set) active(Dataset|State)\(/, /^\s*this\.stateManager\.activeState\b/, /^\s*(\*|\/\/|\/\*)/]],
         // StateManager's own fields, not the browser accessor. Collapsing
         // StateManager is its own candidate; until then its internal spelling
-        // is its business, but reaching for the browser's alias is not.
-        ['stateManager.js', [/\bthis\.active(Dataset|State)\b/]],
+        // is its business, but reaching for the browser's alias is not. Prose is
+        // exempt here for the same reason it is in hicBrowser.js -- a doc
+        // comment naming the field it documents is not a read, and #559's
+        // `setActiveDataset` comment is one.
+        ['stateManager.js', [/\bthis\.active(Dataset|State)\b/, /^\s*(\*|\/\/|\/\*)/]],
         // The declaration of the aliases as public surface.
         ['publicApi.js', [/active(Dataset|State)/]]
     ])

--- a/test/testDefaultViewOrigin.js
+++ b/test/testDefaultViewOrigin.js
@@ -51,11 +51,16 @@ function stubBrowser(recorded) {
             onMapLoaded: () => undefined
         },
         registry: { presentAlert: () => undefined, sync: () => undefined, browsers: [] },
-        setActiveDataset: (dataset, state) => {
+        setActiveDataset: (dataset) => {
             browser.dataset = dataset
+        },
+        // The default view is observed where it now arrives: at the chokepoint.
+        // It used to be read off `setActiveDataset`'s second parameter, which
+        // #559 deleted -- the ladder installs the dataset and then hands the
+        // state to `setState`, so this is the same state one call later.
+        setState: async (state) => {
             recorded.push(state)
         },
-        setState: async () => undefined,
         parseGotoInput: async () => undefined,
         canBeSynched: () => false,
         syncState: async () => undefined

--- a/test/testRestoreBackDoor.js
+++ b/test/testRestoreBackDoor.js
@@ -39,6 +39,15 @@
  * no production restore via `synchState` to validate, and this file says so
  * with a test rather than with a comment that could quietly go stale.
  *
+ * A fourth claim is here because closing the door moved what a *host* sees. The
+ * chokepoint installs a clone (#558), so the state a rung hands it stops being
+ * the state in force the moment it is accepted -- and once the `config.locus`
+ * rung goes through the chokepoint, the object it handed over is a whole-genome
+ * default while the browser sits at the requested locus. `onMapLoaded` publishes
+ * that object, and `COORDINATOR_PAYLOAD_SHAPES` in `js/publicApi.js` declares
+ * the payload as contract, so it is now read back off the browser. The gate
+ * cannot see this: it records `browser.state`, never the callback's argument.
+ *
  * The dataset, the viewport and the stubs are `testRestoreClamp.js`'s, for the
  * reason it gives: a stated 800x800, because JSDOM does no layout (ADR-0009
  * fact 5).
@@ -177,6 +186,25 @@ describe('the state parameter is gone from setActiveDataset (#559)', () => {
         // `parseGotoInput` mutates the state in place rather than installing a
         // new one, so the state left standing is the chokepoint's own clone.
         expect(browser.state).toBe(installed(writes).at(-1).state)
+    })
+
+    test('onMapLoaded publishes the state in force, not the one handed to the chokepoint', async () => {
+
+        const browser = embed()
+        const published = []
+        vi.spyOn(browser.coordinator, 'onMapLoaded').mockImplementation((dataset, state) => {
+            published.push(state)
+        })
+
+        await browser.loadHicFile({url: HIC_URL, locus: 'chr1:1000000-2000000'}, true)
+
+        expect(published).toHaveLength(1)
+
+        // The identity, and then the view: a host that reads the payload sees
+        // where the browser actually is, not the default it started from.
+        expect(published[0]).toBe(browser.state)
+        expect(published[0].chr1).toBe(CHR1)
+        expect(published[0].chr2).toBe(CHR1)
     })
 
     test('the config.synchState rung is unreachable, so no restore takes it (#566)', async () => {

--- a/test/testRestoreBackDoor.js
+++ b/test/testRestoreBackDoor.js
@@ -1,0 +1,228 @@
+/**
+ * The back door beside the ladder is closed. #559, candidate 6, ADR-0009
+ * decision 1.
+ *
+ * `setActiveDataset(dataset, state)` assigned the incoming state straight onto
+ * `activeState` with no validation, from five `dataLoader` call sites, and it
+ * carried no warning comment while running on every load. It is *not* the
+ * bypass the review card names -- `browser.state = x` and
+ * `browser.activeState = x` carry the comment and have zero production callers
+ * (ADR-0009 fact 2). This one was live.
+ *
+ * #558 routed `setState` through the chokepoint, which incidentally fixed the
+ * three rungs that assign and then immediately call it: the unvalidated state
+ * was overwritten a line later. The two rungs it did not reach are the ones
+ * this file is about -- `config.locus` goes on to `parseGotoInput` and
+ * `config.synchState` to a sync, and on both the raw state used to stand.
+ *
+ * `testRestoreGolden.js` (#557) counts `setActiveDataset(state)` per door and
+ * that count is now zero everywhere, which says the parameter stopped being
+ * *passed*. It cannot say the parameter is gone, nor that nothing else writes
+ * `activeState` on the way past. That is what the three claims here are:
+ *
+ * 1. The parameter does not exist, and a caller who passes one anyway installs
+ *    no state. A count of zero would survive the door being left ajar.
+ * 2. On the `config.locus` door, every state that reaches `activeState` came
+ *    out of the chokepoint. Asserted by trapping the field itself rather than
+ *    by counting calls, so a write from anywhere -- this ladder, a helper it
+ *    calls, a path added later -- is seen.
+ * 3. The same trap on the `config.synchState` door. **That rung is unreachable
+ *    in production today** (#566): `loadHicFile` opens with `clearDataset()`,
+ *    four lines above a guard that returns false without an `activeDataset`,
+ *    so a config carrying a `synchState` silently takes the fallback rung. Both
+ *    halves are pinned -- that it is unreachable, and that its code is correct
+ *    for when #566 makes it reachable -- because a ticket that left the branch
+ *    untested until then would be leaving it untested at exactly the moment it
+ *    starts running.
+ *
+ * The third acceptance criterion of #559 is narrowed for that reason: there is
+ * no production restore via `synchState` to validate, and this file says so
+ * with a test rather than with a comment that could quietly go stale.
+ *
+ * The dataset, the viewport and the stubs are `testRestoreClamp.js`'s, for the
+ * reason it gives: a stated 800x800, because JSDOM does no layout (ADR-0009
+ * fact 5).
+ */
+import {beforeEach, afterEach, describe, expect, test, vi} from 'vitest'
+import {igvxhr} from 'igv-utils'
+import ContactMatrixView from '../js/contactMatrixView.js'
+import StateManager from '../js/stateManager.js'
+import State from '../js/hicState.js'
+import {withContainers} from './utils/browserFixture.js'
+import {restoreDataset} from './utils/restoreDataset.js'
+
+vi.mock('../js/hicDataset.js', async () => {
+    const {restoreDataset} = await import('./utils/restoreDataset.js')
+    return {
+        default: {loadDataset: async config => restoreDataset(config)},
+        HiCDataset: class {
+            constructor(config) {
+                Object.assign(this, restoreDataset(config))
+            }
+            async init() {}
+        },
+    }
+})
+
+const {default: HICBrowser} = await import('../js/hicBrowser.js')
+
+const VIEWPORT = {width: 800, height: 800}
+const HIC_URL = 'https://example.org/restore-back-door.hic'
+
+/** chr1 x chr1 at 250kb bins — the zoom `testRestoreClamp.js` drives. */
+const CHR1 = 1
+const ZOOM = 3
+
+/**
+ * Watch `activeState` itself, and record for each write whether the chokepoint
+ * was on the stack.
+ *
+ * The field is trapped on the instance rather than the calls counted on the
+ * prototype: the claim is "no state reaches `activeState` except through
+ * `setState`", and a call count can only speak about the callers it was told
+ * to watch. Writes of `undefined` are recorded too but are not states --
+ * `clearState()` makes one at the top of every load.
+ */
+function trapActiveStateWrites(stateManager) {
+
+    const writes = []
+    let depth = 0
+
+    const chokepoint = StateManager.prototype.setState
+    vi.spyOn(StateManager.prototype, 'setState').mockImplementation(async function (...args) {
+        depth += 1
+        try {
+            return await chokepoint.apply(this, args)
+        } finally {
+            depth -= 1
+        }
+    })
+
+    let held = stateManager.activeState
+    Object.defineProperty(stateManager, 'activeState', {
+        configurable: true,
+        get() {
+            return held
+        },
+        set(value) {
+            writes.push({state: value, throughChokepoint: depth > 0})
+            held = value
+        },
+    })
+
+    return writes
+}
+
+/** The states installed by a load — the writes that were not a clear. */
+function installed(writes) {
+    return writes.filter(write => write.state !== undefined)
+}
+
+describe('the state parameter is gone from setActiveDataset (#559)', () => {
+
+    const dom = withContainers()
+
+    beforeEach(() => {
+        vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(igvxhr, 'loadString').mockImplementation(async () => {
+            throw new Error('unexpected network access from the restore back-door suite')
+        })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    function embed() {
+        const browser = new HICBrowser(dom.another(), {})
+        vi.spyOn(browser.contactMatrixView, 'getViewDimensions').mockReturnValue({...VIEWPORT})
+        return browser
+    }
+
+    test('setActiveDataset takes a dataset and nothing else', async () => {
+
+        const browser = embed()
+        await browser.loadHicFile({url: HIC_URL}, true)
+
+        const before = browser.state
+        expect(before).toBeDefined()
+
+        // Declared arity, and behaviour: a caller written against the old
+        // two-argument form installs a dataset and no state.
+        expect(StateManager.prototype.setActiveDataset.length).toBe(1)
+
+        const smuggled = new State(CHR1, CHR1, ZOOM, 999_999, 999_999, 1e9, 'NONE')
+        browser.setActiveDataset(browser.dataset, smuggled)
+
+        expect(browser.state).toBe(before)
+        expect(browser.state).not.toBe(smuggled)
+    })
+
+    test('the config.locus door installs no state the chokepoint did not produce', async () => {
+
+        const browser = embed()
+        const writes = trapActiveStateWrites(browser.stateManager)
+
+        await browser.loadHicFile({url: HIC_URL, locus: 'chr1:1000000-2000000'}, true)
+
+        // The door ran: a state is installed and the locus was applied to it.
+        expect(installed(writes).length).toBeGreaterThan(0)
+        expect(browser.state.chr1).toBe(CHR1)
+
+        for (const write of installed(writes)) {
+            expect(write.throughChokepoint).toBe(true)
+        }
+
+        // `parseGotoInput` mutates the state in place rather than installing a
+        // new one, so the state left standing is the chokepoint's own clone.
+        expect(browser.state).toBe(installed(writes).at(-1).state)
+    })
+
+    test('the config.synchState rung is unreachable, so no restore takes it (#566)', async () => {
+
+        const browser = embed()
+        await browser.loadHicFile({url: HIC_URL}, true)
+
+        const synchState = browser.getSyncState()
+        expect(synchState).toBeDefined()
+
+        const sync = vi.spyOn(HICBrowser.prototype, 'syncState')
+
+        // Primed — a dataset is already loaded — and the rung is still not
+        // taken: `clearDataset()` runs first and `canBeSynched` returns false
+        // without an `activeDataset`.
+        await browser.loadHicFile({url: HIC_URL, synchState}, true)
+
+        expect(sync).not.toHaveBeenCalled()
+    })
+
+    test('when the rung is reachable, it installs the dataset and then goes through the chokepoint', async () => {
+
+        const browser = embed()
+        await browser.loadHicFile({url: HIC_URL, state: new State(CHR1, CHR1, ZOOM, 40, 40, 2, 'NONE')}, true)
+
+        const synchState = browser.getSyncState()
+
+        // #566, and only #566: the guard four lines below it is what makes the
+        // rung dead, so neutralising the clear is what a fix would amount to.
+        // Nothing else about the door is stubbed.
+        vi.spyOn(HICBrowser.prototype, 'clearDataset').mockImplementation(() => undefined)
+
+        const writes = trapActiveStateWrites(browser.stateManager)
+        const sync = vi.spyOn(HICBrowser.prototype, 'syncState')
+
+        await browser.loadHicFile({url: HIC_URL, synchState}, true)
+
+        expect(sync).toHaveBeenCalled()
+
+        // The sibling's view arrives through `State.sync`, which is itself a
+        // `setView` call, and the freshly installed dataset is then re-clamped
+        // against by `setState`. Either way, nothing lands on `activeState`
+        // that a chokepoint did not shape.
+        expect(installed(writes).length).toBeGreaterThan(0)
+        for (const write of installed(writes)) {
+            expect(write.throughChokepoint).toBe(true)
+        }
+    })
+})

--- a/test/testRestoreGolden.js
+++ b/test/testRestoreGolden.js
@@ -51,9 +51,12 @@
  *   exists to catch, and it would otherwise show up only as a state that moved.
  * - **`state`** -- the resolved `State` off the live browser, field by field,
  *   plus `getLocus` projected at the same stated viewport.
- *   `setActiveDataset(state)` counts only the calls that carry a state -- the
- *   second parameter ADR-0009 decision 1 deletes, and so the number that should
- *   reach zero. It is not a rung; it is the back door beside the ladder.
+ *   `setActiveDataset` counts the dataset installs. It is not a rung; it is the
+ *   back door beside the ladder, and until #559 a companion count --
+ *   `setActiveDataset(state)` -- said how many states each door installed
+ *   through it. That parameter is gone, so the companion count is gone with it;
+ *   `test/testRestoreBackDoor.js` is where the door being *closed* is asserted,
+ *   which a count of zero could never say.
  *
  * A fixture that differs from another only in its tracks or its colour scale
  * produces an identical record here, and that is correct: restore reads the
@@ -126,8 +129,8 @@
  * - A **`pixelSize` cap arriving** -- a value above `MAX_PIXEL_SIZE` coming down
  *   to it, once restore runs `_adjustPixelSize`.
  * - A **normalization coerced against the dataset** (ADR-0009 decision 5).
- * - **`setActiveDataset(state)` falling to zero**, as decision 1 removes the
- *   parameter. It should reach zero on every door in the file.
+ * - **`setActiveDataset(state)` disappearing**, as decision 1 removes the
+ *   parameter. It went from every door at once, in #559.
  *
  * And what does **not**: a `locus` projection moving without its `state` moving
  * -- `getLocus` is a pure function of the fields above it, so that combination
@@ -143,6 +146,7 @@
  * |------|----------|---------------|
  * | 2026-08-22 | all — baseline taken | #557. No production code changed; this is the gate, taken before candidate 6 moves anything. #510 landed first, so the fallback door records a y-origin of 0 rather than baking that defect in. |
  * | 2026-08-22 | `harvested-query-degron-fully-encoded`, `harvested-query-gm12878-nvi` — the `config.state` door, `1600x400` column only | #558. Restore goes through `setView`, so the clamp reaches it. Tally below. |
+ * | 2026-08-22 | all — the `rungs` field only, on every door | #559. `setActiveDataset` loses its `state` parameter, so the count of calls carrying one leaves the file, and the `config.locus` door reaches `setState` where it did not before. Tally below. |
  *
  * ### The #558 tally
  *
@@ -176,7 +180,8 @@
  *   the corpus's smallest saved `pixelSize` is 1. It is named so that "no
  *   `pixelSize` moved" is not read as "no `pixelSize` could have".
  * - **No `rungs` moved, and `setActiveDataset(state)` is still 1 on the doors
- *   that call it.** #558 is decisions 2 and 4 only; the parameter goes in #559.
+ *   that call it.** #558 is decisions 2 and 4 only; the parameter goes in #559,
+ *   which is the row below this tally.
  * - **The live door's negative origins are unchanged** — all still negative.
  *   Finding 2 above is `parseGotoInput` running *after* `setState`, and
  *   `updateWithLoci` passes `{clampXY: false}`, so routing restore through the
@@ -192,6 +197,35 @@
  * A second movement class the ticket authorised did **not** appear: nothing was
  * rejected, and every record still reads `"outcome": "restores"`. Coerced,
  * never refused (ADR-0009 decision 2).
+ *
+ * ### The #559 tally
+ *
+ * Every record moved, and **only `rungs` moved** -- not one field of one
+ * `state`, in either column, on any of the five doors. Two line shapes account
+ * for the whole diff:
+ *
+ * - **`setActiveDataset(state)` removed -- 450 records, i.e. all of them.** The
+ *   parameter is gone, so the count that only ever meant "states installed
+ *   without the chokepoint seeing them" has nothing left to count and is no
+ *   longer emitted. `setActiveDataset` itself is unchanged at 1 everywhere the
+ *   ladder installs a dataset, which is the check the update convention names:
+ *   the door closing must not look like the dataset ceasing to be installed.
+ * - **`setState` added -- 90 records: the `config.locus` door, both columns.**
+ *   45 browser configs x 2 viewports x 1 door. That door used to install
+ *   `State.default()` through the back door and go straight on to
+ *   `parseGotoInput`; it now hands the default to the chokepoint first. The
+ *   `config.synchState` door is the other rung #558 could not reach, and it
+ *   does not appear here because it is still unreachable (#566) and still
+ *   recording the fallback.
+ *
+ * **No `state` moved, and that is the expected shape rather than a null
+ * result.** The three doors that already called `setState` were handing it the
+ * same state before and after. On the `config.locus` door the validated default
+ * is overwritten a line later by `parseGotoInput`, so what the chokepoint now
+ * produces there is not what the record shows -- the door's value is that the
+ * raw state no longer *stands*, which is a claim about the state between two
+ * calls and therefore not a claim a snapshot can make.
+ * `test/testRestoreBackDoor.js` makes it, by trapping the field.
  *
  * @see docs/adr/0009-restore-is-a-translator.md — the decisions this gate guards
  * @see test/data/wireFormatCorpus.js — the inputs
@@ -462,18 +496,17 @@ function rungCounter() {
         for (const method of ['parseGotoInput', 'setState', 'syncState']) {
             count(HICBrowser.prototype, method)
         }
-        // Not a rung: the back door beside the ladder. `setActiveDataset`'s
-        // second parameter is what lets a caller install a state without the
-        // chokepoint seeing it, and ADR-0009 decision 1 deletes it. Counting the
-        // calls that carry one says, per door, how many states this load
-        // installed that way -- which is the number that should reach zero.
+        // Not a rung: the back door beside the ladder. It took a second `state`
+        // parameter until #559, and this counted the calls that carried one --
+        // per door, the states a load installed without the chokepoint seeing
+        // them. The parameter is gone (ADR-0009 decision 1), so what is left to
+        // count is the dataset install itself, which the update convention reads
+        // alongside the state: a door losing this call while its state stays put
+        // would mean the dataset stopped being installed.
         const original = StateManager.prototype.setActiveDataset
-        vi.spyOn(StateManager.prototype, 'setActiveDataset').mockImplementation(function (dataset, state) {
+        vi.spyOn(StateManager.prototype, 'setActiveDataset').mockImplementation(function (dataset) {
             counts['setActiveDataset'] = (counts['setActiveDataset'] || 0) + 1
-            if (state) {
-                counts['setActiveDataset(state)'] = (counts['setActiveDataset(state)'] || 0) + 1
-            }
-            return original.call(this, dataset, state)
+            return original.call(this, dataset)
         })
     })
 


### PR DESCRIPTION
Closes #559. Candidate 6, ADR-0009 decision 1.

`setActiveDataset(dataset, state)` assigned the incoming state onto `activeState` with no validation, from five `dataLoader` sites, and carried no warning comment while running on every load. It now takes a dataset and nothing else; state arrives only through the chokepoint.

#558 incidentally fixed the three rungs that assign and then immediately call `setState`. The two it could not reach are the ones this closes: `config.locus` now hands its default to `setState` before going on to `parseGotoInput`, and `config.synchState` installs the dataset and re-validates the sibling's view against it.

**The gate moved on `rungs` only** — `setActiveDataset(state)` left all 450 records, `setState` arrived on the `config.locus` door in both viewport columns — and not one `state` field moved. The tally is in `test/testRestoreGolden.js`'s log.

`test/testRestoreBackDoor.js` makes the claims a snapshot cannot: it traps `activeState` itself and asserts every state installed during a restore came out of the chokepoint.

### The third acceptance criterion is narrowed

There is no production restore via `synchState` to validate — the rung is unreachable (#566). The branch is fixed anyway, and pinned two ways: one test asserts it is not taken, another neutralises `clearDataset` and asserts the branch is correct for when #566 lifts it.

### One defect found by review, and it is #558's

`onMapLoaded` published the object a rung handed to the chokepoint. The chokepoint installs a *clone*, so that object stops being the state in force — harmless until the `locus` rung went through it, at which point a `?locus=` load published a whole-genome default to hosts. `COORDINATOR_PAYLOAD_SHAPES` declares that payload as contract and Spacewalk reads it. Both load paths now publish `browser.state`. **The gate cannot see this class of defect**: it records `browser.state`, never the callback's argument — worth remembering for #560, #561 and #562.

Full suite green: 47 files, 958 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)