### PR TITLE
#560: resolutionChanged tells the truth on restore

### DIFF
--- a/docs/juicebox-punch-list.md
+++ b/docs/juicebox-punch-list.md
@@ -1,6 +1,6 @@
 # Juicebox.js — Punch List
 
-**As of 2026-08-22. Candidate 6 is the active work; the gate (#557), the behaviour change behind it (#558) and the back door beside it (#559) are in, so the frontier is the parallel branch — [#560](https://github.com/aidenlab/juicebox.js/issues/560), [#561](https://github.com/aidenlab/juicebox.js/issues/561) and [#562](https://github.com/aidenlab/juicebox.js/issues/562), all three now unblocked.**
+**As of 2026-08-22. Candidate 6 is the active work; the gate (#557), the behaviour change behind it (#558), the back door beside it (#559) and the honest change flag (#560) are in, so the frontier is what is left of the parallel branch — [#561](https://github.com/aidenlab/juicebox.js/issues/561) and [#562](https://github.com/aidenlab/juicebox.js/issues/562), both unblocked.**
 
 > **This is the working scratchpad — the only one.** Thrash it freely; nothing else has to
 > agree with it. Where the durable facts live:
@@ -45,7 +45,7 @@ what is actually unblocked.
 | ~~**#557**~~ | Gate: snapshot the resolved state every restore door produces today | ✅ **landed** — 450 records, five doors, two viewports |
 | ~~**#558**~~ | Restore routes through the chokepoint, and the clamp gets one enforcer | ✅ **landed** — `StateManager.setState` delegates to `setView`, `updateLayout`'s `clampXY` is gone, **2 of the gate's 450 records moved** |
 | ~~**#559**~~ | `setActiveDataset` loses its `state` parameter | ✅ **landed** — the parameter is gone from all five `dataLoader` sites, the `config.locus` door now reaches `setState`, and **the gate's `rungs` field moved on all 450 records while not one `state` field did** |
-| **#560** | `resolutionChanged` tells the truth on restore | — **frontier** |
+| ~~**#560**~~ | `resolutionChanged` tells the truth on restore | ✅ **landed** — the flag is computed against the state going out of force, and **not one of the gate's 450 records moved** |
 | **#561** | Normalization is validated against the loaded dataset at restore | — **frontier** |
 | **#562** | The sync trio splits three ways | — **frontier** |
 | #563 | `StateManager` folds into `State`, the setters go, and the discipline is written down | #560, #561, #562 |
@@ -54,8 +54,22 @@ what is actually unblocked.
 candidate with real fan-out rather than a linear chain — which is exactly why the edges are native
 rather than read off a table here.
 
-**#558 is the ticket that deliberately moves snapshots.** #560 moves them for a second, separately
-attributable reason, which is why it is not bundled into #558.
+**#558 is the ticket that deliberately moves snapshots.** #560 was expected to move them for a
+second, separately attributable reason, which is why it was not bundled into #558.
+
+**#560 moved nothing, and the separation still earned its keep.** ADR-0009 decision 3 predicted a
+snapshot move; the gate records the resolved `State` after restore, and a change flag is not a
+resolved state, so there was nothing there to move. The prediction was wrong about the mechanism and
+right about the discipline: had the flag been bundled into #558, the two records that *did* move
+would have had two candidate explanations and no way to choose between them. A separation that costs
+one ticket and buys an unambiguous attribution is worth making even when the movement it guards
+against does not arrive.
+
+The behaviour did change, where a snapshot cannot see it. `resolutionChanged` is what releases the
+resolution lock in `browserCoordinator.onLocusChange`, and it is handed to external `onLocusChange`
+callbacks as declared payload — so a restore onto the current zoom now leaves a locked resolution
+locked. The repaint was never at stake: `hicBrowser.setState` calls `update()` on every restore,
+flag or no. `test/testRestoreResolutionChanged.js` pins the lock, which is the observable half.
 
 **What #558 actually moved: two records of 450**, both the `config.state` door in the `1600x400`
 column, both an `x` clamp on a saved origin too near the end of its chromosome for a wide viewport —

--- a/js/stateManager.js
+++ b/js/stateManager.js
@@ -114,20 +114,28 @@ class StateManager {
      * `resolutionChanged` is computed against the state going out of force, the
      * same comparison `chrChanged` beside it makes, and for the same reason
      * (#560, ADR-0009 decision 3). It used to be `true` unconditionally, so
-     * every restore announced a resolution change and released the resolution
-     * lock whether or not the resolution moved. A restore onto the current zoom
-     * now reports `false` and no longer fires that repaint.
+     * every restore announced a resolution change whether or not the resolution
+     * moved. What that announcement costs is the resolution lock: the
+     * coordinator releases it whenever the flag is set
+     * (`browserCoordinator.onLocusChange`), and it is handed on to external
+     * `onLocusChange` callbacks as contract. The repaint itself is not at stake
+     * — `hicBrowser.setState` calls `update()` on every restore, flag or no.
      *
      * Locus is not cached — consumers derive it via state.getLocus().
      */
     async setState(state) {
+        // Both flags are asked of the state going out of force, in its own
+        // vocabulary: `_detectChromosomeChange` and `_detectResolutionChange`
+        // are the predicates `setView` itself uses, so the answer here and the
+        // answer on every gesture path cannot drift apart. No state in force is
+        // a change on both counts — there is nothing to have been unchanged
+        // from, and `clearDataset()` nulls the state at the top of every load,
+        // so the first restore of a load lands there.
         const chrChanged = !this.activeState ||
-            this.activeState.chr1 !== state.chr1 ||
-            this.activeState.chr2 !== state.chr2;
+            this.activeState._detectChromosomeChange(state.chr1, state.chr2);
 
-        // No state in force is a change: there is nothing to have been unchanged
-        // from, and a freshly loaded map must repaint.
-        const resolutionChanged = !this.activeState || this.activeState.zoom !== state.zoom;
+        const resolutionChanged = !this.activeState ||
+            this.activeState._detectResolutionChange(state.zoom);
 
         const restored = state.clone();
 

--- a/js/stateManager.js
+++ b/js/stateManager.js
@@ -111,9 +111,12 @@ class StateManager {
      * table and resolution ladder. All three production callers set it first,
      * one line earlier; #559 makes that ordering explicit at the call sites.
      *
-     * `resolutionChanged: true` is unconditional and stays that way here: making
-     * it honest is #560, deliberately a ticket of its own so its snapshot
-     * movement has exactly one explanation.
+     * `resolutionChanged` is computed against the state going out of force, the
+     * same comparison `chrChanged` beside it makes, and for the same reason
+     * (#560, ADR-0009 decision 3). It used to be `true` unconditionally, so
+     * every restore announced a resolution change and released the resolution
+     * lock whether or not the resolution moved. A restore onto the current zoom
+     * now reports `false` and no longer fires that repaint.
      *
      * Locus is not cached — consumers derive it via state.getLocus().
      */
@@ -122,14 +125,17 @@ class StateManager {
             this.activeState.chr1 !== state.chr1 ||
             this.activeState.chr2 !== state.chr2;
 
+        // No state in force is a change: there is nothing to have been unchanged
+        // from, and a freshly loaded map must repaint.
+        const resolutionChanged = !this.activeState || this.activeState.zoom !== state.zoom;
+
         const restored = state.clone();
 
         // `setView`'s return is deliberately discarded. It runs on the clone,
-        // which already holds the incoming chromosomes, so its `chrChanged` is
-        // always false and its `resolutionChanged` always false — the comparison
-        // that means anything is against the outgoing value of
-        // `this.activeState`, which is the one computed above.
-        // `resolutionChanged` is #560's to make honest.
+        // which already holds the incoming chromosomes and the incoming zoom, so
+        // its `chrChanged` and its `resolutionChanged` are both always false —
+        // the comparisons that mean anything are against the outgoing value of
+        // `this.activeState`, which are the ones computed above.
         //
         // The clone carries the incoming chr1/chr2 before `setView` runs, so
         // `_adjustPixelSize` consults `browser.minPixelSize` with the same
@@ -145,7 +151,7 @@ class StateManager {
 
         return {
             chrChanged,
-            resolutionChanged: true
+            resolutionChanged
         };
     }
 

--- a/test/testRestoreResolutionChanged.js
+++ b/test/testRestoreResolutionChanged.js
@@ -4,14 +4,17 @@
  *
  * Restore used to return `resolutionChanged: true` unconditionally, so every
  * restore announced a resolution change whether or not the resolution moved.
- * The flag is not decoration: `browserCoordinator.onLocusChange` clears the
- * resolution lock when it is set, and `interactionHandler` drives cache
- * clearing off the same word elsewhere. A restore that lands on the current
- * zoom now says so.
+ * The flag is not decoration: `browserCoordinator.onLocusChange` releases the
+ * resolution lock when it is set, and hands the flag on to external
+ * `onLocusChange` callbacks as declared payload. A restore that lands on the
+ * current zoom now leaves a locked resolution locked. The repaint is not at
+ * stake — `hicBrowser.setState` calls `update()` on every restore, flag or no
+ * — so the lock is the observable half, and claim 4 is where this file earns
+ * its keep.
  *
  * This is deliberately a ticket — and a file — of its own. The change belongs
  * to the invisible-failure-mode class: nothing throws and nothing logs when a
- * repaint that used to fire stops firing, so bundled with #558's clamp a moved
+ * notification that used to fire stops firing, so bundled with #558's clamp a moved
  * snapshot would have had two possible causes and could have been attributed to
  * neither. #536's lesson inverted.
  *
@@ -30,9 +33,10 @@
  * 1. A restore onto the same zoom reports `false`.
  * 2. A restore onto a different zoom reports `true`.
  * 3. The first restore of a load, with no state yet in force, reports `true`.
- *    There is nothing to have been unchanged from, and a fresh map must repaint.
+ *    There is nothing to have been unchanged from, and `clearDataset()` nulls
+ *    the state at the top of every load, so every load lands there.
  * 4. The flag survives the trip to the coordinator, and a same-zoom restore no
- *    longer clears the resolution lock. Claims 1 and 2 read the chokepoint's
+ *    longer releases the resolution lock. Claims 1 and 2 read the chokepoint's
  *    return; this one reads what a widget sees, which is where the behaviour
  *    change is actually visible.
  *

--- a/test/testRestoreResolutionChanged.js
+++ b/test/testRestoreResolutionChanged.js
@@ -1,0 +1,168 @@
+/**
+ * `resolutionChanged` tells the truth on restore. #560, candidate 6, ADR-0009
+ * decision 3.
+ *
+ * Restore used to return `resolutionChanged: true` unconditionally, so every
+ * restore announced a resolution change whether or not the resolution moved.
+ * The flag is not decoration: `browserCoordinator.onLocusChange` clears the
+ * resolution lock when it is set, and `interactionHandler` drives cache
+ * clearing off the same word elsewhere. A restore that lands on the current
+ * zoom now says so.
+ *
+ * This is deliberately a ticket — and a file — of its own. The change belongs
+ * to the invisible-failure-mode class: nothing throws and nothing logs when a
+ * repaint that used to fire stops firing, so bundled with #558's clamp a moved
+ * snapshot would have had two possible causes and could have been attributed to
+ * neither. #536's lesson inverted.
+ *
+ * The honest answer is computed the same way `chrChanged` beside it is: against
+ * the **outgoing** `activeState`. `setView`'s own `resolutionChanged` cannot
+ * serve, and the reason is worth stating because the ticket assumed otherwise.
+ * The chokepoint runs on a clone of the *incoming* state (#558), and that clone
+ * already carries the incoming zoom, so `_detectResolutionChange` compares the
+ * incoming zoom against itself and answers `false` on every restore. It is a
+ * clone deliberately — `_adjustPixelSize` must see the incoming chr1/chr2 — so
+ * the comparison that means anything is the one made before the clone is
+ * installed.
+ *
+ * Four claims:
+ *
+ * 1. A restore onto the same zoom reports `false`.
+ * 2. A restore onto a different zoom reports `true`.
+ * 3. The first restore of a load, with no state yet in force, reports `true`.
+ *    There is nothing to have been unchanged from, and a fresh map must repaint.
+ * 4. The flag survives the trip to the coordinator, and a same-zoom restore no
+ *    longer clears the resolution lock. Claims 1 and 2 read the chokepoint's
+ *    return; this one reads what a widget sees, which is where the behaviour
+ *    change is actually visible.
+ *
+ * The dataset, the viewport and the stubs are `testRestoreClamp.js`'s, for the
+ * reason it gives: a stated 800x800, because JSDOM does no layout (ADR-0009
+ * fact 5).
+ */
+import {beforeEach, afterEach, describe, expect, test, vi} from 'vitest'
+import {igvxhr} from 'igv-utils'
+import ContactMatrixView from '../js/contactMatrixView.js'
+import State from '../js/hicState.js'
+import {withContainers} from './utils/browserFixture.js'
+import {restoreDataset} from './utils/restoreDataset.js'
+
+vi.mock('../js/hicDataset.js', async () => {
+    const {restoreDataset} = await import('./utils/restoreDataset.js')
+    return {
+        default: {loadDataset: async config => restoreDataset(config)},
+        HiCDataset: class {
+            constructor(config) {
+                Object.assign(this, restoreDataset(config))
+            }
+            async init() {}
+        },
+    }
+})
+
+const {default: HICBrowser} = await import('../js/hicBrowser.js')
+
+const VIEWPORT = {width: 800, height: 800}
+const HIC_URL = 'https://example.org/restore-resolution-changed.hic'
+
+/** chr1 x chr1, and two zooms off the same ladder `testRestoreClamp.js` drives. */
+const CHR1 = 1
+const ZOOM = 3
+const OTHER_ZOOM = 5
+
+const savedView = (zoom, x = 0, y = 0) => new State(CHR1, CHR1, zoom, x, y, 2, 'NONE')
+
+describe('resolutionChanged tells the truth on restore (#560)', () => {
+
+    const dom = withContainers()
+
+    beforeEach(() => {
+        vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(igvxhr, 'loadString').mockImplementation(async () => {
+            throw new Error('unexpected network access from the restore resolution suite')
+        })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    function embed() {
+        const browser = new HICBrowser(dom.another(), {})
+        vi.spyOn(browser.contactMatrixView, 'getViewDimensions').mockReturnValue({...VIEWPORT})
+        return browser
+    }
+
+    /** A loaded browser sitting at ZOOM, ready to be restored onto. */
+    async function loaded() {
+        const browser = embed()
+        await browser.loadHicFile({url: HIC_URL, state: savedView(ZOOM)}, true)
+        expect(browser.state.zoom).toBe(ZOOM)
+        return browser
+    }
+
+    test('a restore onto the same zoom reports resolutionChanged false', async () => {
+
+        const browser = await loaded()
+
+        // A different origin, so the restore is a real move — just not a
+        // resolution one.
+        const {resolutionChanged} = await browser.stateManager.setState(savedView(ZOOM, 40, 40))
+
+        expect(resolutionChanged).toBe(false)
+        expect(browser.state.zoom).toBe(ZOOM)
+    })
+
+    test('a restore onto a different zoom reports resolutionChanged true', async () => {
+
+        const browser = await loaded()
+
+        const {resolutionChanged} = await browser.stateManager.setState(savedView(OTHER_ZOOM))
+
+        expect(resolutionChanged).toBe(true)
+        expect(browser.state.zoom).toBe(OTHER_ZOOM)
+    })
+
+    test('the first restore of a load, with no state in force, reports true', async () => {
+
+        const browser = embed()
+        const flags = []
+        const chokepoint = browser.stateManager.setState.bind(browser.stateManager)
+        vi.spyOn(browser.stateManager, 'setState').mockImplementation(async state => {
+            const result = await chokepoint(state)
+            flags.push(result.resolutionChanged)
+            return result
+        })
+
+        await browser.loadHicFile({url: HIC_URL, state: savedView(ZOOM)}, true)
+
+        expect(flags.length).toBeGreaterThan(0)
+        expect(flags[0]).toBe(true)
+    })
+
+    test('the flag reaches the coordinator, and a same-zoom restore leaves the resolution lock alone', async () => {
+
+        const browser = await loaded()
+
+        const seen = []
+        const onLocusChange = browser.coordinator.onLocusChange.bind(browser.coordinator)
+        vi.spyOn(browser.coordinator, 'onLocusChange').mockImplementation(eventData => {
+            seen.push(eventData.resolutionChanged)
+            return onLocusChange(eventData)
+        })
+
+        // The lock is the widget-visible consequence: `onLocusChange` releases it
+        // whenever the flag is set, which is what every restore used to do.
+        browser.resolutionLocked = true
+        await browser.setState(savedView(ZOOM, 40, 40))
+
+        expect(seen).toEqual([false])
+        expect(browser.resolutionLocked).toBe(true)
+
+        await browser.setState(savedView(OTHER_ZOOM))
+
+        expect(seen).toEqual([false, true])
+        expect(browser.resolutionLocked).toBe(false)
+    })
+})


### PR DESCRIPTION
Closes #560. Candidate 6, [ADR-0009](https://github.com/aidenlab/juicebox.js/blob/master/docs/adr/0009-restore-is-a-translator.md) decision 3.

## What changed

`StateManager.setState` returned `resolutionChanged: true` unconditionally, so every restore announced a resolution change whether or not the resolution moved. It now asks the state going out of force, through `State`'s own `_detectChromosomeChange` / `_detectResolutionChange` — the predicates `setView` itself uses, so the answer on restore and the answer on every gesture path cannot drift apart.

**The ticket's premise was wrong, and this departs from it.** #560 says "the chokepoint already computes the honest answer — this ticket stops discarding it." It does not. The chokepoint runs `setView` on a clone of the *incoming* state (#558), so the clone already carries the incoming zoom and `_detectResolutionChange` compares it against itself, answering `false` on every restore. The clone is deliberate — `_adjustPixelSize` must see the incoming chr1/chr2 — so the only comparison that means anything is the one made before the clone is installed. That is where it is made.

## What a user sees

`resolutionChanged` releases the resolution lock in `browserCoordinator.onLocusChange`, and is handed to external `onLocusChange` callbacks as declared payload. **A restore onto the current zoom now leaves a locked resolution locked.** The repaint was never at stake: `hicBrowser.setState` calls `update()` on every restore, flag or no.

## Snapshots

**None moved.** The #557 gate records the resolved `State` after restore, and a change flag is not a resolved state, so there was nothing there to move. ADR-0009 decision 3 predicted a move and was wrong about the mechanism — and right about the discipline: bundled into #558, the two records that *did* move would have had two candidate explanations and no way to choose. Recorded in `docs/juicebox-punch-list.md` with that attribution.

## Tests

`test/testRestoreResolutionChanged.js`, four claims: same zoom reports `false`, a different zoom reports `true`, the first restore of a load reports `true`, and the flag survives the trip to the coordinator with the resolution lock as the observable half. Full suite 962 passing; build clean.

## Reviewed

Both axes. Standards found the punch list unupdated (fixed here, in the same commit, as #558 and #559 did) and the hand-spelled comparison becoming a pattern (fixed by using the predicates). Spec found the code comment and test header claiming a repaint no longer fires, which was false (fixed). The third copy of the restore-suite harness is filed as #571 rather than extracted here.

## Known, out of scope

The `config.synchState` rung passes `browser.state` straight back into `setState`, so both flags compare an object against itself and can only report `false` — even across a dataset change, where zoom index *n* names a different bin size. That rung is unreachable in production today (#566), so it is left alone rather than widening this ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)