### PR TITLE
#562: the sync trio splits three ways

### DIFF
--- a/docs/juicebox-punch-list.md
+++ b/docs/juicebox-punch-list.md
@@ -1,6 +1,6 @@
 # Juicebox.js — Punch List
 
-**As of 2026-08-22. Candidate 6 is the active work; the gate (#557), the behaviour change behind it (#558), the back door beside it (#559) and the honest change flag (#560) are in, so the frontier is what is left of the parallel branch — [#561](https://github.com/aidenlab/juicebox.js/issues/561) and [#562](https://github.com/aidenlab/juicebox.js/issues/562), both unblocked.**
+**As of 2026-08-22. Candidate 6 is the active work; the gate (#557), the behaviour change behind it (#558), the back door beside it (#559), the honest change flag (#560) and both halves of the parallel branch (#561, #562) are in, so the frontier is the join — [#563](https://github.com/aidenlab/juicebox.js/issues/563), the fold, now unblocked.**
 
 > **This is the working scratchpad — the only one.** Thrash it freely; nothing else has to
 > agree with it. Where the durable facts live:
@@ -46,11 +46,11 @@ what is actually unblocked.
 | ~~**#558**~~ | Restore routes through the chokepoint, and the clamp gets one enforcer | ✅ **landed** — `StateManager.setState` delegates to `setView`, `updateLayout`'s `clampXY` is gone, **2 of the gate's 450 records moved** |
 | ~~**#559**~~ | `setActiveDataset` loses its `state` parameter | ✅ **landed** — the parameter is gone from all five `dataLoader` sites, the `config.locus` door now reaches `setState`, and **the gate's `rungs` field moved on all 450 records while not one `state` field did** |
 | ~~**#560**~~ | `resolutionChanged` tells the truth on restore | ✅ **landed** — the flag is computed against the state going out of force, and **not one of the gate's 450 records moved** |
-| **#561** | Normalization is validated against the loaded dataset at restore | — **frontier** |
-| **#562** | The sync trio splits three ways | — **frontier** |
-| #563 | `StateManager` folds into `State`, the setters go, and the discipline is written down | #560, #561, #562 |
+| ~~**#561**~~ | Normalization is validated against the loaded dataset at restore | ✅ **landed** — a normalization the loaded dataset does not offer is coerced to `NONE` in the chokepoint, `NONE` short-circuiting ahead of the dataset |
+| ~~**#562**~~ | The sync trio splits three ways | ✅ **landed** — `canBeSynched` to `syncGroup.js`, `getSyncState` to `State`, `StateManager.syncState` deleted; **the `synchable` guard on `HICBrowser.syncState` stayed**, see below |
+| **#563** | `StateManager` folds into `State`, the setters go, and the discipline is written down | — **frontier**, all three blockers closed |
 
-**#560, #561 and #562 are a parallel branch** off #559; #563 is the join. This is the first
+**#560, #561 and #562 were a parallel branch** off #559; #563 is the join, and all three legs are in. This is the first
 candidate with real fan-out rather than a linear chain — which is exactly why the edges are native
 rather than read off a table here.
 
@@ -91,7 +91,9 @@ Read ADR-0009 before touching a ticket. Four of the card's claims did not surviv
   restore never is. Same session, two behaviours — and it is why the gate states *two* viewports:
   at one, a golden cannot tell a clamp from a coincidence.
 - **The sync trio is not one group.** Moving `canBeSynched` onto `State`, as the card says, would
-  make a *fourth* copy of the `synchable` rule rather than removing the third.
+  make a *fourth* copy of the `synchable` rule rather than removing the third. ✅ Held up in #562:
+  the three copies collapsed to one `isSynchable` in `syncGroup.js`, and `State` gained only
+  `getSyncState`, which is a projection through a dataset like `getLocus`.
 - **Counts moved.** `StateManager` is twelve methods, not ten; `testState.js` is 70 tests, not 54,
   and **none of them drives a restore**.
 
@@ -118,6 +120,16 @@ through the chokepoint. Both paths now read the payload back off the browser. **
 this class of defect** — it records `browser.state`, never the callback's argument — which is worth
 remembering for #560, #561 and #562, all three of which move the same seam.
 
+**What #562 could not delete: `HICBrowser.syncState`'s `synchable` guard.** The ticket named it as
+one of the three copies and expected the callers to carry the question. Both review axes found the
+same seam from opposite sides: the load-end sync step in `dataLoader` filters peers on
+`isCompatible` and **never looked at `synchable`**, so that guard was its only opt-out — and
+`synchedBrowsers` is a snapshot from the last `registry.sync()`, so a host flipping `synchable`
+afterwards was caught by the guard too. Deleting it strengthened one path and weakened the other,
+which "moves code, does not change what syncing does" does not allow. The guard stayed, written as
+`isSynchable(this)` — **one statement of the rule, three readers**, which is what the acceptance
+criterion was actually protecting. `test/testSyncOptOut.js` pins both paths and fails without it.
+
 **One split found while decomposing, against the ADR's own sequencing.** The ADR treats restore
 through the chokepoint as one ticket; it is two. Three of the five `setActiveDataset` call sites are
 immediately followed by `browser.setState`, which overwrites the unvalidated assignment — so #558
@@ -136,7 +148,7 @@ than rediscovered one at a time.
 | ~~**#510**~~ | Aug 2026 | Was the frontier. Promoted from a candidate-5 follow-up by ADR-0009 | ✅ **fixed**, before the gate, exactly as ADR-0009 sequenced it |
 | **#372** | Jul 2026 | Its **validation half is #561**. Restore is the first moment a valid normalization set exists | leave open; it narrows to notification |
 | **#528** | Aug 2026 | **Answered by ADR-0009.** It asked whether a numeric seventh state token (`normalization: "2000"`) should be rejected or coerced; decisions 2 and 5 say coerce, at restore, against the dataset | ✅ re-labelled `ready-for-agent` and pointed at #561; use it as #561's fixture |
-| **#280** | 2018 | **Plausibly this candidate's bug.** See the hypothesis below | ✅ linked both ways with #562; do **not** close on the reading |
+| **#280** | 2018 | **Hypothesis weakened by #566** — the rung it blames is unreachable, not racy. See below | linked both ways with #562; still open, needs the repro, do **not** close on the reading |
 | **#473** | Aug 2026 | Same in-flight hazard as #469, on `TrackPair` rather than `ContactMatrixView`. Candidate 6 changes who owns state mutation, so it may get easier or harder | watch during #563 |
 | ~~**#125**~~ | 2020 | Asked how `state` should be encoded for `loadHicFile`. The syntax in the question was always right; `docs/url.md` now documents v0 and v1 per ADR-0006 decision 2 | ✅ **answered and closed** |
 | ~~**#283**~~ | 2018 | Share produced `?juiceboxURL=undefined`. Moot — nothing writes that format since #506; only the adapter that refuses it remains | ✅ **closed as moot** |
@@ -150,9 +162,16 @@ assigned, and `canBeSynched` returns false when `activeDataset` is undefined. So
 two-map URL, whichever browser loses the load race falls through to the `else` branch and opens at
 `State.default` instead of synced. A race would produce exactly the reported intermittency.
 
-**Not reproduced.** It is a reading, not a diagnosis — but it is the kind of reading #557's golden
-can settle cheaply, because `synchState` is one of the five doors it pins. If the hypothesis holds,
-#559 and #562 close a bug that has been open for eight years, and that belongs in the Outcome box.
+**Not reproduced, and the mechanism is now doubtful.** #566 found the `config.synchState` rung
+*unreachable* rather than racy: `clearDataset()` runs four lines above it, so `canBeSynched` is
+never true and every first load carrying a `synchState` takes the fallback — not 30% of the time,
+always. A rung nothing takes cannot produce intermittency, so either #280 is a different bug or the
+reading is wrong about which door it comes through.
+
+**#562 landed without testing it**, deliberately: the check needs the repro, not another reading,
+and #562 moved `canBeSynched` without changing what it answers. **#280 stays open and stays linked.**
+The next honest move is to run its repro against a build with #566 lifted; until then it does not
+belong in candidate 6's Outcome box.
 
 ## The release note this candidate owes
 

--- a/docs/state-manipulation.md
+++ b/docs/state-manipulation.md
@@ -226,7 +226,8 @@ For BP coordinates, always go through `state.getLocus(dataset, viewDimensions)`.
 
 - `js/hicState.js` — `State` class. Canonical fields, all translators, `setView`, `getLocus`, helpers (`_adjustPixelSize`, `clampXY`).
 - `js/interactionHandler.js` — bridges UI events to translators. Should not mutate state fields directly.
-- `js/stateManager.js` — bulk replacement (`setState`, `setControlState`, `syncState`), state cloning for the active/control split.
+- `js/stateManager.js` — bulk replacement (`setState`, `setControlState`), state cloning for the active/control split.
+- `js/syncGroup.js` — the sync-group rule: which browsers pair (`pairSynchable`) and whether one may take a published state (`canBeSynched`). The only reader of `synchable` (#562).
 - `js/hicBrowser.js` — public API methods. Mostly thin delegations to `interactionHandler` or `stateManager`.
 - `js/dataLoader.js` — session/URL ingestion path.
 - `test/testState.js` — characterization tests for every translator and the chokepoint. The behavioral contract.

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -36,6 +36,7 @@ import Track2D from './track2D.js'
 
 import {decodeState} from "./sessionCodec.js"
 import {mapTrackConfig} from "./urlMapper.js"
+import {canBeSynched} from "./syncGroup.js"
 
 /**
  * How this module reports a `config.state` that is neither a state token nor a
@@ -140,7 +141,7 @@ class DataLoader {
             } else if (config.state) {
                 this.browser.setActiveDataset(dataset);
                 await this.browser.setState(decodeState(config.state, reportUnknownStateType));
-            } else if (config.synchState && this.browser.canBeSynched(config.synchState)) {
+            } else if (canBeSynched(this.browser, config.synchState)) {
                 await this.browser.syncState(config.synchState);
                 // syncState already sets the dataset, but ensure it's set with current dataset
                 if (this.browser.dataset !== dataset) {
@@ -188,14 +189,19 @@ class DataLoader {
 
             registry.sync(); // Sync browsers to ensure all browsers are updated with the new dataset
 
-            // Find a browser to sync with, if any
-            const compatibleBrowsers = registry.browsers.filter(
+            // Find a browser to sync with, if any. `canBeSynched` is the guard
+            // that keeps a browser opted out of syncing out of it -- it used to
+            // be `syncState`'s own, and #562 left `synchable` one reader.
+            const peer = registry.browsers.find(
                 b => b !== this.browser &&
                      b.dataset &&
                      b.dataset.isCompatible(this.browser.dataset)
             );
-            if (compatibleBrowsers.length > 0) {
-                await this.browser.syncState(compatibleBrowsers[0].getSyncState());
+            if (peer) {
+                const peerSyncState = peer.getSyncState();
+                if (canBeSynched(this.browser, peerSyncState)) {
+                    await this.browser.syncState(peerSyncState);
+                }
             }
 
             return dataset;

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -189,19 +189,16 @@ class DataLoader {
 
             registry.sync(); // Sync browsers to ensure all browsers are updated with the new dataset
 
-            // Find a browser to sync with, if any. `canBeSynched` is the guard
-            // that keeps a browser opted out of syncing out of it -- it used to
-            // be `syncState`'s own, and #562 left `synchable` one reader.
+            // Find a browser to sync with, if any. The opt-out is `syncState`'s
+            // own guard, as it was before #562 -- this filter has never looked
+            // at `synchable`.
             const peer = registry.browsers.find(
                 b => b !== this.browser &&
                      b.dataset &&
                      b.dataset.isCompatible(this.browser.dataset)
             );
             if (peer) {
-                const peerSyncState = peer.getSyncState();
-                if (canBeSynched(this.browser, peerSyncState)) {
-                    await this.browser.syncState(peerSyncState);
-                }
+                await this.browser.syncState(peer.getSyncState());
             }
 
             return dataset;

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -39,6 +39,7 @@ import InteractionHandler from "./interactionHandler.js"
 import DataLoader from "./dataLoader.js"
 import {normalizeTrackConfigs} from "./normalizeSession.js"
 import {unmappedUrl} from "./urlMapper.js"
+import {isSynchable} from "./syncGroup.js"
 
 const DEFAULT_PIXEL_SIZE = 1
 const MAX_PIXEL_SIZE = 128
@@ -967,14 +968,16 @@ class HICBrowser {
     /**
      * Take a sync state published by a sibling browser.
      *
-     * Whether this browser *may* take it is `canBeSynched` in `syncGroup.js`,
-     * and every caller has already asked: `syncToOtherBrowsers` walks
-     * `synchedBrowsers`, which `pairSynchable` built, and `dataLoader` guards
-     * both of its calls. So no `synchable` check here -- #562 left the flag one
-     * reader.
+     * The guard is `isSynchable` from `syncGroup.js` -- the same expression
+     * `pairSynchable` and `canBeSynched` read, so #562 left the `synchable`
+     * rule written down once. The guard itself stays here rather than being
+     * left to the callers: `syncToOtherBrowsers` walks `synchedBrowsers`, a set
+     * `registry.sync()` last rebuilt, so a browser whose host flipped
+     * `synchable` since then is still in it. That was master's behaviour and
+     * the ticket does not change what syncing does.
      */
     async syncState(targetState) {
-        if (!targetState || !this.dataset || !this.state) {
+        if (!targetState || !isSynchable(this) || !this.state) {
             return;
         }
 

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -951,30 +951,34 @@ class HICBrowser {
 
     /**
      * Return a modified state object used for synching.  Other datasets might have different chromosome ordering
-     * and resolution arrays
+     * and resolution arrays.
+     *
+     * The projection itself is `State.getSyncState(dataset)`; what is here is
+     * the "is there anything to publish yet" question, which is about the
+     * browser rather than about the view.
      */
     getSyncState() {
-        return this.stateManager.getSyncState();
+        if (!this.dataset || !this.state) {
+            return undefined;
+        }
+        return this.state.getSyncState(this.dataset);
     }
 
     /**
-     * Return true if this browser can be synced to the given state
-     * @param syncState
+     * Take a sync state published by a sibling browser.
+     *
+     * Whether this browser *may* take it is `canBeSynched` in `syncGroup.js`,
+     * and every caller has already asked: `syncToOtherBrowsers` walks
+     * `synchedBrowsers`, which `pairSynchable` built, and `dataLoader` guards
+     * both of its calls. So no `synchable` check here -- #562 left the flag one
+     * reader.
      */
-    canBeSynched(syncState) {
-        return this.stateManager.canBeSynched(syncState);
-    }
-
     async syncState(targetState) {
-        if (!targetState || false === this.synchable) {
+        if (!targetState || !this.dataset || !this.state) {
             return;
         }
 
-        if (!this.dataset) {
-            return;
-        }
-
-        const { zoomChanged, chrChanged } = await this.stateManager.syncState(targetState);
+        const { zoomChanged, chrChanged } = await this.state.sync(targetState, this, this.genome, this.dataset);
 
         // For sync, we don't want to propagate back to other browsers (would cause infinite loop)
         // So we update without syncing

--- a/js/hicState.js
+++ b/js/hicState.js
@@ -424,6 +424,28 @@ class State {
         )
     }
 
+    /**
+     * The view as a sibling browser can read it: chromosomes by name and a bin
+     * size rather than a zoom index, because the sibling's dataset may order
+     * its chromosomes differently and offer a different resolution array.
+     *
+     * A projection through a dataset, like `getLocus` -- so the dataset is a
+     * parameter, not a remembered field (ADR-0009 decision 6, #562).
+     *
+     * @param {Object} dataset
+     * @returns {Object} the sync state `State.sync` consumes on the other side
+     */
+    getSyncState(dataset) {
+        return {
+            chr1Name: dataset.chromosomes[this.chr1].name,
+            chr2Name: dataset.chromosomes[this.chr2].name,
+            binSize: dataset.bpResolutions[this.zoom],
+            binX: this.x,
+            binY: this.y,
+            pixelSize: this.pixelSize
+        }
+    }
+
     async sync(targetState, browser, genome, dataset) {
         const chr1 = genome.getChromosome(targetState.chr1Name)
         const chr2 = genome.getChromosome(targetState.chr2Name)

--- a/js/stateManager.js
+++ b/js/stateManager.js
@@ -27,8 +27,13 @@
  * This class manages:
  * - Active dataset and state
  * - State transitions and validation
- * - Cross-browser synchronization state
  * - State normalization and pixel size adjustments
+ *
+ * It no longer manages synchronization. #562 sent the three sync methods to the
+ * two places they belong: `canBeSynched` to `syncGroup.js`, where the rest of
+ * the group-membership rule lives, `getSyncState` to `State`, which is what
+ * projects a state through a dataset, and `syncState` nowhere -- it was a
+ * pass-through to `State.sync` whose guard its caller already carried.
  */
 class StateManager {
 
@@ -275,74 +280,6 @@ class StateManager {
         this.activeDataset = undefined;
         this.activeState = undefined;
         this.controlDataset = undefined;
-    }
-
-    /**
-     * Return a modified state object used for synching.
-     * Other datasets might have different chromosome ordering and resolution arrays.
-     * 
-     * @returns {Object} - Sync state object with chromosome names and bin coordinates
-     */
-    getSyncState() {
-        if (!this.activeDataset || !this.activeState) {
-            return undefined;
-        }
-
-        return {
-            chr1Name: this.activeDataset.chromosomes[this.activeState.chr1].name,
-            chr2Name: this.activeDataset.chromosomes[this.activeState.chr2].name,
-            binSize: this.activeDataset.bpResolutions[this.activeState.zoom],
-            binX: this.activeState.x,
-            binY: this.activeState.y,
-            pixelSize: this.activeState.pixelSize
-        };
-    }
-
-    /**
-     * Return true if this browser can be synced to the given state.
-     * 
-     * @param {Object} syncState - The sync state to check compatibility with
-     * @returns {boolean} - True if browser can sync to the given state
-     */
-    canBeSynched(syncState) {
-        if (false === this.browser.synchable) {
-            return false; // Explicitly not synchable
-        }
-
-        if (!this.activeDataset) {
-            return false;
-        }
-
-        return (
-            this.activeDataset.getChrIndexFromName(syncState.chr1Name) !== undefined &&
-            this.activeDataset.getChrIndexFromName(syncState.chr2Name) !== undefined
-        );
-    }
-
-    /**
-     * Sync this browser's state to match a target sync state.
-     * This method updates the state to match another browser's state for synchronization.
-     * 
-     * @param {Object} targetState - The target sync state to sync to
-     * @returns {Promise<{zoomChanged: boolean, chrChanged: boolean}>} - Change flags
-     */
-    async syncState(targetState) {
-        if (!targetState || false === this.browser.synchable) {
-            return { zoomChanged: false, chrChanged: false };
-        }
-
-        if (!this.activeDataset || !this.activeState) {
-            return { zoomChanged: false, chrChanged: false };
-        }
-
-        const { zoomChanged, chrChanged } = await this.activeState.sync(
-            targetState, 
-            this.browser, 
-            this.browser.genome, 
-            this.activeDataset
-        );
-
-        return { zoomChanged, chrChanged };
     }
 
     /**

--- a/js/syncGroup.js
+++ b/js/syncGroup.js
@@ -1,10 +1,10 @@
 /**
  * Has this browser opted out of syncing, and does it have a dataset to sync?
  *
- * The single reading of `synchable` in the codebase. It was read three times
+ * The single statement of the `synchable` rule. It was written out three times
  * until #562 -- here, in `HICBrowser.syncState`, and in
- * `StateManager.canBeSynched` -- and the two rules that need it now share this
- * one expression rather than restating it.
+ * `StateManager.canBeSynched` -- and its three readers now share this one
+ * expression rather than each restating it.
  *
  * @param {Object} browser
  * @returns {boolean}
@@ -73,4 +73,4 @@ function pairSynchable(browsers) {
     return pairs
 }
 
-export {pairSynchable, canBeSynched}
+export {pairSynchable, canBeSynched, isSynchable}

--- a/js/syncGroup.js
+++ b/js/syncGroup.js
@@ -1,4 +1,47 @@
 /**
+ * Has this browser opted out of syncing, and does it have a dataset to sync?
+ *
+ * The single reading of `synchable` in the codebase. It was read three times
+ * until #562 -- here, in `HICBrowser.syncState`, and in
+ * `StateManager.canBeSynched` -- and the two rules that need it now share this
+ * one expression rather than restating it.
+ *
+ * @param {Object} browser
+ * @returns {boolean}
+ */
+function isSynchable(browser) {
+    return browser.synchable !== false && browser.dataset !== undefined
+}
+
+/**
+ * May this browser take the state a sibling published?
+ *
+ * The inbound half of the sync-group rule: `pairSynchable` answers which
+ * browsers sync with which, this answers whether one particular published state
+ * can land on one particular browser. Same two membership questions, plus one
+ * more -- the dataset has to know the chromosomes the state names by name,
+ * since a sync state names them rather than indexing them.
+ *
+ * It lives here, not on `State`, because `synchable` is a group-membership fact
+ * about the browser and not a fact about the view. See ADR-0009 decision 6.
+ *
+ * @param {Object} browser
+ * @param {Object} syncState - as produced by `State.getSyncState`
+ * @returns {boolean}
+ */
+function canBeSynched(browser, syncState) {
+
+    if (!syncState || !isSynchable(browser)) {
+        return false
+    }
+
+    return (
+        browser.dataset.getChrIndexFromName(syncState.chr1Name) !== undefined &&
+        browser.dataset.getChrIndexFromName(syncState.chr2Name) !== undefined
+    )
+}
+
+/**
  * The sync-group pairing rule, as a pure function over a list of browsers.
  *
  * See decision 6 of `docs/adr/0004-browser-registry-per-container.md`: keeping
@@ -15,7 +58,7 @@
  */
 function pairSynchable(browsers) {
 
-    const synchableBrowsers = browsers.filter(b => b.synchable !== false && b.dataset !== undefined)
+    const synchableBrowsers = browsers.filter(isSynchable)
 
     const pairs = []
     for (let i = 0; i < synchableBrowsers.length; i++) {
@@ -30,4 +73,4 @@ function pairSynchable(browsers) {
     return pairs
 }
 
-export {pairSynchable}
+export {pairSynchable, canBeSynched}

--- a/test/testDefaultViewOrigin.js
+++ b/test/testDefaultViewOrigin.js
@@ -62,7 +62,6 @@ function stubBrowser(recorded) {
             recorded.push(state)
         },
         parseGotoInput: async () => undefined,
-        canBeSynched: () => false,
         syncState: async () => undefined
     }
     return browser

--- a/test/testRestoreGolden.js
+++ b/test/testRestoreGolden.js
@@ -95,7 +95,7 @@
  *    therefore **baseline**, not a regression -- it is finding 1 showing through,
  *    since no door clamps.
  * 3. **The `config.synchState` rung is unreachable.** Its guard is
- *    `config.synchState && browser.canBeSynched(...)`, and `canBeSynched`
+ *    `canBeSynched(browser, config.synchState)`, and `canBeSynched`
  *    returns false without an `activeDataset` -- which `loadHicFile` has just
  *    cleared, four lines earlier, by calling `clearDataset()`. So a config
  *    carrying a `synchState` silently takes the fallback rung instead. The door
@@ -424,7 +424,7 @@ function renderState(state, dataset, viewport) {
 }
 
 /**
- * `StateManager.getSyncState`, computed off a state that has not been restored
+ * `State.getSyncState`, computed off a state that has not been restored
  * yet.
  *
  * This is the one door whose input does not exist in any wire format: a
@@ -479,7 +479,7 @@ const RESTORE_DOORS = [
     {
         id: 'config.synchState — the sibling rung',
         // **Primed, because the rung is unreachable cold.** The ladder's guard is
-        // `config.synchState && browser.canBeSynched(...)`, and `canBeSynched`
+        // `canBeSynched(browser, config.synchState)`, and `canBeSynched`
         // returns false when `activeDataset` is undefined -- which it is, because
         // the ladder does not set the dataset until *inside* one of its branches.
         // So a first load carrying a `synchState` silently takes the fallback rung

--- a/test/testState.js
+++ b/test/testState.js
@@ -1194,3 +1194,49 @@ describe('State.default — the fall-back view', () => {
         expect(State.default().pixelSize).toBe(DEFAULT_PIXEL_SIZE)
     })
 })
+
+/**
+ * `getSyncState` is the outbound half of syncing: the projection a browser
+ * publishes so a sibling with a different chromosome ordering and a different
+ * resolution array can still find the same view. It names chromosomes rather
+ * than indexing them and carries a bin size rather than a zoom index, for
+ * exactly that reason. It reads the dataset, so the dataset is a parameter --
+ * the convention `setView` established (#562, ADR-0009 decision 6).
+ */
+describe('State.getSyncState — pure projection through a dataset', () => {
+
+    test('names the chromosomes and resolves the zoom index to a bin size', () => {
+        const dataset = createMockDataset()
+        const state = createState({ chr1: 1, chr2: 2, zoom: 3, x: 100, y: 50, pixelSize: 2 })
+
+        expect(state.getSyncState(dataset)).toEqual({
+            chr1Name: 'chr1',
+            chr2Name: 'chr2',
+            binSize: 250000,   // bpResolutions[3]
+            binX: 100,
+            binY: 50,
+            pixelSize: 2,
+        })
+    })
+
+    test('reads names and bin size from the dataset it is handed, not from a remembered one', () => {
+        const state = createState({ chr1: 1, chr2: 1, zoom: 0, x: 7, y: 9, pixelSize: 3 })
+
+        const other = createMockDataset({
+            chromosomes: [
+                { index: 0, name: 'all', size: 3000000000 },
+                { index: 1, name: 'I', size: 230218 },
+            ],
+            bpResolutions: [5000, 1000],
+        })
+
+        expect(state.getSyncState(other)).toEqual({
+            chr1Name: 'I',
+            chr2Name: 'I',
+            binSize: 5000,
+            binX: 7,
+            binY: 9,
+            pixelSize: 3,
+        })
+    })
+})

--- a/test/testSyncGroup.js
+++ b/test/testSyncGroup.js
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest'
-import {pairSynchable} from '../js/syncGroup.js'
+import {pairSynchable, canBeSynched} from '../js/syncGroup.js'
 
 /**
  * The sync-group pairing rule -- see #476, decision 6 of ADR-0004.
@@ -10,11 +10,15 @@ import {pairSynchable} from '../js/syncGroup.js'
  * flag and a `dataset` that can answer `isCompatible`.
  */
 
-function fakeDataset(genomeId) {
+function fakeDataset(genomeId, chromosomeNames = ['all', 'chr1', 'chr2']) {
     return {
         genomeId,
         isCompatible(other) {
             return other.genomeId === genomeId
+        },
+        getChrIndexFromName(name) {
+            const index = chromosomeNames.indexOf(name)
+            return index === -1 ? undefined : index
         }
     }
 }
@@ -84,5 +88,49 @@ describe('pairSynchable', () => {
         const empty = fakeBrowser('empty')
 
         expect(pairSynchable([a, other, b, optedOut, empty, c])).toEqual([[a, b], [a, c], [b, c]])
+    })
+})
+
+/**
+ * `canBeSynched` is the inbound half of the same rule: not "which browsers pair
+ * with which" but "may this one browser take that published state". It lives
+ * here because it asks the same two questions the pairing filter asks -- has
+ * this browser opted out, and does it have a dataset -- and then one more, that
+ * the dataset knows the chromosomes the state names. Keeping it beside
+ * `pairSynchable` is what lets `synchable` be read in exactly one expression
+ * (#562, ADR-0009 decision 6).
+ */
+describe('canBeSynched', () => {
+
+    const syncState = {chr1Name: 'chr1', chr2Name: 'chr2', binSize: 100000, binX: 0, binY: 0, pixelSize: 1}
+
+    it('accepts a browser whose dataset knows both chromosomes', () => {
+        const browser = fakeBrowser('a', {dataset: fakeDataset('hg38')})
+
+        expect(canBeSynched(browser, syncState)).toBe(true)
+    })
+
+    it('keeps a browser that opted out of syncing out, even when its dataset would fit', () => {
+        const browser = fakeBrowser('opted-out', {dataset: fakeDataset('hg38'), synchable: false})
+
+        expect(canBeSynched(browser, syncState)).toBe(false)
+    })
+
+    it('refuses a browser with no dataset', () => {
+        const browser = fakeBrowser('empty')
+
+        expect(canBeSynched(browser, syncState)).toBe(false)
+    })
+
+    it('refuses a state naming a chromosome the dataset does not have', () => {
+        const browser = fakeBrowser('a', {dataset: fakeDataset('hg38', ['all', 'chr1'])})
+
+        expect(canBeSynched(browser, syncState)).toBe(false)
+    })
+
+    it('refuses a missing state rather than throwing', () => {
+        const browser = fakeBrowser('a', {dataset: fakeDataset('hg38')})
+
+        expect(canBeSynched(browser, undefined)).toBe(false)
     })
 })

--- a/test/testSyncOptOut.js
+++ b/test/testSyncOptOut.js
@@ -1,0 +1,102 @@
+/**
+ * A browser that opted out of syncing stays out.
+ *
+ * `synchable: false` is a host's way of pinning one panel while the others move
+ * together. Until #562 the flag was read in three places, one of which --
+ * `HICBrowser.syncState`'s own guard -- was the only thing stopping the
+ * "sync with a compatible browser" step at the end of `loadHicFile`, since that
+ * step's filter never looked at the flag. The split moved the reading to
+ * `canBeSynched`, so this pins the behaviour rather than the reader: load a map
+ * into an opted-out browser next to a compatible peer, and it must open at its
+ * own state.
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+const loadDataset = vi.fn()
+
+vi.mock('../js/hicDataset.js', () => ({
+    default: { loadDataset: (...args) => loadDataset(...args) },
+    HiCDataset: class {}
+}))
+
+const { default: DataLoader } = await import('../js/dataLoader.js')
+
+const CHROMOSOMES = [
+    { name: 'All', size: 2000, index: 0 },
+    { name: 'chr1', size: 1000, index: 1 }
+]
+
+function stubDataset() {
+    return {
+        genomeId: 'hg19',
+        chromosomes: CHROMOSOMES,
+        bpResolutions: [1000, 100],
+        datasetType: 'hic',
+        isCompatible: () => true,
+        getChrIndexFromName: name => CHROMOSOMES.find(c => c.name === name)?.index
+    }
+}
+
+/** The sibling already showing a map, whose state the loading browser would take. */
+function stubPeer() {
+    return {
+        dataset: stubDataset(),
+        getSyncState: () => ({
+            chr1Name: 'chr1', chr2Name: 'chr1', binSize: 1000, binX: 3, binY: 4, pixelSize: 2
+        })
+    }
+}
+
+function stubBrowser({ synchable, peer, synched }) {
+    const browser = {
+        synchable,
+        genome: undefined,
+        dataset: undefined,
+        clearDataset: () => undefined,
+        stopSpinner: () => undefined,
+        contactMatrixView: { startSpinner: () => undefined },
+        contactMapLabel: { textContent: '', title: '' },
+        userInteractionShield: { style: {} },
+        controlDataset: undefined,
+        coordinator: {
+            onNormalizationExternalChange: () => undefined,
+            onGenomeChange: () => undefined,
+            onNormVectorIndexLoad: () => undefined,
+            onMapLoaded: () => undefined
+        },
+        registry: { presentAlert: () => undefined, sync: () => undefined, browsers: [peer] },
+        setActiveDataset: dataset => { browser.dataset = dataset },
+        setState: async () => undefined,
+        parseGotoInput: async () => undefined,
+        syncState: async targetState => { synched.push(targetState) }
+    }
+    browser.registry.browsers.push(browser)
+    return browser
+}
+
+describe('the sync step at the end of a map load', () => {
+
+    beforeEach(() => {
+        loadDataset.mockReset()
+        loadDataset.mockResolvedValue(stubDataset())
+    })
+
+    test('a browser that opted out of syncing does not take a compatible peer\'s state', async () => {
+        const synched = []
+        const browser = stubBrowser({ synchable: false, peer: stubPeer(), synched })
+
+        await new DataLoader(browser).loadHicFile({ url: 'https://example.org/a.hic' }, true)
+
+        expect(synched).toEqual([])
+    })
+
+    test('a browser that did not opt out takes it', async () => {
+        const synched = []
+        const browser = stubBrowser({ synchable: undefined, peer: stubPeer(), synched })
+
+        await new DataLoader(browser).loadHicFile({ url: 'https://example.org/a.hic' }, true)
+
+        expect(synched).toHaveLength(1)
+        expect(synched[0]).toMatchObject({ chr1Name: 'chr1', binX: 3, binY: 4 })
+    })
+})

--- a/test/testSyncOptOut.js
+++ b/test/testSyncOptOut.js
@@ -20,6 +20,7 @@ vi.mock('../js/hicDataset.js', () => ({
 }))
 
 const { default: DataLoader } = await import('../js/dataLoader.js')
+const { default: HICBrowser } = await import('../js/hicBrowser.js')
 
 const CHROMOSOMES = [
     { name: 'All', size: 2000, index: 0 },
@@ -47,10 +48,23 @@ function stubPeer() {
     }
 }
 
+/**
+ * The stub takes `HICBrowser`'s real `syncState` -- the guard under test is in
+ * it, so a hand-written stand-in would test nothing. Everything that method
+ * touches beyond the guard is stubbed: `state.sync` records the call, `update`
+ * and the coordinator do nothing.
+ */
 function stubBrowser({ synchable, peer, synched }) {
     const browser = {
         synchable,
-        genome: undefined,
+        genome: { getChromosome: name => CHROMOSOMES.find(c => c.name === name) },
+        state: {
+            sync: async targetState => {
+                synched.push(targetState)
+                return { zoomChanged: false, chrChanged: false }
+            }
+        },
+        update: async () => undefined,
         dataset: undefined,
         clearDataset: () => undefined,
         stopSpinner: () => undefined,
@@ -59,6 +73,7 @@ function stubBrowser({ synchable, peer, synched }) {
         userInteractionShield: { style: {} },
         controlDataset: undefined,
         coordinator: {
+            onLocusChange: () => undefined,
             onNormalizationExternalChange: () => undefined,
             onGenomeChange: () => undefined,
             onNormVectorIndexLoad: () => undefined,
@@ -68,7 +83,7 @@ function stubBrowser({ synchable, peer, synched }) {
         setActiveDataset: dataset => { browser.dataset = dataset },
         setState: async () => undefined,
         parseGotoInput: async () => undefined,
-        syncState: async targetState => { synched.push(targetState) }
+        syncState: targetState => HICBrowser.prototype.syncState.call(browser, targetState)
     }
     browser.registry.browsers.push(browser)
     return browser
@@ -98,5 +113,36 @@ describe('the sync step at the end of a map load', () => {
 
         expect(synched).toHaveLength(1)
         expect(synched[0]).toMatchObject({ chr1Name: 'chr1', binX: 3, binY: 4 })
+    })
+})
+
+/**
+ * `synchedBrowsers` is a snapshot: `registry.sync()` rebuilds it with
+ * `pairSynchable`, and it stands until the next rebuild. A host that flips
+ * `synchable` in between leaves a browser in a set it no longer belongs to, and
+ * the only thing that catches it is `syncState`'s own guard -- which is why
+ * #562 kept that guard rather than leaving the question to the callers.
+ */
+describe('the sync a browser pushes to the browsers it is linked with', () => {
+
+    test('a browser that opted out after the group was built does not take the state', async () => {
+        const synched = []
+        const recipient = stubBrowser({ synchable: undefined, peer: undefined, synched })
+        recipient.dataset = stubDataset()
+
+        const source = {
+            synchedBrowsers: new Set([recipient]),
+            getSyncState: () => ({
+                chr1Name: 'chr1', chr2Name: 'chr1', binSize: 1000, binX: 3, binY: 4, pixelSize: 2
+            })
+        }
+
+        // The host flips the flag; nothing rebuilds the group.
+        recipient.synchable = false
+
+        HICBrowser.prototype.syncToOtherBrowsers.call(source)
+        await Promise.resolve()
+
+        expect(synched).toEqual([])
     })
 })


### PR DESCRIPTION
Closes #562. Candidate 6, [ADR-0009](https://github.com/aidenlab/juicebox.js/blob/master/docs/adr/0009-restore-is-a-translator.md) decision 6.

## What moved

- **`canBeSynched` → `js/syncGroup.js`**, beside `pairSynchable`. Both read one shared `isSynchable(browser)`, so the `synchable` rule is written down once instead of three times.
- **`getSyncState` → `State.getSyncState(dataset)`**. A projection through a dataset like `getLocus`, with the dataset as a parameter — the convention `setView` established. `HICBrowser.getSyncState()` keeps only the "is there anything to publish yet" question, which is about the browser rather than the view.
- **`StateManager.syncState` deleted.** `HICBrowser.syncState` reaches `State.sync` directly. `StateManager` no longer has a sync concern.

## Where this diverges from the ticket

The ticket lists `HICBrowser.syncState`'s `synchable` guard among the three checks that should collapse, leaving the question to its callers. Both review axes found the same seam from opposite sides:

- The load-end sync step in `dataLoader` filters peers on `isCompatible` and **never looked at `synchable`** — that guard was its only opt-out.
- `synchedBrowsers` is a snapshot from the last `registry.sync()`, so a host flipping `synchable` afterwards was caught by the guard too.

Deleting it strengthened one path and weakened the other, which the last acceptance criterion — *"this ticket moves code, it does not change what syncing does"* — does not allow. **The guard stayed, written as `isSynchable(this)`**: one statement of the rule, three readers, which is what the criterion about `synchable` was actually protecting.

## Tests

`test/testSyncOptOut.js` (new) drives the real `HICBrowser.syncState` rather than a stand-in, covering both the load-end path and `syncToOtherBrowsers`; all three tests fail with the guard removed. Plus `canBeSynched` cases in `testSyncGroup.js` and `State.getSyncState` cases in `testState.js`. Full suite: 981 passing.

## Not done, on purpose

The issue asks that the split be checked against #280's repro. That needs the repro, not another reading — and #566 found the `config.synchState` rung unreachable rather than racy, which is not a mechanism that produces intermittency. #280 stays open, stays linked, and stays out of candidate 6's Outcome box; the punch list now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)