### PR TITLE
#521: one outward shape for a session that will not decode

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -174,6 +174,15 @@ have never been sampled. The contract is frozen against what the decoder takes,
 and the evidence that this matches what users send is partial by decision. See
 `test/data/wireFormatCorpus.js`'s harvest-scope note.
 
+**Session source** — *where* a session was read from, as distinct from what it
+says: the `session=` parameter itself, a File, or a fetched URL. The three arms
+of the `session` adapter, and a fact a user needs when a link will not open —
+"which of my links is this?" is the first question a refusal has to answer. It
+is carried outward on the `source` field of a `SessionDecodeError` and spelled
+into that error's message, both from `SESSION_SOURCES` (`js/sessionCodec.js`).
+Vocabulary of the `session=` format only: the legacy braced parameters name
+themselves in their own messages. #521.
+
 **Wire-format adapter** — one entry in `WIRE_FORMATS` (`js/sessionCodec.js`):
 the pair of "does this input carry my format?" and "decode it into the shared
 decode context." The array is the only place a format is named, so adding a

--- a/js/sessionCodec.js
+++ b/js/sessionCodec.js
@@ -60,7 +60,7 @@
  * 10: a session parameter may name a URL whose *contents* then need sniffing, so
  * a caller deciding whether more I/O is needed would need to know the format.
  *
- * The one read left inside is `File.text()`, in the `session` adapter's second
+ * The one read left inside is `File.text()`, in the `session` adapter's File
  * arm — an arm the sole caller cannot reach at all (see `testDecoderGolden.js`,
  * "the File arm is not reachable"). It gets no loader slot because inventing one
  * for a dead arm would be design work in service of nothing.
@@ -150,12 +150,21 @@ const COMPRESSED_PREFIXES = {
  * `cause` is the failure underneath — a `SyntaxError` from `JSON.parse`, or
  * whatever the decompressor threw, which is not always an `Error`: `BGZip`
  * rejects a corrupt payload with a bare string.
+ *
+ * `source` says where the session came from — a key of {@link SESSION_SOURCES}
+ * — and is carried by the one a caller sees, the error {@link sessionFailure}
+ * writes. It is a constructor parameter rather than a field stamped on
+ * afterwards because it is the half of the report a caller is invited to branch
+ * on, and a field the type does not declare is a field the next reader has to
+ * discover. Absent on the errors raised *inside* the decode ladder, which
+ * describe a string and cannot know where it was read from.
  */
 export class SessionDecodeError extends Error {
-    constructor(message, cause) {
+    constructor(message, cause, source) {
         super(message)
         this.name = 'SessionDecodeError'
         this.cause = cause
+        this.source = source
     }
 }
 
@@ -614,8 +623,7 @@ function sessionFailure(source, e) {
 
     const failure = new SessionDecodeError(
         `Could not decode the session from ${SESSION_SOURCES[source]}: ${e.message}${describeCause(e.cause)}`,
-        e)
-    failure.source = source
+        e, source)
 
     console.error(failure.message, e)
 
@@ -629,8 +637,25 @@ function sessionFailure(source, e) {
  * an empty pair of brackets after it.
  */
 function describeCause(cause) {
-    if (undefined === cause || null === cause) return ''
-    return ` (${cause instanceof Error ? cause.message : String(cause)})`
+    const described = undefined === cause || null === cause
+        ? ''
+        : (cause instanceof Error ? cause.message : String(cause))
+    return '' === described ? '' : ` (${described})`
+}
+
+/**
+ * Decode one session string, reporting a refusal as coming from `source`.
+ *
+ * The three arms differ in where their text comes from and in nothing else, so
+ * this is what they have in common written once rather than three times — which
+ * is the "one shape" of #521 made structural instead of maintained by hand.
+ */
+function decodeFrom(source, text) {
+    try {
+        return decodeSessionString(text)
+    } catch (e) {
+        throw sessionFailure(source, e)
+    }
 }
 
 /**
@@ -729,28 +754,18 @@ export const WIRE_FORMATS = [
             const sessionValue = ctx.query.session
             let source
 
-            // The File is asked about first, and has to be: `isCompressedSession`
-            // sniffs a prefix off a string and raises a bare `TypeError` on
-            // anything else, so with the string test in front of it the File arm
-            // could not be entered at all -- not even by a caller driving this
-            // adapter directly -- and so could not report in the one shape #521
-            // is about. The order is safe because a query value that is a string
-            // is never a File: `isFile` wants `name`, `slice` and `arrayBuffer`.
-            if (isFile(sessionValue)) {
-                source = 'file'
-                const sessionText = await sessionValue.text()
-                try {
-                    ctx.config = decodeSessionString(sessionText)
-                } catch (e) {
-                    throw sessionFailure(source, e)
-                }
-            } else if (isCompressedSession(sessionValue)) {
+            // `isCompressedSession` sniffs a prefix off a string and raises a
+            // bare `TypeError` on anything else, so the string test in front of
+            // it is what makes the arms below reachable at all -- the File arm
+            // could not be entered even by a caller driving this adapter
+            // directly, which is why it had no way to report in the one shape.
+            // The arms themselves stay in the order they have always been in.
+            if (typeof sessionValue === 'string' && isCompressedSession(sessionValue)) {
                 source = 'parameter'
-                try {
-                    ctx.config = decodeSessionString(sessionValue)
-                } catch (e) {
-                    throw sessionFailure(source, e)
-                }
+                ctx.config = decodeFrom(source, sessionValue)
+            } else if (isFile(sessionValue)) {
+                source = 'file'
+                ctx.config = decodeFrom(source, await sessionValue.text())
             } else if (typeof sessionValue === 'string') {
                 // A session URL, or a local file path. The fetched document is
                 // itself sniffed -- it may be plain JSON or either compressed
@@ -772,11 +787,15 @@ export const WIRE_FORMATS = [
                         new SessionDecodeError('Session document could not be fetched', e))
                 }
 
-                try {
-                    ctx.config = decodeSessionString(sessionText)
-                } catch (e) {
-                    throw sessionFailure(source, e)
-                }
+                ctx.config = decodeFrom(source, sessionText)
+            } else {
+                // Neither a File nor a string. Unreachable from `extractConfig`,
+                // whose parser can only produce strings, and reported anyway:
+                // the value came off the parameter, and the ladder says what is
+                // wrong with it ("Session must be a string, got …") in the one
+                // shape rather than as a bare `TypeError` out of the sniff.
+                source = 'parameter'
+                ctx.config = decodeFrom(source, sessionValue)
             }
 
             // Outside the arms on purpose, and after all three: the version is a
@@ -835,7 +854,18 @@ export const WIRE_FORMATS = [
             const {query} = ctx
             let q;
             if (query.hasOwnProperty("juiceboxData")) {
-                q = BGZip.uncompressString(query["juiceboxData"])
+                // Wrapped for the same reason the session arms are (#521): a
+                // corrupt payload rejects out of `BGZip` with a bare string, and
+                // "the rejection is always an `Error`" is a claim about
+                // `extractConfig`, not about the `session` parameter alone. The
+                // parameter names itself in the message, so there is no source
+                // to carry -- `SESSION_SOURCES` is the `session=` vocabulary.
+                try {
+                    q = BGZip.uncompressString(query["juiceboxData"])
+                } catch (e) {
+                    throw new SessionDecodeError(
+                        'juiceboxData= is not a readable compressed query string', e)
+                }
             } else {
                 q = query["juicebox"];
                 if (q.startsWith("%7B")) {

--- a/js/sessionCodec.js
+++ b/js/sessionCodec.js
@@ -74,18 +74,16 @@
  *
  * ## The error contract
  *
- * One condition, one error: anything this module cannot decode raises a
- * `SessionDecodeError` carrying the underlying failure as `cause`. Previously
- * the same malformed input produced a different message depending on which of
- * three call sites reached it, which made a user's bug report ambiguous about
- * where their link actually failed.
- *
- * **The three arms of the `session` adapter still rethrow `cause` in the shape
- * each has always thrown** — they were three call sites in `urlUtils.js` until
- * #505 moved them here — because ADR-0006's golden file (#503) pins those
- * outward messages and neither ticket changes behaviour. Unifying what the
- * *caller* reports is a deliberate, snapshot-moving change and belongs to a
- * later ticket in the candidate; unifying what the *decoder* raises is this one.
+ * One condition, one error, one shape: anything this module cannot decode
+ * raises a `SessionDecodeError` carrying the underlying failure as `cause`, and
+ * anything that leaves the `session` adapter has been through
+ * {@link sessionFailure} — so a malformed session reports the same way whichever
+ * of the three arms fetched it, naming both what would not decode and where the
+ * session came from. Before, the same input produced a different message
+ * depending on which path reached it (and, down one of them, a value that was
+ * not an `Error` at all), which made a user's bug report ambiguous about where
+ * their link had actually failed. #504 unified what the decoder *raises*; #521
+ * unified what the caller *reports*, and moved four golden snapshots doing it.
  *
  * @see docs/adr/0006-session-wire-format-and-one-decoder.md
  * @see docs/url.md — the format specification
@@ -574,17 +572,65 @@ function decodeQuery(query, uriDecode) {
 // ---------------------------------------------------------------------------
 
 /**
- * Report a session that would not decode, in the shape the arm naming `origin`
- * has always reported it. Two arms, one shape, one noun apart.
- *
- * `cause` is the failure underneath the codec's single `SessionDecodeError`, and
- * is not always an `Error` -- `BGZip` rejects a corrupt payload with a bare
- * string, whose `message` is `undefined`. That `undefined` reaches the user
- * today; #521 is where it stops.
+ * Where a session came from, spelled for a user. The keys are the vocabulary a
+ * caller branches on and the values are what the message says; both are here so
+ * that the three arms cannot drift into three ways of naming the same thing
+ * again.
  */
-function parseFailure(origin, e) {
-    console.error(`Error parsing session ${origin}:`, e.cause);
-    return new Error(`Failed to parse session ${origin}: ${e.cause?.message}`);
+export const SESSION_SOURCES = {
+    parameter: 'the session= parameter',
+    file: 'a session file',
+    url: 'a session URL',
+}
+
+/**
+ * The one outward shape for a session that will not decode. #521.
+ *
+ * Until this ticket each arm reported in the shape it happened to have grown:
+ * the parameter arm rethrew `cause` untouched — a bare **string** from `BGZip`,
+ * so `name` and `message` were both `undefined` and what escaped `extractConfig`
+ * was not an `Error` at all — while the File and URL arms wrote one sentence and
+ * two respectively. The same malformed input therefore reported differently
+ * depending on which path reached it, and a user's bug report could not say
+ * where their link had actually failed.
+ *
+ * What comes out now is always a `SessionDecodeError` carrying **two facts in
+ * one message**: what would not decode, and where the session came from. The
+ * *what* is the codec's own reason ({@link decodeSessionString} and
+ * {@link takeSessionVersion} raise one for every condition), which is why this
+ * reads `e.message` and not `e.cause?.message` — the reason is always present
+ * and always a string, where the underlying failure is neither. The underlying
+ * failure is not lost: it is quoted in parentheses when it says anything, and
+ * stays reachable through the `cause` chain either way.
+ *
+ * @param {string} source - a key of {@link SESSION_SOURCES}
+ * @param {SessionDecodeError} e - the codec's reason for refusing. An arm that
+ *   fails before the codec is reached — the URL arm, whose fetch can fail —
+ *   states its own reason as one of these, so that every path through here has
+ *   a *what* to report and not just a cause.
+ * @returns {SessionDecodeError} to throw
+ */
+function sessionFailure(source, e) {
+
+    const failure = new SessionDecodeError(
+        `Could not decode the session from ${SESSION_SOURCES[source]}: ${e.message}${describeCause(e.cause)}`,
+        e)
+    failure.source = source
+
+    console.error(failure.message, e)
+
+    return failure
+}
+
+/**
+ * Quote a failure that is not necessarily an `Error` — `BGZip` rejects a corrupt
+ * payload with a bare string — as a parenthetical, or as nothing when there is
+ * nothing underneath. A version refusal has no cause, and reads better without
+ * an empty pair of brackets after it.
+ */
+function describeCause(cause) {
+    if (undefined === cause || null === cause) return ''
+    return ` (${cause instanceof Error ? cause.message : String(cause)})`
 }
 
 /**
@@ -671,60 +717,80 @@ export const WIRE_FORMATS = [
      * `?session=` — the only form juicebox still writes, and the only one that
      * may need a second read. Three arms, one decoder: they differ in where the
      * session text comes from — the parameter itself, a File, or a fetched
-     * document — and in how they report a failure. The reporting is preserved
-     * verbatim, because #503's golden file pins those messages; collapsing the
-     * three outward messages into one is #521.
+     * document — and in nothing else. **They used to differ in how they reported
+     * a failure too**; #521 collapsed that into the one shape
+     * {@link sessionFailure} writes, which is why each arm now does no more than
+     * name where its text came from.
      */
     {
         format: 'session',
         appliesTo: ({query}) => query.hasOwnProperty('session'),
         decode: async ctx => {
             const sessionValue = ctx.query.session
+            let source
 
-            if (isCompressedSession(sessionValue)) {
-                // No wrapping here, and never has been: a corrupt share link
-                // rejects with whatever the decompressor threw, which is a bare
-                // string rather than an Error.
-                try {
-                    ctx.config = decodeSessionString(sessionValue)
-                } catch (e) {
-                    throw e.cause ?? e
-                }
-            } else if (isFile(sessionValue)) {
+            // The File is asked about first, and has to be: `isCompressedSession`
+            // sniffs a prefix off a string and raises a bare `TypeError` on
+            // anything else, so with the string test in front of it the File arm
+            // could not be entered at all -- not even by a caller driving this
+            // adapter directly -- and so could not report in the one shape #521
+            // is about. The order is safe because a query value that is a string
+            // is never a File: `isFile` wants `name`, `slice` and `arrayBuffer`.
+            if (isFile(sessionValue)) {
+                source = 'file'
                 const sessionText = await sessionValue.text()
                 try {
                     ctx.config = decodeSessionString(sessionText)
                 } catch (e) {
-                    throw parseFailure('file', e)
+                    throw sessionFailure(source, e)
+                }
+            } else if (isCompressedSession(sessionValue)) {
+                source = 'parameter'
+                try {
+                    ctx.config = decodeSessionString(sessionValue)
+                } catch (e) {
+                    throw sessionFailure(source, e)
                 }
             } else if (typeof sessionValue === 'string') {
                 // A session URL, or a local file path. The fetched document is
                 // itself sniffed -- it may be plain JSON or either compressed
                 // form -- which is why this read cannot be hoisted out of the
                 // decoder (ADR-0006 decision 10).
+                source = 'url'
                 const loadString = requireLoader(ctx, 'loadString', 'a session URL')
+
+                // Two reads, two catches, in sequence rather than nested. Nested
+                // is how the double-wrapped message arose -- the outer catch saw
+                // the inner one's rethrow and wrapped it a second time -- and it
+                // also folded two different repairs, a link that does not resolve
+                // and a document that is not a session, into one report.
+                let sessionText
                 try {
-                    const sessionText = await loadString(sessionValue)
-                    try {
-                        ctx.config = decodeSessionString(sessionText)
-                    } catch (e) {
-                        throw parseFailure('from URL/file', e)
-                    }
+                    sessionText = await loadString(sessionValue)
                 } catch (e) {
-                    console.error("Error loading session from URL/file:", e);
-                    throw new Error(`Failed to load session from URL/file: ${e.message}`);
+                    throw sessionFailure(source,
+                        new SessionDecodeError('Session document could not be fetched', e))
+                }
+
+                try {
+                    ctx.config = decodeSessionString(sessionText)
+                } catch (e) {
+                    throw sessionFailure(source, e)
                 }
             }
 
-            // Outside the arms on purpose, and after all three. Outside, because
-            // each arm rewraps what it catches -- the URL arm's wrapper reads
-            // `cause.message`, which a version refusal does not have, so a check
-            // inside would report `undefined` to the user (#521). After, because
-            // the version is a property of the document, not of where it was
-            // read from: a session named by a URL is version-checked exactly as
-            // one carried in the parameter.
+            // Outside the arms on purpose, and after all three: the version is a
+            // property of the document, not of where it was read from, so a
+            // session named by a URL is version-checked exactly as one carried
+            // in the parameter. It is reported *with* the source all the same --
+            // "which of my links is this?" is the first question a refusal has
+            // to answer, whatever raised it.
             if (ctx.config) {
-                ctx.config = takeSessionVersion(ctx.config)
+                try {
+                    ctx.config = takeSessionVersion(ctx.config)
+                } catch (e) {
+                    throw sessionFailure(source, e)
+                }
             }
         },
     },

--- a/test/__snapshots__/testDecoderGolden.js.snap
+++ b/test/__snapshots__/testDecoderGolden.js.snap
@@ -457,9 +457,8 @@ exports[`decoder golden file — inputs the decoder takes as a string > reject-q
 exports[`decoder golden file — inputs the decoder takes as a string > reject-session-blob-corrupt 1`] = `
 {
   "error": {
-    "message": undefined,
-    "name": undefined,
-    "thrown": "string: invalid block type",
+    "message": "Could not decode the session from the session= parameter: Session is not a readable blob (invalid block type)",
+    "name": "SessionDecodeError",
   },
   "outcome": "throws",
 }
@@ -468,9 +467,8 @@ exports[`decoder golden file — inputs the decoder takes as a string > reject-s
 exports[`decoder golden file — inputs the decoder takes as a string > reject-session-gzip-data-uri 1`] = `
 {
   "error": {
-    "message": undefined,
-    "name": undefined,
-    "thrown": "string: invalid distance too far back",
+    "message": "Could not decode the session from the session= parameter: Session is not a readable data-uri (invalid distance too far back)",
+    "name": "SessionDecodeError",
   },
   "outcome": "throws",
 }
@@ -1028,8 +1026,8 @@ exports[`decoder golden file — inputs the decoder takes as a string > synth-se
 exports[`decoder golden file — session URLs, driven from their loader response > reject-session-url-invalid-json 1`] = `
 {
   "error": {
-    "message": "Failed to load session from URL/file: Failed to parse session from URL/file: Unexpected token '<', "<!doctype "... is not valid JSON",
-    "name": "Error",
+    "message": "Could not decode the session from a session URL: Session is not valid JSON (Unexpected token '<', "<!doctype "... is not valid JSON)",
+    "name": "SessionDecodeError",
   },
   "outcome": "throws",
 }
@@ -1038,8 +1036,8 @@ exports[`decoder golden file — session URLs, driven from their loader response
 exports[`decoder golden file — session URLs, driven from their loader response > reject-session-url-unreachable 1`] = `
 {
   "error": {
-    "message": "Failed to load session from URL/file: simulated fetch failure",
-    "name": "Error",
+    "message": "Could not decode the session from a session URL: Session document could not be fetched (simulated fetch failure)",
+    "name": "SessionDecodeError",
   },
   "outcome": "throws",
 }

--- a/test/data/wireFormatCorpus.js
+++ b/test/data/wireFormatCorpus.js
@@ -667,7 +667,7 @@ export const wireFormatCorpus = [
         outcome: 'throws',
         input: '?session=https://example.org/fixtures/does-not-exist.json',
         loaderResponse: null,
-        note: 'A `loaderResponse` of null means the loader rejects. Wrapped as "Failed to load session from URL/file: …". This is the failure a stale `?session=` link produces, and the outer of the two nested catches — the inner one is reject-session-url-invalid-json.',
+        note: 'A `loaderResponse` of null means the loader rejects. This is the failure a stale `?session=` link produces. It and reject-session-url-invalid-json were the two nested catches, and the nesting is why a document that fetched fine and then would not parse was reported as if the fetch had failed; #521 unnested them, so the two now report the same shape with different *reasons* — "Session document could not be fetched" here, "Session is not valid JSON" there.',
     },
 
     {
@@ -679,7 +679,7 @@ export const wireFormatCorpus = [
         outcome: 'throws',
         input: '?session=https://example.org/fixtures/not-json.txt',
         loaderResponse: '<!doctype html><title>404</title>',
-        note: 'The loader succeeds and returns something that is neither compressed nor JSON — in practice a login page or an error page served with a 200. Wrapped as "Failed to parse session from URL/file: …".',
+        note: 'The loader succeeds and returns something that is neither compressed nor JSON — in practice a login page or an error page served with a 200. Reported as a parse failure naming a session URL as the source (#521); it used to arrive double-wrapped inside a load failure.',
     },
 
     {
@@ -690,7 +690,7 @@ export const wireFormatCorpus = [
         source: 'urlUtils.js:89 — BGZip.uncompressString on a payload that is not compressed',
         outcome: 'throws',
         input: '?session=blob:not-actually-compressed',
-        note: 'Throws out of the decompressor, uncaught and unwrapped — the `blob:`/`data:` arm has no try/catch, unlike the file and URL arms. The message is undefined. A truncated share link lands here.',
+        note: 'A truncated share link lands here. It used to throw out of the decompressor uncaught and unwrapped — the `blob:`/`data:` arm had no try/catch, unlike the file and URL arms, so what escaped `extractConfig` was a bare string with no `message` at all. #521 gave it the one shape the other arms report in.',
     },
 
     {
@@ -701,7 +701,7 @@ export const wireFormatCorpus = [
         source: 'urlUtils.js:101-104 — the isFile catch',
         outcome: 'throws',
         fileText: '{ this is not json',
-        note: 'Wrapped: "Failed to parse session file: …". Same reachability caveat as the other sessionFile fixtures.',
+        note: 'Reported in the one shape (#521), naming a session file as the source. Same reachability caveat as the other sessionFile fixtures — which is why the File arm\'s share of that shape is asserted against the adapter in `testSessionDecode.js` rather than here.',
     },
 
     {

--- a/test/testDecoderGolden.js
+++ b/test/testDecoderGolden.js
@@ -54,6 +54,7 @@
  * | 2026-08-09 | `harvested-juiceboxURL-bitly` — `decodes` became `throws` | **#506**, ADR-0006 decision 1: the named exception to the frozen contract. The bit.ly expansion and its embedded credential are gone, so the fixture that decoded a two-browser session through a live third-party endpoint now records the refusal that replaced it. **This is the first deliberate deviation from the baseline** — the whole point of the log is that it is written down rather than absorbed by a bare `-u`. No other fixture moved, which is the other half of the claim. |
  * | 2026-08-11 | `harvested-query-wapl-wt`, `harvested-query-wapl-ko`, `harvested-query-gm12878-nvi`, `harvested-query-degron-fully-encoded`, `synth-query-colorscale-bare-threshold` | **#514**, the bare-threshold colour scale. The five moved fixtures are exactly the five carrying a `colorScale` of a threshold with no RGB, and every moved line is `r: undefined` → `255`, `g: undefined` → `0` or `b: undefined` → `0` — `defaultColorScaleConfig`, which `parseSingle` never consulted, so the bare form decoded to a scale that painted `rgba(undefined,undefined,undefined,alpha)`. **This is not a change to the wire format**: the same strings are accepted, the threshold is untouched, and no encoder writes the bare form. What moved is the colour an *absent* component resolves to. `testConfigGolden.js`'s query columns move in the same five, for the same three lines, and nothing else. |
  * | 2026-08-11 | `harvested-query-wapl-wt`, `harvested-query-wapl-ko`, `harvested-juicebox-literal-braces`, `harvested-query-4dn-state-colorscale-track`, `synth-query-tracks-empty-range` | **#515**, the empty data-range field. The five moved fixtures are exactly the five carrying a four-field track string with an empty third field, and every moved line is a **deleted** `min: NaN` or `max: NaN` — twelve tracks, twenty-four lines, nothing added. `destringifyTracksV0` gated on `tokens.length > 2`, which an empty field satisfies, so `parseFloat("")` handed a track that would otherwise autoscale a range it could not use; it now reads the field only when it holds something. **This is not a change to the wire format**: the same strings are accepted and the same tracks come out of them, minus two keys that never meant anything. `testConfigGolden.js` did **not** move at all, because `normalizeSession` was already deleting these downstream — what closed is the round trip through `NaN`, not the end state. |
+ * | 2026-08-23 | `reject-session-blob-corrupt`, `reject-session-gzip-data-uri`, `reject-session-url-invalid-json`, `reject-session-url-unreachable` | **#521**, the one outward failure shape. The four moved fixtures are exactly the four that reject *inside the `session` adapter*, one per arm-and-failure: the two compressed forms, a fetched document that is not a session, and a link that does not resolve. Every moved line is the error itself — `name` is now `SessionDecodeError` in all four where it was `Error` twice and `undefined` twice, and the message says what would not decode **and** where the session came from, in one sentence and once. The two `undefined` names are the acceptance criterion's other half: those two rejected with a bare string from `BGZip`, so `describeThrow`'s `thrown` field had to stand in for a `name` and `message` that did not exist; the field is now absent from every snapshot in the file. **This is not a change to the wire format.** The same inputs are refused, for the same reasons, at the same point; what moved is how the refusal is reported. Nothing that decodes moved, and the three `sessionFile` fixtures did not move either — that arm is still unreachable from `extractConfig` (#519), which is why its share of this ticket is asserted in `testSessionDecode.js` against the adapter instead. |
  *
  * @see docs/adr/0006-session-wire-format-and-one-decoder.md
  * @see test/data/wireFormatCorpus.js — the inputs
@@ -74,11 +75,15 @@ import {
 /**
  * Describe a rejection well enough that its snapshot means something.
  *
- * Not everything the decoder throws is an `Error`: the `blob:`/`data:` arm has
- * no try/catch of its own, so a corrupt share link rejects with whatever the
- * decompressor threw, `name` and `message` both undefined. `{name, message}`
- * alone would snapshot that as two blanks and pin nothing at all, so the raw
- * value is stringified alongside for those.
+ * The `thrown` field is a **tripwire, and is expected to stay unused**. It was
+ * written because not everything the decoder threw was an `Error`: the
+ * `blob:`/`data:` arm had no try/catch of its own, so a corrupt share link
+ * rejected with whatever the decompressor threw — a bare string, `name` and
+ * `message` both undefined — which `{name, message}` alone would have
+ * snapshotted as two blanks, pinning nothing at all. #521 closed that: every
+ * arm now rejects with a `SessionDecodeError`. The field stays so that a
+ * non-`Error` escaping again shows up as a snapshot movement rather than as a
+ * pair of blanks.
  */
 function describeThrow(e) {
     const described = {name: e?.name, message: e?.message}

--- a/test/testSessionDecode.js
+++ b/test/testSessionDecode.js
@@ -487,12 +487,13 @@ describe('decodeSession — one outward failure shape', () => {
 
     /** Reject and return the rejection, so the shape can be read off it. */
     async function rejection(promise) {
+        let resolved
         try {
-            await promise
-            throw new Error('expected a rejection, and the session decoded')
+            resolved = await promise
         } catch (e) {
             return e
         }
+        throw new Error(`expected a rejection, and the session decoded to ${JSON.stringify(resolved)}`)
     }
 
     const arms = {

--- a/test/testSessionDecode.js
+++ b/test/testSessionDecode.js
@@ -575,6 +575,35 @@ describe('decodeSession — one outward failure shape', () => {
     })
 
     /**
+     * The criterion is written against `extractConfig`, which is more than the
+     * `session` parameter: `?juiceboxData=` decompresses too, and rejected with
+     * the same kind of bare string. It carries no source — the parameter names
+     * itself, and `SESSION_SOURCES` is the `session=` vocabulary — but it is an
+     * `Error`, which is the half of the criterion that was failing.
+     */
+    test('a corrupt juiceboxData= link rejects with an Error too', async () => {
+        const e = await rejection(decodeSession('?juiceboxData=not-compressed-at-all', noIO))
+
+        expect(e).toBeInstanceOf(SessionDecodeError)
+        expect(e.message).toContain('juiceboxData=')
+        expect(e.cause).toBeDefined()
+    })
+
+    /**
+     * A session value that is neither a File nor a string cannot arrive through
+     * `extractConfig`, whose parser only ever produces strings. It used to raise
+     * a bare `TypeError` out of the prefix sniff all the same; a caller driving
+     * the adapter gets the one shape instead, and the ladder's own reason.
+     */
+    test('a session value that is not a string is refused in the same shape', async () => {
+        const e = await rejection(sessionAdapter.decode({query: {session: 42}, loaders: {}}))
+
+        expect(e).toBeInstanceOf(SessionDecodeError)
+        expect(e.source).toBe('parameter')
+        expect(e.message).toContain('Session must be a string, got number')
+    })
+
+    /**
      * The version refusal is raised after the arms, on the document rather than
      * on where it was read from -- and it still has to come out in the one shape,
      * carrying the source of the document it refused.

--- a/test/testSessionDecode.js
+++ b/test/testSessionDecode.js
@@ -31,6 +31,7 @@
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import {BGZip} from 'igv-utils'
 import {
+    SESSION_SOURCES,
     SESSION_VERSION,
     SessionDecodeError,
     WIRE_FORMATS,
@@ -38,6 +39,7 @@ import {
     encodeSession,
 } from '../js/sessionCodec.js'
 import State from '../js/hicState.js'
+import {File} from './utils/File.js'
 
 /**
  * A loader that fails the test rather than the fetch. Passed wherever a fixture
@@ -222,14 +224,14 @@ describe('decodeSession — a session URL, driven from a fake loader', () => {
             loadString: async () => {
                 throw new Error('404')
             },
-        })).rejects.toThrow('Failed to load session from URL/file: 404')
+        })).rejects.toThrow('Session document could not be fetched (404)')
     })
 
     test('a fetched document that is not a session is reported as a parse failure', async () => {
         await expect(decodeSession('?session=https://example.org/index.html', {
             ...noIO,
             loadString: async () => '<html lang="en"></html>',
-        })).rejects.toThrow(/Failed to parse session from URL\/file/)
+        })).rejects.toThrow(/Session is not valid JSON/)
     })
 })
 
@@ -454,5 +456,137 @@ describe('the format registry', () => {
         // recorded, and "retired, refuse it loudly" is a disposition.
         expect(WIRE_FORMATS.map(a => a.format))
             .toEqual(['session', 'juiceboxURL', 'juicebox', 'query'])
+    })
+})
+
+/**
+ * One outward failure shape, whatever fetched the session. #521.
+ *
+ * The three arms of the `session` adapter differ only in where the text came
+ * from, and until this ticket they differed in how they said so: the parameter
+ * arm rethrew a bare string from `BGZip` (`name` and `message` both `undefined`),
+ * the File arm wrote one sentence, and the URL arm wrote that sentence wrapped
+ * inside a second one. The same malformed input therefore reported differently
+ * depending on which path reached it, which is what made a bug report ambiguous
+ * about where the link actually failed.
+ *
+ * What is asserted here is the shape, not the prose: a `SessionDecodeError`,
+ * always, carrying **two facts in one message** — what would not decode, and
+ * where the session came from — plus the source as a field a caller can branch
+ * on and the original failure still reachable through `cause`.
+ *
+ * The File arm is driven through the adapter rather than through
+ * `decodeSession`, because `extractQuery` can only ever produce string values
+ * and so the arm is unreachable from the entry point (#519). Its *shape* is
+ * still this suite's business: the arm is the one #521 has to bring into line
+ * and the one no golden snapshot can see.
+ */
+describe('decodeSession — one outward failure shape', () => {
+
+    const sessionAdapter = WIRE_FORMATS.find(adapter => adapter.format === 'session')
+
+    /** Reject and return the rejection, so the shape can be read off it. */
+    async function rejection(promise) {
+        try {
+            await promise
+            throw new Error('expected a rejection, and the session decoded')
+        } catch (e) {
+            return e
+        }
+    }
+
+    const arms = {
+        parameter: () => decodeSession('?session=blob:not-compressed-at-all', noIO),
+        file: () => sessionAdapter.decode({
+            query: {session: new File(Buffer.from('<html lang="en"></html>'), 'session.json')},
+            loaders: {},
+        }),
+        url: () => decodeSession('?session=https://example.org/index.html', {
+            ...noIO,
+            loadString: async () => '<html lang="en"></html>',
+        }),
+    }
+
+    for (const [source, arm] of Object.entries(arms)) {
+
+        test(`the ${source} arm rejects with a SessionDecodeError naming its source`, async () => {
+            const e = await rejection(arm())
+
+            expect(e).toBeInstanceOf(Error)
+            expect(e).toBeInstanceOf(SessionDecodeError)
+            expect(e.name).toBe('SessionDecodeError')
+            expect(e.source).toBe(source)
+            expect(e.message).toContain(SESSION_SOURCES[source])
+        })
+
+        test(`the ${source} arm keeps the failure underneath as cause`, async () => {
+            const e = await rejection(arm())
+
+            expect(e.cause).toBeDefined()
+        })
+    }
+
+    /**
+     * The bare string is the one the acceptance criterion names outright: `BGZip`
+     * rejects a corrupt payload with a string, and until now the parameter arm
+     * rethrew it untouched, so `extractConfig` rejected with a value that was not
+     * an `Error` at all.
+     */
+    test('a corrupt share link no longer rejects with a bare string', async () => {
+        const e = await rejection(decodeSession('?session=blob:not-compressed-at-all', noIO))
+
+        expect(typeof e).not.toBe('string')
+        expect(e.message).toMatch(/[a-z]/)
+        expect(e.message).not.toContain('undefined')
+    })
+
+    /** Two facts, one message — and the decoder's own reason is the *what*. */
+    test('the message says what would not decode as well as where it came from', async () => {
+        const e = await rejection(arms.url())
+
+        expect(e.message).toContain('Session is not valid JSON')
+        expect(e.message).toContain(SESSION_SOURCES.url)
+    })
+
+    /**
+     * The URL arm used to nest its parse failure inside a load failure, so a
+     * document that fetched fine and then would not parse was reported as if the
+     * fetch had failed. The two are different repairs for a user and stay told
+     * apart — but each is now said once.
+     */
+    test('a fetch that failed and a document that would not parse are told apart, and neither is double-wrapped', async () => {
+        const unreachable = await rejection(decodeSession('?session=https://example.org/gone.json', {
+            ...noIO,
+            loadString: async () => {
+                throw new Error('404')
+            },
+        }))
+        const unparseable = await rejection(arms.url())
+
+        expect(unreachable.message).toContain('404')
+        expect(unreachable.message).not.toContain('Session is not valid JSON')
+        expect(unparseable.message).not.toMatch(/could not be fetched/)
+
+        for (const e of [unreachable, unparseable]) {
+            expect(e.source).toBe('url')
+            expect(e.message.match(/Could not decode/g)).toHaveLength(1)
+        }
+    })
+
+    /**
+     * The version refusal is raised after the arms, on the document rather than
+     * on where it was read from -- and it still has to come out in the one shape,
+     * carrying the source of the document it refused.
+     */
+    test('a version refusal is reported in the same shape, with the source of the document', async () => {
+        const e = await rejection(decodeSession('?session=https://example.org/session.json', {
+            ...noIO,
+            loadString: async () => JSON.stringify({browsers: [{url: 'https://example.org/one.hic'}], version: 7}),
+        }))
+
+        expect(e).toBeInstanceOf(SessionDecodeError)
+        expect(e.source).toBe('url')
+        expect(e.message).toContain('version 7')
+        expect(e.message).toContain(SESSION_SOURCES.url)
     })
 })


### PR DESCRIPTION
Closes #521.

## What this is

`extractConfig` reported a malformed session three different ways depending on which arm of the `session` adapter had fetched it: the `blob:`/`data:` arm rethrew a bare **string** from `BGZip` (`name` and `message` both `undefined`, so not an `Error` at all), the File arm wrote one sentence, and the URL arm nested a parse failure inside a load failure and wrote two. The same input therefore reported differently depending on the path, and a user's bug report could not say where their link had actually failed.

`sessionFailure(source, e)` is now the one exit. It always returns a `SessionDecodeError`, and the message carries **two facts** — what would not decode, and where the session came from:

```
Could not decode the session from a session URL: Session is not valid JSON (Unexpected token '<', "<!doctype "... is not valid JSON)
Could not decode the session from the session= parameter: Session is not a readable blob (invalid block type)
Could not decode the session from a session URL: Session document could not be fetched (simulated fetch failure)
```

`source` (`parameter` | `file` | `url`) is a constructor field on `SessionDecodeError`, so a caller can branch on it without parsing prose; `SESSION_SOURCES` holds the spellings, and `CONTEXT.md` gains the noun.

## Acceptance criteria

- [x] A session that will not decode produces the same error shape from all three arms
- [x] The rejection is always an `Error` — no bare string escapes `extractConfig`. This is a claim about `extractConfig`, not about `session=` alone, so `?juiceboxData=` — which handed a corrupt payload straight to `BGZip` — is wrapped too
- [x] The source of the session survives in the error, as a field and in the message
- [x] `testDecoderGolden.js.snap` updated **per fixture**, with a row in the "Authorised snapshot movements" table naming this issue

## Falling out of it

- The URL arm's two reads are **sequenced rather than nested**. The nesting is what produced the double wrap, and it also folded two different repairs — a link that does not resolve, and a document that is not a session — into one report.
- The prefix sniff is guarded by a `typeof` test. `isCompressedSession` raises a bare `TypeError` on a non-string, which is why the File arm could not be entered even by a caller driving the adapter directly. **Arm order is unchanged.** A session value that is neither a File nor a string is now refused in the one shape rather than exploding in the sniff.
- The version refusal goes through the same helper, so a refusal raised after the arms still names the source of the document it refused.

## Snapshots

Four moved — exactly the four fixtures that reject inside the `session` adapter, one per arm-and-failure. Every moved line is the error itself; `name` is now `SessionDecodeError` in all four where it was `Error` twice and `undefined` twice. **Nothing that decodes moved**, and the three `sessionFile` fixtures did not move either: that arm is still unreachable from `extractConfig` (#519), which is why its share of the shape is asserted against the adapter in `testSessionDecode.js` instead.

## Verification

994 tests passing (50 files); `npm run build` clean. Reviewed on both axes with `/code-review`; every finding is addressed in the third commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)