### PR TITLE
#571: the restore suites share one harness

### DIFF
--- a/test/testRestoreBackDoor.js
+++ b/test/testRestoreBackDoor.js
@@ -51,33 +51,21 @@
  * the payload as contract, so it is now read back off the browser. The gate
  * cannot see this: it records `browser.state`, never the callback's argument.
  *
- * The dataset, the viewport and the stubs are `testRestoreClamp.js`'s, for the
- * reason it gives: a stated 800x800, because JSDOM does no layout (ADR-0009
- * fact 5).
+ * The dataset, the viewport and the stubs are `test/utils/restoreFixture.js`'s,
+ * for the reason it gives: a stated 800x800, because JSDOM does no layout
+ * (ADR-0009 fact 5).
  */
-import {beforeEach, afterEach, describe, expect, test, vi} from 'vitest'
-import {igvxhr} from 'igv-utils'
-import ContactMatrixView from '../js/contactMatrixView.js'
+import {describe, expect, test, vi} from 'vitest'
 import State from '../js/hicState.js'
-import {withContainers} from './utils/browserFixture.js'
-import {restoreDataset} from './utils/restoreDataset.js'
+import {restoreFixture} from './utils/restoreFixture.js'
 
 vi.mock('../js/hicDataset.js', async () => {
-    const {restoreDataset} = await import('./utils/restoreDataset.js')
-    return {
-        default: {loadDataset: async config => restoreDataset(config)},
-        HiCDataset: class {
-            constructor(config) {
-                Object.assign(this, restoreDataset(config))
-            }
-            async init() {}
-        },
-    }
+    const {restoreDataset, datasetModule} = await import('./utils/restoreDataset.js')
+    return datasetModule(restoreDataset)
 })
 
 const {default: HICBrowser} = await import('../js/hicBrowser.js')
 
-const VIEWPORT = {width: 800, height: 800}
 const HIC_URL = 'https://example.org/restore-back-door.hic'
 
 /** chr1 x chr1 at 250kb bins — the zoom `testRestoreClamp.js` drives. */
@@ -127,25 +115,7 @@ function installed(installs) {
 
 describe('the state parameter is gone from setActiveDataset (#559)', () => {
 
-    const dom = withContainers()
-
-    beforeEach(() => {
-        vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
-        vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
-        vi.spyOn(igvxhr, 'loadString').mockImplementation(async () => {
-            throw new Error('unexpected network access from the restore back-door suite')
-        })
-    })
-
-    afterEach(() => {
-        vi.restoreAllMocks()
-    })
-
-    function embed() {
-        const browser = new HICBrowser(dom.another(), {})
-        vi.spyOn(browser.contactMatrixView, 'getViewDimensions').mockReturnValue({...VIEWPORT})
-        return browser
-    }
+    const {embed} = restoreFixture(HICBrowser, {suite: 'restore back-door'})
 
     test('setActiveDataset takes a dataset and nothing else', async () => {
 

--- a/test/testRestoreBackDoor.js
+++ b/test/testRestoreBackDoor.js
@@ -115,7 +115,7 @@ function installed(installs) {
 
 describe('the state parameter is gone from setActiveDataset (#559)', () => {
 
-    const {embed} = restoreFixture(HICBrowser, {suite: 'restore back-door'})
+    const {embed} = restoreFixture(HICBrowser, {suite: 'restore back-door', url: HIC_URL})
 
     test('setActiveDataset takes a dataset and nothing else', async () => {
 

--- a/test/testRestoreClamp.js
+++ b/test/testRestoreClamp.js
@@ -35,10 +35,12 @@
  * chromosome table and juicer resolution ladder the gate reads its numbers off,
  * so a bound computed here and a bound recorded there are the same bound.
  *
- * The viewport is stated, not measured, for the reason ADR-0009 fact 5 gives:
- * JSDOM does no layout, `getViewDimensions()` answers `{0, 0}`, and a clamp read
- * against zero is a clamp against the whole chromosome. `testState.js` states
- * 800x800 and so does the gate's first column; this file states the same.
+ * The dataset, the viewport and the stubs are `test/utils/restoreFixture.js`'s,
+ * for the reason it gives: a stated 800x800, because JSDOM does no layout and
+ * `getViewDimensions()` answers `{0, 0}` (ADR-0009 fact 5). A clamp read against
+ * zero is a clamp against the whole chromosome, which would make every bound
+ * below fictional -- so of the four suites on that harness this is the one whose
+ * claims turn on the stated viewport being what the gate's first column states.
  */
 import {describe, expect, test, vi} from 'vitest'
 import State from '../js/hicState.js'
@@ -88,10 +90,7 @@ function stubTrackPair(window) {
 
 describe('restore routes through the chokepoint (#558)', () => {
 
-    const {dom, restore: restoreFrom} = restoreFixture(HICBrowser, {suite: 'restore clamp'})
-
-    /** One embed, one load of the fixture file. Returns the live browser. */
-    const restore = state => restoreFrom(HIC_URL, state)
+    const {dom, restore} = restoreFixture(HICBrowser, {suite: 'restore clamp', url: HIC_URL})
 
     test('a saved pixelSize above the cap opens at the cap', async () => {
 

--- a/test/testRestoreClamp.js
+++ b/test/testRestoreClamp.js
@@ -40,30 +40,18 @@
  * against zero is a clamp against the whole chromosome. `testState.js` states
  * 800x800 and so does the gate's first column; this file states the same.
  */
-import {beforeEach, afterEach, describe, expect, test, vi} from 'vitest'
-import {igvxhr} from 'igv-utils'
-import ContactMatrixView from '../js/contactMatrixView.js'
+import {describe, expect, test, vi} from 'vitest'
 import State from '../js/hicState.js'
 import {MAX_PIXEL_SIZE} from '../js/hicBrowser.js'
-import {withContainers} from './utils/browserFixture.js'
-import {restoreDataset} from './utils/restoreDataset.js'
+import {restoreFixture, VIEWPORT} from './utils/restoreFixture.js'
 
 vi.mock('../js/hicDataset.js', async () => {
-    const {restoreDataset} = await import('./utils/restoreDataset.js')
-    return {
-        default: {loadDataset: async config => restoreDataset(config)},
-        HiCDataset: class {
-            constructor(config) {
-                Object.assign(this, restoreDataset(config))
-            }
-            async init() {}
-        },
-    }
+    const {restoreDataset, datasetModule} = await import('./utils/restoreDataset.js')
+    return datasetModule(restoreDataset)
 })
 
 const {default: HICBrowser} = await import('../js/hicBrowser.js')
 
-const VIEWPORT = {width: 800, height: 800}
 const HIC_URL = 'https://example.org/restore-clamp.hic'
 
 /** chr1 x chr1 at 250kb bins — a zoom the corpus's harvested states also use. */
@@ -100,27 +88,10 @@ function stubTrackPair(window) {
 
 describe('restore routes through the chokepoint (#558)', () => {
 
-    const dom = withContainers()
+    const {dom, restore: restoreFrom} = restoreFixture(HICBrowser, {suite: 'restore clamp'})
 
-    beforeEach(() => {
-        vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
-        vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
-        vi.spyOn(igvxhr, 'loadString').mockImplementation(async () => {
-            throw new Error('unexpected network access from the restore clamp suite')
-        })
-    })
-
-    afterEach(() => {
-        vi.restoreAllMocks()
-    })
-
-    /** One embed, one load, one stated viewport. Returns the live browser. */
-    async function restore(state) {
-        const browser = new HICBrowser(dom.another(), {})
-        vi.spyOn(browser.contactMatrixView, 'getViewDimensions').mockReturnValue({...VIEWPORT})
-        await browser.loadHicFile({url: HIC_URL, state}, true)
-        return browser
-    }
+    /** One embed, one load of the fixture file. Returns the live browser. */
+    const restore = state => restoreFrom(HIC_URL, state)
 
     test('a saved pixelSize above the cap opens at the cap', async () => {
 

--- a/test/testRestoreGolden.js
+++ b/test/testRestoreGolden.js
@@ -272,15 +272,14 @@
  * @see test/data/wireFormatCorpus.js — the inputs
  * @see test/testDecoderGolden.js, test/testConfigGolden.js — the same instrument, one seam either side
  */
-import {beforeEach, afterEach, describe, expect, test, vi} from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {igvxhr} from 'igv-utils'
 import {extractConfig} from '../js/urlUtils.js'
 import {decodeState} from '../js/sessionCodec.js'
 import {normalizeSession} from '../js/normalizeSession.js'
-import ContactMatrixView from '../js/contactMatrixView.js'
 import {selfContained, viaLoader, wireFormatCorpus} from './data/wireFormatCorpus.js'
-import {withContainers} from './utils/browserFixture.js'
 import {restoreDataset} from './utils/restoreDataset.js'
+import {restoreFixture} from './utils/restoreFixture.js'
 
 /**
  * The two things behind the restore path that a test cannot supply: the `.hic`
@@ -554,34 +553,19 @@ function rungCounter() {
 /**
  * A JSDOM, the two stubs every restore needs, and the rung counter.
  *
- * `withContainers()` is composed rather than re-implemented, the same way
- * `testConfigGolden.js`'s `goldenSuite()` composes it: this file needs the
+ * The DOM and the stubs are `test/utils/restoreFixture.js`'s (#571), which is
+ * where the `update` stubs, the network tripwire and the composed
+ * `withContainers()` now live for all five restore suites. This file needs the
  * `another()` container factory for the reason that helper exists -- one embed
  * per drive -- and nothing else about the DOM. It does not navigate, because no
  * door here reads `window.location`.
  *
- * `update` is stubbed on both the browser and the view for the reason
- * `stubbedLoads` gives: every route out of a repaint ends at the network or a
- * pixel, and rendering has its own tests. `getViewDimensions` is stubbed per
- * drive rather than here, because its value is the column.
+ * The fixture's `embed()` is deliberately not used: it states one viewport, and
+ * here the viewport is the column, so `drive()` states its own per drive.
  */
 function restoreSuite() {
 
-    const dom = withContainers()
-
-    beforeEach(() => {
-        vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
-        vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
-        // A tripwire, as in #503 and #531: nothing on this path should reach the
-        // network. The corpus's own decode happens before the browser is built.
-        vi.spyOn(igvxhr, 'loadString').mockImplementation(async () => {
-            throw new Error('unexpected network access from the restore golden-file suite')
-        })
-    })
-
-    afterEach(() => {
-        vi.restoreAllMocks()
-    })
+    const {dom} = restoreFixture(HICBrowser, {suite: 'restore golden-file'})
 
     return {dom, rungs: rungCounter()}
 }

--- a/test/testRestoreGolden.js
+++ b/test/testRestoreGolden.js
@@ -293,16 +293,8 @@ import {restoreDataset} from './utils/restoreDataset.js'
  * through `new HiCDataset(...)`, and a constructor cannot be spied.
  */
 vi.mock('../js/hicDataset.js', async () => {
-    const {restoreDataset} = await import('./utils/restoreDataset.js')
-    return {
-        default: {loadDataset: async config => restoreDataset(config)},
-        HiCDataset: class {
-            constructor(config) {
-                Object.assign(this, restoreDataset(config))
-            }
-            async init() {}
-        },
-    }
+    const {restoreDataset, datasetModule} = await import('./utils/restoreDataset.js')
+    return datasetModule(restoreDataset)
 })
 
 const {default: HICBrowser} = await import('../js/hicBrowser.js')

--- a/test/testRestoreNormalization.js
+++ b/test/testRestoreNormalization.js
@@ -40,7 +40,8 @@
  *
  * The dataset is `test/utils/restoreDataset.js`, the fixture the gate and
  * `testRestoreClamp.js` both drive, wrapped here to answer
- * `getNormalizationOptions`. A wrapper rather than a change to the fixture: the
+ * `getNormalizationOptions` -- the one thing this suite's harness does that
+ * `test/utils/restoreFixture.js`'s shared one does not. A wrapper rather than a change to the fixture: the
  * fixture's silence on normalization is itself a case this file drives (a
  * dataset that cannot answer at all), and the browser's own fallback for that
  * silence -- `['NONE']` -- is what the last test pins.
@@ -49,11 +50,9 @@
  * Nothing here depends on its size; it is stated so the load behaves the way it
  * does in the neighbouring suites.
  */
-import {beforeEach, afterEach, describe, expect, test, vi} from 'vitest'
-import {igvxhr} from 'igv-utils'
-import ContactMatrixView from '../js/contactMatrixView.js'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 import State from '../js/hicState.js'
-import {withContainers} from './utils/browserFixture.js'
+import {restoreFixture} from './utils/restoreFixture.js'
 
 /**
  * What the next loaded dataset offers, or `undefined` for a dataset that does
@@ -62,29 +61,19 @@ import {withContainers} from './utils/browserFixture.js'
 let offered
 
 vi.mock('../js/hicDataset.js', async () => {
-    const {restoreDataset} = await import('./utils/restoreDataset.js')
-    const build = config => {
+    const {restoreDataset, datasetModule} = await import('./utils/restoreDataset.js')
+    return datasetModule(config => {
         const dataset = restoreDataset(config)
         if (offered !== undefined) {
             const options = offered
             dataset.getNormalizationOptions = async () => options
         }
         return dataset
-    }
-    return {
-        default: {loadDataset: async config => build(config)},
-        HiCDataset: class {
-            constructor(config) {
-                Object.assign(this, build(config))
-            }
-            async init() {}
-        },
-    }
+    })
 })
 
 const {default: HICBrowser} = await import('../js/hicBrowser.js')
 
-const VIEWPORT = {width: 800, height: 800}
 const HIC_URL = 'https://example.org/restore-normalization.hic'
 
 /** chr1 x chr1 at 250kb bins, at an origin well inside the chromosome. */
@@ -96,28 +85,14 @@ const savedWith = normalization => new State(CHR1, CHR1, ZOOM, 10, 10, 2, normal
 
 describe('normalization is validated against the loaded dataset at restore (#561)', () => {
 
-    const dom = withContainers()
+    const {embed, restore: restoreFrom} = restoreFixture(HICBrowser, {suite: 'restore normalization'})
 
     beforeEach(() => {
         offered = undefined
-        vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
-        vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
-        vi.spyOn(igvxhr, 'loadString').mockImplementation(async () => {
-            throw new Error('unexpected network access from the restore normalization suite')
-        })
     })
 
-    afterEach(() => {
-        vi.restoreAllMocks()
-    })
-
-    /** One embed, one load, one stated viewport. Returns the live browser. */
-    async function restore(state) {
-        const browser = new HICBrowser(dom.another(), {})
-        vi.spyOn(browser.contactMatrixView, 'getViewDimensions').mockReturnValue({...VIEWPORT})
-        await browser.loadHicFile({url: HIC_URL, state}, true)
-        return browser
-    }
+    /** One embed, one load of the fixture file. Returns the live browser. */
+    const restore = state => restoreFrom(HIC_URL, state)
 
     test('a saved normalization the dataset offers is preserved exactly', async () => {
 
@@ -197,8 +172,7 @@ describe('normalization is validated against the loaded dataset at restore (#561
         offered = ['NONE', 'KR']
         const asked = vi.fn(async () => offered)
 
-        const browser = new HICBrowser(dom.another(), {})
-        vi.spyOn(browser.contactMatrixView, 'getViewDimensions').mockReturnValue({...VIEWPORT})
+        const browser = embed()
         vi.spyOn(browser, 'getNormalizationOptions').mockImplementation(asked)
 
         await browser.loadHicFile({url: HIC_URL, state: savedWith('NONE')}, true)
@@ -224,8 +198,7 @@ describe('normalization is validated against the loaded dataset at restore (#561
         // claim 4's rule, asked at the other door.
         offered = ['VC']
 
-        const browser = new HICBrowser(dom.another(), {})
-        vi.spyOn(browser.contactMatrixView, 'getViewDimensions').mockReturnValue({...VIEWPORT})
+        const browser = embed()
 
         await browser.init({url: HIC_URL, state: savedWith('NONE'), normalization: 'KR'})
 
@@ -236,8 +209,7 @@ describe('normalization is validated against the loaded dataset at restore (#561
 
         offered = ['NONE', 'VC', 'KR']
 
-        const browser = new HICBrowser(dom.another(), {})
-        vi.spyOn(browser.contactMatrixView, 'getViewDimensions').mockReturnValue({...VIEWPORT})
+        const browser = embed()
 
         await browser.init({url: HIC_URL, state: savedWith('NONE'), normalization: 'KR'})
 

--- a/test/testRestoreNormalization.js
+++ b/test/testRestoreNormalization.js
@@ -40,11 +40,12 @@
  *
  * The dataset is `test/utils/restoreDataset.js`, the fixture the gate and
  * `testRestoreClamp.js` both drive, wrapped here to answer
- * `getNormalizationOptions` -- the one thing this suite's harness does that
- * `test/utils/restoreFixture.js`'s shared one does not. A wrapper rather than a change to the fixture: the
- * fixture's silence on normalization is itself a case this file drives (a
- * dataset that cannot answer at all), and the browser's own fallback for that
- * silence -- `['NONE']` -- is what the last test pins.
+ * `getNormalizationOptions` -- the one thing this suite asks of its dataset that
+ * the shared harness (`test/utils/restoreFixture.js`) does not provide. A
+ * wrapper rather than a change to the fixture: the fixture's silence on
+ * normalization is itself a case this file drives (a dataset that cannot answer
+ * at all), and the browser's own fallback for that silence -- `['NONE']` -- is
+ * what the last test pins.
  *
  * The viewport is stated, not measured, for the reason ADR-0009 fact 5 gives.
  * Nothing here depends on its size; it is stated so the load behaves the way it
@@ -85,14 +86,12 @@ const savedWith = normalization => new State(CHR1, CHR1, ZOOM, 10, 10, 2, normal
 
 describe('normalization is validated against the loaded dataset at restore (#561)', () => {
 
-    const {embed, restore: restoreFrom} = restoreFixture(HICBrowser, {suite: 'restore normalization'})
+    const {embed, restore} = restoreFixture(HICBrowser, {suite: 'restore normalization', url: HIC_URL})
 
     beforeEach(() => {
         offered = undefined
     })
 
-    /** One embed, one load of the fixture file. Returns the live browser. */
-    const restore = state => restoreFrom(HIC_URL, state)
 
     test('a saved normalization the dataset offers is preserved exactly', async () => {
 

--- a/test/testRestoreResolutionChanged.js
+++ b/test/testRestoreResolutionChanged.js
@@ -45,33 +45,21 @@
  * take. That is the better instrument anyway: the payload is what
  * `js/publicApi.js` declares as contract, and the return value never was.
  *
- * The dataset, the viewport and the stubs are `testRestoreClamp.js`'s, for the
- * reason it gives: a stated 800x800, because JSDOM does no layout (ADR-0009
- * fact 5).
+ * The dataset, the viewport and the stubs are `test/utils/restoreFixture.js`'s,
+ * for the reason it gives: a stated 800x800, because JSDOM does no layout
+ * (ADR-0009 fact 5).
  */
-import {beforeEach, afterEach, describe, expect, test, vi} from 'vitest'
-import {igvxhr} from 'igv-utils'
-import ContactMatrixView from '../js/contactMatrixView.js'
+import {describe, expect, test, vi} from 'vitest'
 import State from '../js/hicState.js'
-import {withContainers} from './utils/browserFixture.js'
-import {restoreDataset} from './utils/restoreDataset.js'
+import {restoreFixture} from './utils/restoreFixture.js'
 
 vi.mock('../js/hicDataset.js', async () => {
-    const {restoreDataset} = await import('./utils/restoreDataset.js')
-    return {
-        default: {loadDataset: async config => restoreDataset(config)},
-        HiCDataset: class {
-            constructor(config) {
-                Object.assign(this, restoreDataset(config))
-            }
-            async init() {}
-        },
-    }
+    const {restoreDataset, datasetModule} = await import('./utils/restoreDataset.js')
+    return datasetModule(restoreDataset)
 })
 
 const {default: HICBrowser} = await import('../js/hicBrowser.js')
 
-const VIEWPORT = {width: 800, height: 800}
 const HIC_URL = 'https://example.org/restore-resolution-changed.hic'
 
 /** chr1 x chr1, and two zooms off the same ladder `testRestoreClamp.js` drives. */
@@ -83,25 +71,7 @@ const savedView = (zoom, x = 0, y = 0) => new State(CHR1, CHR1, zoom, x, y, 2, '
 
 describe('resolutionChanged tells the truth on restore (#560)', () => {
 
-    const dom = withContainers()
-
-    beforeEach(() => {
-        vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
-        vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
-        vi.spyOn(igvxhr, 'loadString').mockImplementation(async () => {
-            throw new Error('unexpected network access from the restore resolution suite')
-        })
-    })
-
-    afterEach(() => {
-        vi.restoreAllMocks()
-    })
-
-    function embed() {
-        const browser = new HICBrowser(dom.another(), {})
-        vi.spyOn(browser.contactMatrixView, 'getViewDimensions').mockReturnValue({...VIEWPORT})
-        return browser
-    }
+    const {embed} = restoreFixture(HICBrowser, {suite: 'restore resolution'})
 
     /**
      * The `resolutionChanged` flag of every locus change the browser publishes,

--- a/test/testRestoreResolutionChanged.js
+++ b/test/testRestoreResolutionChanged.js
@@ -71,7 +71,7 @@ const savedView = (zoom, x = 0, y = 0) => new State(CHR1, CHR1, zoom, x, y, 2, '
 
 describe('resolutionChanged tells the truth on restore (#560)', () => {
 
-    const {embed} = restoreFixture(HICBrowser, {suite: 'restore resolution'})
+    const {embed} = restoreFixture(HICBrowser, {suite: 'restore resolution', url: HIC_URL})
 
     /**
      * The `resolutionChanged` flag of every locus change the browser publishes,

--- a/test/utils/restoreDataset.js
+++ b/test/utils/restoreDataset.js
@@ -98,3 +98,29 @@ export function restoreDataset(config = {}) {
         hicFile: {config: {nvi: config.nvi}},
     }
 }
+
+/**
+ * The module shape a `vi.mock('../js/hicDataset.js')` factory has to return:
+ * `loadDataset` for the ladder, and a `HiCDataset` class for the callers that
+ * construct one. The four restore suites (#571) all return this.
+ *
+ * It lives beside the dataset rather than in `restoreFixture.js` because a mock
+ * factory runs *inside* the module graph it is mocking: a factory that imported
+ * the fixture would pull `hicBrowser.js` back in through it, and the load would
+ * deadlock on itself. This file imports nothing.
+ *
+ * `build` is a `config => dataset` function -- ordinarily `restoreDataset`
+ * itself, and a wrapper around it for a suite that needs the dataset to answer
+ * one more question.
+ */
+export function datasetModule(build) {
+    return {
+        default: {loadDataset: async config => build(config)},
+        HiCDataset: class {
+            constructor(config) {
+                Object.assign(this, build(config))
+            }
+            async init() {}
+        },
+    }
+}

--- a/test/utils/restoreFixture.js
+++ b/test/utils/restoreFixture.js
@@ -1,0 +1,85 @@
+/**
+ * The harness the restore suites share: a mocked dataset, a stated viewport,
+ * and a browser you can embed and load without touching the network.
+ *
+ * `testRestoreClamp.js` (#558), `testRestoreBackDoor.js` (#559),
+ * `testRestoreResolutionChanged.js` (#560) and `testRestoreNormalization.js`
+ * (#561) all drive the same seam -- `loadHicFile` with a saved state, running
+ * for real from the ladder down through `setState` -- and each opened with the
+ * same forty lines. On copy four that stopped being a borrow and became a
+ * fixture (#571). What each suite keeps is what is its own: its zooms, its
+ * saved states, and its claims.
+ *
+ * One line cannot move here, and it is the `vi.mock('../js/hicDataset.js')`
+ * call. Vitest hoists a `vi.mock` to the top of the file it is *written* in and
+ * registers it against that file's module graph, so a call made from this
+ * module would register nothing for the suite importing it. What moves instead
+ * is the module shape the factory has to return -- `datasetModule()`, which
+ * lives in `restoreDataset.js` rather than here because a factory that reached
+ * into this module would pull `hicBrowser.js` back in behind it and deadlock
+ * the load it is part of.
+ */
+
+import {beforeEach, afterEach, vi} from 'vitest'
+import {igvxhr} from 'igv-utils'
+import ContactMatrixView from '../../js/contactMatrixView.js'
+import {withContainers} from './browserFixture.js'
+
+/**
+ * The viewport every restore suite states.
+ *
+ * Stated, not measured, for the reason ADR-0009 fact 5 gives: JSDOM does no
+ * layout, `getViewDimensions()` answers `{0, 0}`, and a clamp read against zero
+ * is a clamp against the whole chromosome. `testState.js` states 800x800 and so
+ * does the gate's first column; the suites here state the same, which is what
+ * makes a bound computed in one of them and a bound recorded in the #557 gate
+ * the same bound.
+ */
+export const VIEWPORT = {width: 800, height: 800}
+
+/**
+ * A JSDOM, the three stubs, and an embed -- around each test in the calling
+ * describe.
+ *
+ * `HICBrowser` is passed in rather than imported here because the suites reach
+ * it through the deferred `await import('../js/hicBrowser.js')` their own
+ * `vi.mock` forces, and the class this fixture spies on has to be the one the
+ * suite drives. `suite` names the file in the network-access error, so a stray
+ * read says which suite made it.
+ *
+ * Returns the `withContainers` holder alongside `embed` and `restore`; the
+ * holder's fields do not exist until `beforeEach` runs, which is why this hands
+ * back an object rather than the elements.
+ */
+export function restoreFixture(HICBrowser, {suite}) {
+
+    const dom = withContainers()
+
+    beforeEach(() => {
+        vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(igvxhr, 'loadString').mockImplementation(async () => {
+            throw new Error(`unexpected network access from the ${suite} suite`)
+        })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    /** One embed, one stated viewport. Returns the live browser, unloaded. */
+    function embed() {
+        const browser = new HICBrowser(dom.another(), {})
+        vi.spyOn(browser.contactMatrixView, 'getViewDimensions').mockReturnValue({...VIEWPORT})
+        return browser
+    }
+
+    /** One embed, one load of `url` carrying `state`. Returns the live browser. */
+    async function restore(url, state) {
+        const browser = embed()
+        await browser.loadHicFile({url, state}, true)
+        return browser
+    }
+
+    return {dom, embed, restore}
+}

--- a/test/utils/restoreFixture.js
+++ b/test/utils/restoreFixture.js
@@ -45,19 +45,23 @@ export const VIEWPORT = {width: 800, height: 800}
  * it through the deferred `await import('../js/hicBrowser.js')` their own
  * `vi.mock` forces, and the class this fixture spies on has to be the one the
  * suite drives. `suite` names the file in the network-access error, so a stray
- * read says which suite made it.
+ * read says which suite made it, and `url` is the `.hic` file `restore` loads
+ * -- one per suite, so it is stated once here rather than at every call.
  *
  * Returns the `withContainers` holder alongside `embed` and `restore`; the
  * holder's fields do not exist until `beforeEach` runs, which is why this hands
  * back an object rather than the elements.
  */
-export function restoreFixture(HICBrowser, {suite}) {
+export function restoreFixture(HICBrowser, {suite, url}) {
 
     const dom = withContainers()
 
     beforeEach(() => {
         vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
         vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
+        // A tripwire, as in #503 and #531: nothing on this path should reach
+        // the network. What the dataset would have been read from is the mock,
+        // and a corpus fixture is decoded before the browser is built.
         vi.spyOn(igvxhr, 'loadString').mockImplementation(async () => {
             throw new Error(`unexpected network access from the ${suite} suite`)
         })
@@ -74,8 +78,8 @@ export function restoreFixture(HICBrowser, {suite}) {
         return browser
     }
 
-    /** One embed, one load of `url` carrying `state`. Returns the live browser. */
-    async function restore(url, state) {
+    /** One embed, one load of the suite's file carrying `state`. Returns the live browser. */
+    async function restore(state) {
         const browser = embed()
         await browser.loadHicFile({url, state}, true)
         return browser


### PR DESCRIPTION
Closes #571.

`testRestoreClamp.js` (#558), `testRestoreBackDoor.js` (#559),
`testRestoreResolutionChanged.js` (#560) and `testRestoreNormalization.js`
(#561) each opened with the same forty lines. Copy four is past the rule of
three.

`test/utils/restoreFixture.js` now holds the stated 800x800 viewport — with the
ADR-0009 fact-5 reason attached — and `restoreFixture(HICBrowser, {suite, url})`,
which registers the three stubs and hands back `embed` and `restore`. Each suite
keeps what is its own: its zooms, its saved states, its claims and its header
essay. `testRestoreGolden.js` (#557) takes the DOM and the stubs too, but not
`embed()`: its viewport is a golden column, so it stays stated per drive.

The `vi.mock` call itself cannot move — vitest hoists it to the top of the file
it is written in and registers it against that file's module graph. What moved
is the shape its factory returns, `datasetModule()`, which lives beside the
dataset in `test/utils/restoreDataset.js`: a factory reaching into the fixture
would pull `hicBrowser.js` back into the graph it is mocking and deadlock the
load. That is the one deviation from the ticket's "one harness module".

## Acceptance criteria

- [x] One harness module; the suites import it and keep their own constants
- [x] The stated viewport lives in one place, with the ADR-0009 fact-5 reason on it
- [x] No suite loses a claim or a header essay — test counts identical either side
- [x] Full suite green (50 files, 988 tests), no snapshot moved

Reviewed on both axes; the Standards and Spec findings are acted on in the
second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)