### PR TITLE
#584: a saved track keeps its indexURL

### DIFF
--- a/examples/juicebox-api.html
+++ b/examples/juicebox-api.html
@@ -44,6 +44,14 @@ This example illustrates the use of the juicebox API to dynamically load a map a
 </div>
 
 
+<div style="margin-top: 50px;margin-bottom: 50px">
+    <h2>Or: load a session file from disk</h2>
+    <label for="session-input"><span style="font-size: large;font-weight: bold">Session (.json file)</span></label>
+    <input type="file" id="session-input" accept=".json,application/json">
+    <span id="session-status" style="margin-left: 10px"></span>
+</div>
+
+
 <div id="app-container"></div>
 
 
@@ -65,18 +73,22 @@ This example illustrates the use of the juicebox API to dynamically load a map a
     juicebox.init(container, config)
         .then(function (hicBrowser) {
             console.log("Juicebox loaded");
-            initMenus(hicBrowser);
+            initMenus();
         })
 
 
-    function initMenus(hicBrowser) {
+    function initMenus() {
         const hicSelect = document.getElementById("hic-select");
         const tracksSelect = document.getElementById("tracks-select");
+        const sessionInput = document.getElementById("session-input");
+        const sessionStatus = document.getElementById("session-status");
 
         hicSelect.onchange = async (e) => {
             const idx = hicSelect.selectedIndex;
             const option = hicSelect.options[idx];
-            await hicBrowser.loadHicFile({url: option.value});
+            // getCurrentBrowser() rather than the browser init handed us: a
+            // session restore replaces the browsers, so the original is stale.
+            await juicebox.getCurrentBrowser().loadHicFile({url: option.value});
             tracksSelect.removeAttribute("disabled")
         }
 
@@ -84,7 +96,36 @@ This example illustrates the use of the juicebox API to dynamically load a map a
             const idx = tracksSelect.selectedIndex;
             const option = tracksSelect.options[idx];
             const trackConfig = trackDictionary[option.value];
-            hicBrowser.loadTracks([trackConfig]);
+            juicebox.getCurrentBrowser().loadTracks([trackConfig]);
+        }
+
+        // A session file is just JSON on disk: the host reads it and hands the
+        // parsed object to restoreSession. juicebox never sees the File.
+        sessionInput.onchange = async (e) => {
+
+            const file = sessionInput.files[0];
+            if (!file) {
+                return;
+            }
+
+            sessionStatus.textContent = `Loading ${file.name} ...`;
+
+            try {
+                const session = JSON.parse(await file.text());
+                await juicebox.restoreSession(container, session);
+                sessionStatus.textContent = `Loaded ${file.name}`;
+            } catch (error) {
+                console.error(error);
+                sessionStatus.textContent = `Could not load ${file.name}: ${error.message}`;
+            }
+
+            // Restoring replaces the browsers, so the menus above no longer
+            // describe what is on screen. Reset them, and allow the same file
+            // to be picked again.
+            hicSelect.selectedIndex = 0;
+            tracksSelect.selectedIndex = 0;
+            tracksSelect.setAttribute("disabled", "disabled");
+            sessionInput.value = "";
         }
 
     }

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -37,7 +37,7 @@ import BrowserCoordinator from "./browserCoordinator.js"
 import InteractionHandler from "./interactionHandler.js"
 import DataLoader from "./dataLoader.js"
 import {normalizeTrackConfigs} from "./normalizeSession.js"
-import {unmappedUrl} from "./urlMapper.js"
+import {unmappedUrl, unmappedIndexUrl} from "./urlMapper.js"
 import {isSynchable} from "./syncGroup.js"
 
 const DEFAULT_PIXEL_SIZE = 1
@@ -1322,6 +1322,19 @@ class HICBrowser {
                 if (typeof url === "string") {
 
                     const t = {url}
+
+                    // The index is what makes a track random-access. Dropped, the
+                    // reload does not fail -- it downgrades to a whole-file read,
+                    // and only stalls once the view is zoomed in far enough for igv
+                    // to ask for data. A session saved at 1kb over `hg38.fa` was
+                    // fetching the whole three-gigabyte FASTA on restore, and never
+                    // finishing; the same session saved zoomed out restored fine,
+                    // because nothing had asked the sequence track for anything yet
+                    // (#584).
+                    const indexURL = unmappedIndexUrl(config)
+                    if (typeof indexURL === "string") {
+                        t.indexURL = indexURL
+                    }
 
                     if (config.type) {
                         t.type = config.type

--- a/js/urlMapper.js
+++ b/js/urlMapper.js
@@ -54,9 +54,8 @@ function mapUrl(url) {
  * read is what it hands over. Those rewritten values must never escape into a saved session, so the
  * originals travel alongside them and `HICBrowser.toJSON` serializes those instead.
  *
- * Every URL the mapper rewrites is stashed, `indexURL` included — nothing serializes an `indexURL`
- * today, but a rewrite whose original cannot be recovered is exactly the leak this field exists to
- * prevent, and half an invariant is worse than none.
+ * Every URL the mapper rewrites is stashed, `indexURL` included, and both are serialized —
+ * `unmappedUrl` and `unmappedIndexUrl` below are the two readers.
  */
 const UNMAPPED_URLS = 'unmappedUrls'
 
@@ -101,4 +100,15 @@ function unmappedUrl(config) {
     return Object.hasOwn(config, UNMAPPED_URLS) ? config[UNMAPPED_URLS].url : config.url
 }
 
-export { setUrlMapper, getUrlMapper, mapUrl, mapTrackConfig, unmappedUrl }
+/**
+ * The index URL a track config should be serialized with: the original, whenever mapTrackConfig
+ * rewrote one. Safe on any config, mapped or not.
+ *
+ * @param {object} config
+ * @returns {*} the pre-mapping indexURL, or undefined where the track has none.
+ */
+function unmappedIndexUrl(config) {
+    return Object.hasOwn(config, UNMAPPED_URLS) ? config[UNMAPPED_URLS].indexURL : config.indexURL
+}
+
+export { setUrlMapper, getUrlMapper, mapUrl, mapTrackConfig, unmappedUrl, unmappedIndexUrl }

--- a/test/testSessionTrackIndexUrl.js
+++ b/test/testSessionTrackIndexUrl.js
@@ -1,0 +1,78 @@
+/**
+ * A saved session keeps a track's `indexURL`.
+ *
+ * `HICBrowser.toJSON` copies a whitelist of track fields, and `indexURL` was not
+ * on it. The field is what makes a track *random-access*, so dropping it does
+ * not fail the reload -- it silently downgrades the track to a whole-file read,
+ * and the reload only stalls once the view is zoomed in far enough for igv to
+ * ask for data. The report that found it was a session saved at 1kb over a
+ * `hg38.fa` sequence track: restoring it fetched the entire three-gigabyte FASTA
+ * and never finished, while the same session saved zoomed out restored in
+ * seconds because nothing had asked the sequence track for anything yet.
+ *
+ * The dev-proxy spelling is asserted alongside it: `mapTrackConfig` stashes the
+ * *original* `indexURL` next to the original url, and a session must carry that
+ * one rather than the proxied path -- the same rule as the url itself, #450.
+ */
+import {describe, it, expect, afterEach} from 'vitest'
+import {withContainers} from './utils/browserFixture.js'
+import HICBrowser from '../js/hicBrowser.js'
+import State from '../js/hicState.js'
+import {setUrlMapper, mapTrackConfig} from '../js/urlMapper.js'
+
+const FASTA = 'https://igv.org/genomes/data/hg38/hg38.fa'
+const FAI = 'https://igv.org/genomes/data/hg38/hg38.fa.fai'
+
+/** The one thing `toJSON` reads off a dataset, plus the nvi it looks for. */
+function stubDataset(url) {
+    return {url, name: 'map', hicFile: {config: {}}}
+}
+
+/** A `trackPairs` entry, cut down to the `x.track` `toJSON` reaches through. */
+function stubTrackPair(config) {
+    return {x: {track: {config, name: config.name}}}
+}
+
+function serializeWithTracks(browser, configs) {
+    browser.dataset = stubDataset('https://example.org/map.hic')
+    // `state` is a getter over a private field; the chokepoint that writes it is
+    // async and renders. What `toJSON` wants is a State to stringify, so one is
+    // placed over the getter for the call.
+    Object.defineProperty(browser, 'state', {value: State.default(), configurable: true})
+    browser.trackPairs = configs.map(stubTrackPair)
+    browser.tracks2D = []
+    return browser.toJSON().tracks
+}
+
+describe('a saved track keeps its index', () => {
+
+    const dom = withContainers()
+
+    afterEach(() => setUrlMapper(undefined))
+
+    it('serializes indexURL', () => {
+        const browser = new HICBrowser(dom.another(), {})
+        const [track] = serializeWithTracks(browser, [
+            {url: FASTA, indexURL: FAI, type: 'sequence', format: 'sequence'}
+        ])
+        expect(track.indexURL).toBe(FAI)
+    })
+
+    it('leaves indexURL out entirely when the track has none', () => {
+        const browser = new HICBrowser(dom.another(), {})
+        const [track] = serializeWithTracks(browser, [
+            {url: 'https://example.org/a.bigWig', type: 'wig', format: 'bigwig'}
+        ])
+        expect(Object.hasOwn(track, 'indexURL')).toBe(false)
+    })
+
+    it('serializes the original indexURL, not the mapped one', () => {
+        setUrlMapper(url => `/__hic-proxy/${url}`)
+        const browser = new HICBrowser(dom.another(), {})
+        const [track] = serializeWithTracks(browser, [
+            mapTrackConfig({url: FASTA, indexURL: FAI, type: 'sequence', format: 'sequence'})
+        ])
+        expect(track.url).toBe(FASTA)
+        expect(track.indexURL).toBe(FAI)
+    })
+})


### PR DESCRIPTION
Closes #584.

A session saved while zoomed in never finished restoring. The same session saved zoomed out restored in seconds, and interactive zoom/pan in the live app was fine throughout — so the bug looked like it was about zoom. It was not.

## Cause

`HICBrowser.toJSON` serializes tracks through a whitelist — `url`, `type`, `format`, `name`, `min`/`max`, `color` — and `indexURL` was not on it. Every indexed track lost its index across a save.

Dropping the index does not fail the reload; it downgrades the track to a whole-file read, and igv only notices once something asks the track for data. A sequence track asks below its ~30 kb visibility window. The reported session sat at chr6, zoom index 12 (1 kb bins), `pixelSize: 128` — about 10 kb visible — so restoring it began fetching the whole three-gigabyte `hg38.fa` and never came back. Zoomed out, nothing asks, and the missing index is invisible.

`js/urlMapper.js` had the gap written down as a fact: *"nothing serializes an `indexURL` today"*.

## Change

- `js/hicBrowser.js` — `toJSON` writes `indexURL` when the track has one, and no key when it does not.
- `js/urlMapper.js` — new `unmappedIndexUrl()`, so a dev-proxied index serializes as its original URL rather than the proxy path. Same rule `unmappedUrl` already applied to `url` (#450); the mapper had been stashing the original `indexURL` all along with nothing reading it.
- `examples/juicebox-api.html` — a session-file picker. This is the harness the bug was found with: the host reads the JSON off disk and hands the parsed object to `restoreSession`. The two menus now reach the live browser through `getCurrentBrowser()`, because a restore replaces the browsers and the one `init` handed back goes stale.

## Evidence

Real Chrome against the dev server, asserting `restoreSession` resolves. Only the named field differs from the reported session:

| session | result |
| --- | --- |
| as reported | **never resolves** (>60 s); sole in-flight request is `hg38.fa` |
| `pixelSize: 32` | resolved, 2.6 s |
| `zoom: 9` | resolved, 3.0 s |
| sequence track removed | resolved, 2.9 s |
| `indexURL` added | resolved, 2.6 s |

End to end after the fix: saving from the running app at the zoomed state emits `indexURL`, and reloading that file resolves in 3.2 s.

## Tests

`test/testSessionTrackIndexUrl.js` — three cases: the index is preserved, an absent index stays absent, and with a mapper registered the original wins over the mapped path. Red before the change, green after. Full suite 991 passing.

## Note for existing sessions

Sessions saved before this cannot be repaired by it — they simply lack the field. Adding `"indexURL"` to the track by hand fixes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
