### PR TITLE
Add .out-of-scope/ knowledge base from the 2017-2019 backlog triage

### DIFF
--- a/.out-of-scope/contact-map-menu-curation.md
+++ b/.out-of-scope/contact-map-menu-curation.md
@@ -1,7 +1,11 @@
-# Contact Map Menu Curation
+# Data Selection UI Curation
 
-juicebox.js does not own the contact-map selection menu, and will not grow a
-searchable, metadata-driven catalog of `.hic` files.
+juicebox.js does not own the UI by which a user *chooses* data — neither the
+contact-map selection menu nor the ENCODE track pane — and will not grow
+searchable, metadata-driven catalogs for either.
+
+_(File kept under its original name so links posted on closed issues still
+resolve; the concept it records is the broader one.)_
 
 ## Why this is out of scope
 
@@ -20,7 +24,22 @@ The specific artifact attached to the original request (`hicfiles.json`, a flat
 list of S3 URLs with per-file metadata) is also a snapshot of one lab's holdings
 at one moment, not a format this component should learn to read.
 
+## The same applies to the ENCODE pane
+
+A later request asked for richer detail in the ENCODE track pane — searching by
+ENCODE file accession so that, for example, a replicate-combination file can be
+told apart from its siblings.
+
+That pane is not juicebox.js's either. There is no ENCODE selector anywhere in
+`js/`, and no `igv-widgets` dependency to supply one; the only ENCODE strings in
+this repo are entries in the `nvi.js` lookup table, which is a normalization
+index, not a catalog. The host app owns the pane, so the search fields it offers
+are the host's decision — and how much metadata is available to offer is
+ENCODE's.
+
 ## Prior requests
 
 - #226 — "Use JSON file to load menu" (attached `hicfiles.json.txt`, requesting
   ENCODE-table-style search over journal and cell type)
+- #285 — "More detail in ENCODE pane" (requesting search by ENCODE file
+  accession, to distinguish a replicate combination from its siblings)

--- a/.out-of-scope/contact-map-menu-curation.md
+++ b/.out-of-scope/contact-map-menu-curation.md
@@ -1,0 +1,26 @@
+# Contact Map Menu Curation
+
+juicebox.js does not own the contact-map selection menu, and will not grow a
+searchable, metadata-driven catalog of `.hic` files.
+
+## Why this is out of scope
+
+juicebox.js is an embeddable component, not an application. The list of maps a
+user can choose from is a property of the *host* — Juicebox-web presents a
+curated public catalog, Spacewalk presents whatever the current model implies,
+and a third embedder may present none at all. There is no menu machinery in
+`js/` to extend, and adding one would push product curation into a library.
+
+The component's contract is the other direction: the host hands it a map to
+load, through the documented config and session paths. Anything richer — search
+by journal, filter by cell type, faceted browse in the manner of the ENCODE
+table — is a catalog UI, and belongs to whoever owns the catalog.
+
+The specific artifact attached to the original request (`hicfiles.json`, a flat
+list of S3 URLs with per-file metadata) is also a snapshot of one lab's holdings
+at one moment, not a format this component should learn to read.
+
+## Prior requests
+
+- #226 — "Use JSON file to load menu" (attached `hicfiles.json.txt`, requesting
+  ENCODE-table-style search over journal and cell type)

--- a/.out-of-scope/map-summing.md
+++ b/.out-of-scope/map-summing.md
@@ -1,0 +1,28 @@
+# Summing Contact Maps
+
+juicebox.js does not sum two or more contact maps into a combined map, and will
+not grow the feature. Desktop Juicebox has it; this component does not.
+
+## Why this is out of scope
+
+juicebox.js does have a two-map story, but it is a **display-time** one. When a
+control map is loaded, the second map participates through the color scale —
+`ratioColorScale.js`, `diffColorScale.js` and the A/B display modes in
+`ContactMatrixView` — comparing the two maps' already-rendered values per bin at
+paint time. Nothing in the pipeline combines contact records before they become
+pixels.
+
+Summing is the other kind of operation. Two maps can only be added meaningfully
+at the level of raw observed counts, which means reconciling resolutions, bin
+boundaries, genome builds and normalization between the files, then producing a
+new matrix that has its own norm vectors and its own expected-value curves. That
+is a data-processing job, and it belongs where the other data-processing jobs
+live — Juicer Tools, which already produces combined `.hic` files.
+
+The resulting combined file then loads here like any other map, which is the
+division this component is built around: juicebox.js visualizes `.hic` files,
+it does not manufacture them.
+
+## Prior requests
+
+- #299 — "warn: js doesn't support summing"

--- a/.out-of-scope/normalization-vector-track.md
+++ b/.out-of-scope/normalization-vector-track.md
@@ -1,0 +1,42 @@
+# Normalization Vector As A 1D Track
+
+juicebox.js does not render a normalization vector as a 1D track alongside the
+contact map, the way Desktop Juicebox does.
+
+## Why this is out of scope
+
+Normalization in juicebox.js is a property of the *matrix*, not a signal to plot.
+The whole normalization path exists to answer one question — which normalization
+should the tiles be drawn with — and it ends at the color scale:
+
+```js
+// DataLoader.loadNormalizationFile
+const normVectors = await this.browser.dataset.hicFile.readNormalizationVectorFile(
+    url, this.browser.dataset.chromosomes
+);
+for (let type of normVectors['types']) {
+    // ...register the type as a selectable normalization
+    this.browser.coordinator.onNormVectorIndexLoad(this.browser.dataset);
+}
+```
+
+The vectors are read, their *types* are registered as options in the
+normalization selector, and the values themselves are consumed inside straw when
+tiles are built. Nothing downstream models a normalization vector as a track.
+
+Making one a track means the opposite framing: a per-bin signal with its own
+data range, autoscale behaviour, color, gear menu, session serialization, and a
+`TrackPair` on both axes — all the machinery 1D tracks carry, wrapped around a
+value that is currently an implementation detail of rendering. That is a new
+track type, not a display toggle.
+
+It is also a **parity** request rather than a need. Desktop Juicebox is a
+full application, and its feature surface is not the target for this component;
+juicebox.js is embedded in hosts that supply their own track UI, and a host that
+genuinely wants the vector plotted can fetch it and hand it in as an ordinary
+1D track config. That path already works and requires nothing from this library.
+
+## Prior requests
+
+- #284 — "Feature request: normalization vector" (requesting Desktop Juicebox's
+  load-normalization-vector-as-track behaviour)

--- a/.out-of-scope/per-axis-track-assignment.md
+++ b/.out-of-scope/per-axis-track-assignment.md
@@ -1,0 +1,41 @@
+# Per-Axis Track Assignment
+
+juicebox.js does not offer a control for running a given 1D track along only the
+X axis or only the Y axis. Every 1D track is drawn along both.
+
+## Why this is out of scope
+
+A Hi-C contact map is a symmetric 2D view, and juicebox's whole 1D-track model is
+built on that symmetry. `TrackPair` (`js/trackPair.js`) is the unit of track
+state: one loaded track, two renderers, one `x` and one `y`, constructed together
+and torn down together.
+
+```js
+class TrackPair {
+    constructor(browser, track) {
+        this.browser = browser
+        this.track = track
+        this.x = undefined
+        this.y = undefined
+    }
+```
+
+Everything downstream inherits that pairing — the gear menu, the color picker,
+the data-range dialog, reordering, and the session format all address the pair,
+not a side. Making a track single-axis is therefore not a rendering flag; it
+means splitting `TrackPair` into an axis-optional container and revisiting every
+call site that assumes both halves exist.
+
+The original request named the blocker itself and never resolved it: it is not
+clear where the track label goes when a track is Y-only, and the row/column
+layout has no place to put one. Eight years produced no answer and no second
+request, which is the strongest available evidence that the symmetric model is
+the right one for this component.
+
+Downstream consumers that need an asymmetric arrangement are better served by
+igv.js directly, which is linear by design.
+
+## Prior requests
+
+- #95 — "Have any given track run either along X or along Y" (filed as an
+  explicit "dream feature, not core"; later narrowed to X-only, then dormant)

--- a/.out-of-scope/track-format-validation.md
+++ b/.out-of-scope/track-format-validation.md
@@ -1,0 +1,36 @@
+# Track Format Validation
+
+juicebox.js does not validate track file formats or maintain its own list of
+recognized track extensions, and will not raise its own "unknown file type"
+error at the track-load door.
+
+## Why this is out of scope
+
+Format inference for 1D tracks is igv.js's responsibility. juicebox.js passes a
+track config through to igv.js and lets it decide what the file is; the only
+format decisions juicebox makes are the two-dimensional ones it actually owns
+(2D/bedpe annotations, and the `sequence` special case for FASTA). Adding a
+juicebox-side allowlist would mean maintaining a second, always-drifting copy of
+igv.js's format table, and a file igv.js gained support for would start being
+rejected here first.
+
+What juicebox does own is *surfacing* failures rather than swallowing them, and
+that exists: `DataLoader.loadTracks` wraps the whole load in a handler that
+reports to the user rather than logging quietly.
+
+```js
+} catch (error) {
+    presentError(this.browser.registry, errorPrefix, error);
+    console.error(error);
+}
+```
+
+So the durable position is: igv.js decides what a file is and reports when it
+cannot read one; juicebox displays that error. A silently-ignored track is a bug
+in that chain, to be fixed where the silence is — not a case for a pre-flight
+extension check.
+
+## Prior requests
+
+- #220 — "Loading unknown track file type should present error" (a `.hic` URL
+  entered into the Track URL field, failing silently)


### PR DESCRIPTION
Triage of the 8–9 year and 7-year issue blocks closed fourteen issues. Six of them were **rejected enhancements**, which `/triage` records in `.out-of-scope/` so the reasoning survives the closed issue and future duplicates can be matched against it by concept.

| File | Issues | Rejection |
|------|--------|-----------|
| `per-axis-track-assignment.md` | #95 | `TrackPair` is the unit of 1D track state; single-axis is a container split, not a flag — and the original blocker (where the label goes) was never resolved |
| `contact-map-menu-curation.md` | #226, #285 | Data-selection UI — the contact-map menu and the ENCODE pane alike — belongs to the host, not to an embeddable component |
| `track-format-validation.md` | #220 | 1D format inference is igv.js's job; a juicebox-side allowlist would be a drifting second copy |
| `normalization-vector-track.md` | #284 | Normalization is a property of the matrix, not a signal to plot; a host wanting it plotted can pass it as an ordinary 1D track |
| `map-summing.md` | #299 | juicebox's two-map story is display-time (ratio/diff color scales); summing is a raw-counts operation belonging to Juicer Tools |

`contact-map-menu-curation.md` is broadened in the second commit to cover selection UI generally. Its filename is deliberately unchanged so the link already posted on closed #226 keeps resolving.

No code changes — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)