### PR TITLE
Make All a zoom rung for single-chromosome assemblies (#236)

### DIFF
--- a/docs/adr/0010-all-is-a-zoom-rung-not-a-chromosome.md
+++ b/docs/adr/0010-all-is-a-zoom-rung-not-a-chromosome.md
@@ -121,6 +121,38 @@ and as wire format — and disappears exactly where it was redundant.
   (`interactionHandler.js:345`) becomes unreachable for these datasets, since
   `state.chr1` is never 0. It is left in place for normal genomes.
 
+## Amendments, recorded during implementation (2026-08-24)
+
+Three things the decision above did not anticipate, found while building it and
+recorded here rather than left in a commit message.
+
+**The blast radius of decision 2 is wider than "ruler, `State`, tile source".**
+Seven further sites index `bpResolutions[state.zoom]` on a path the sentinel can
+reach, and each returns `undefined` at index `-1`: the scrollbar, sweep zoom,
+`genomicState`, `resolution()`, and -- via `getZoomDataByIndex(-1)` -- the smooth
+zoom animation and the 2D track pass. They are converted. Thirteen conversions
+against the five budgeted; the count was an underestimate, not a boundary that
+was crossed for convenience. Seven direct-index sites remain for #398.
+
+**2D annotations draw nothing at the sentinel.** The 2D pass resolves through
+`matrixViewForZoom` like the tile pass, so at the sentinel its axes are named
+`All` and a track keyed to the scaffold matches nothing. This is exactly what
+the whole-genome view it replaces does today, and one rung in the annotations
+are back -- at 500 bins across a 2.4 Gbp scaffold a loop call is sub-pixel
+anyway. Drawing them would mean running the 2D pass in the state's vocabulary
+while the tile pass runs in the data's, which is decisions 3 and 4 pulled apart
+one layer too far.
+
+**Sync had to be told about the rung.** `State.sync` matched an incoming peer's
+bin size against `dataset.bpResolutions`, which cannot name the sentinel -- so a
+peer sitting on it would have been followed to the coarsest *declared* rung, a
+visibly different view. It now matches against `browser.getResolutions()`. For a
+browser with no control map the two lists carry the same bin sizes and the rung
+chosen is the rung it always was; for an A/B map the new list is the
+intersection, which is strictly more correct -- the old one could pick a bin the
+B map does not carry. Decision 6 governs the *process* boundary; sync is
+in-process, and is the one place the sentinel legitimately travels.
+
 ## Considered and rejected
 
 - **Filtering the pulldown only.** Leaves `All` reachable by three other paths.

--- a/docs/state-manipulation.md
+++ b/docs/state-manipulation.md
@@ -12,7 +12,7 @@ This document catalogs every way the browser's `State` can be mutated. It exists
 | `chr2` | Chromosome index, y axis |
 | `x` | Bin position, x axis |
 | `y` | Bin position, y axis |
-| `zoom` | Resolution index (into `dataset.bpResolutions`) |
+| `zoom` | Resolution index (into `dataset.bpResolutions`), or the **sentinel** `-1` — see below |
 | `pixelSize` | Pixels per bin (display scaling) |
 | `normalization` | Normalization vector ID (`'NONE'`, `'KR'`, etc.) |
 
@@ -39,6 +39,30 @@ async state.setView(chr1, chr2, x, y, zoom, pixelSize,
 - Adjusts `pixelSize` through the standard floor-and-cap pipeline (`Math.max(1, x)` → floor by `minPixelSize` → `Math.min(MAX_PIXEL_SIZE, x)`).
 - Mutates the canonical fields in a fixed order.
 - Optionally clamps `x`/`y` to chromosome bounds.
+- Redirects `All` to the sole scaffold on a **single-chromosome assembly**, landing
+  the view on the sentinel zoom rung. See below.
+
+### The sentinel zoom rung
+
+On a dataset whose chromosome table is the `All` entry plus exactly one real
+chromosome, `All` is not a chromosome the view can be at. `setView` rewrites such
+a view to `{chr1: sole, chr2: sole, zoom: -1}` — `-1` being the **sentinel**, a
+rung juicebox synthesises from the whole-genome matrix rather than reading off
+the file's resolution ladder. `x`, `y` and `pixelSize` carry over untouched,
+because the whole-genome bin and the sentinel bin are the same bin.
+
+Two consequences worth knowing before touching this code:
+
+- **`zoom` is not always an index into `bpResolutions`.** Read bin sizes through
+  `dataset.binSizeForZoom(zoom)` or `browser.binSizeForZoom(zoom)`, and resolve
+  matrix coordinates through `dataset.matrixViewForZoom(chr1, chr2, zoom)`.
+- **The sentinel never crosses the process boundary.** `State.toJSON` writes it
+  out as `{chr1: 0, chr2: 0, zoom: 0}`, the whole-genome view — which is the same
+  picture for this assembly, and is redirected back on the way in.
+
+ADR-0010 has the full reasoning, including why the two whole-genome tests
+(`dataset.isWholeGenome(chrIndex)` and `0 === zd.chr1.index`) are divergent by
+design at this rung.
 
 ### `setView` options
 
@@ -69,7 +93,7 @@ The translators are thin wrappers (typically ~10–20 lines each) that convert d
 |---|---|---|
 | `updateWithLoci(chr1Name, bpX, bpXMax, chr2Name, bpY, bpYMax, browser, width, height)` | BP loci → bin positions, target zoom from `bpPerPixelTarget` | Locus goto, gene search, programmatic `browser.goto()`, sweep zoom |
 | `panShift(dx, dy, browser, dataset, viewDimensions)` | Screen pixel deltas → bin position deltas | Drag pan |
-| `panWithZoom(zoom, pixelSize, anchorPx, anchorPy, binSize, browser, dataset, viewDimensions, bpResolutions)` | Anchor pixel + new zoom/pixelSize → anchor-preserving bin position | Wheel zoom, pinch zoom |
+| `panWithZoom(zoom, pixelSize, anchorPx, anchorPy, binSize, browser, dataset, viewDimensions)` | Anchor pixel + new zoom/pixelSize → anchor-preserving bin position | Wheel zoom, pinch zoom |
 | `setWithZoom(zoom, viewDimensions, browser, dataset)` | Target zoom only → view-center-preserving bin position; applies `useDefaultMin: true` | Resolution selector, zoom-step from `zoomAndCenter` |
 | `sync(targetState, browser, genome, dataset)` | Peer-browser state (different binSize/dataset) → bin-converted local state | Cross-browser sync |
 | `zoomBy(direction, centerPX, centerPY, browser, dataset, viewDimensions)` | Zoom direction at click point under resolution lock or zoom boundary → atomic recenter + pixelSize doubling/halving | Double-click and wheel zoom when locked or at boundary |

--- a/js/chromosomeSelector.js
+++ b/js/chromosomeSelector.js
@@ -65,8 +65,14 @@ class ChromosomeSelector {
     }
 
     respondToDataLoadWithDataset(dataset) {
-        const { chromosomes } = dataset;
-        const options = chromosomes.map(({ name }, index) => `<option value="${index}">${name}</option>`).join('');
+        // `All` is dropped for a single-chromosome assembly: it and the sole
+        // scaffold describe the same view, and offering both is the duplicate
+        // #236 asked to be rid of. The entry survives as data and as wire
+        // format -- what goes is the vocabulary. ADR-0010.
+        const chromosomes = dataset.isSingleChromosome()
+            ? dataset.chromosomes.filter(chromosome => !dataset.isWholeGenome(chromosome.index))
+            : dataset.chromosomes;
+        const options = chromosomes.map(({ name, index }) => `<option value="${index}">${name}</option>`).join('');
         this.xAxisSelector.innerHTML = options;
         this.yAxisSelector.innerHTML = options;
 

--- a/js/contactMatrixView.js
+++ b/js/contactMatrixView.js
@@ -297,13 +297,18 @@ class ContactMatrixView {
         const state = this.browser.state;
         const viewportWidth = this.viewportElement.offsetWidth;
         const viewportHeight = this.viewportElement.offsetHeight;
-        const matrices = await getMatrices.call(this, state.chr1, state.chr2);
+        // The same matrix and resolution the tile pass drew from, so the extent
+        // computed here is in the same units as `this.genomicExtent`, which is
+        // recorded off `tile.binSize`. At the sentinel rung both are the
+        // whole-genome matrix's. ADR-0010 decision 3.
+        const view = this.browser.dataset.matrixViewForZoom(state.chr1, state.chr2, state.zoom);
+        const matrices = await getMatrices.call(this, view.chr1, view.chr2);
 
         const matrix = matrices[0];
 
         if (matrix) {
             const unit = "BP";
-            const zd = await matrix.getZoomDataByIndex(state.zoom, unit);
+            const zd = await matrix.getZoomDataByIndex(view.zoomIndex, unit);
             const newGenomicExtent = {
                 x: state.x * zd.zoom.binSize,
                 y: state.y * zd.zoom.binSize,
@@ -694,8 +699,15 @@ class ContactMatrixView {
 
     async render2DTracks(track2DList, dataset, state) {
 
-        const matrix = await dataset.getMatrix(state.chr1, state.chr2)
-        const zoomData = matrix.getZoomDataByIndex(state.zoom, 'BP')
+        // Resolved the same way the tile pass resolves it, so `bpPerPixel` below
+        // is in the matrix's own units. At the sentinel rung that is the
+        // whole-genome matrix, whose axes are named `All` -- so a 2D track keyed
+        // to the scaffold matches nothing and draws nothing, exactly as it does
+        // in the whole-genome view the sentinel replaces. One rung in, it is
+        // back. ADR-0010 decision 3.
+        const view = dataset.matrixViewForZoom(state.chr1, state.chr2, state.zoom)
+        const matrix = await dataset.getMatrix(view.chr1, view.chr2)
+        const zoomData = matrix.getZoomDataByIndex(view.zoomIndex, 'BP')
 
         const { width, height } = this.getViewDimensions()
         const bpPerPixel = zoomData.zoom.binSize/state.pixelSize

--- a/js/contactMatrixView.js
+++ b/js/contactMatrixView.js
@@ -300,7 +300,11 @@ class ContactMatrixView {
         // The same matrix and resolution the tile pass drew from, so the extent
         // computed here is in the same units as `this.genomicExtent`, which is
         // recorded off `tile.binSize`. At the sentinel rung both are the
-        // whole-genome matrix's. ADR-0010 decision 3.
+        // whole-genome matrix's, which states its bins in kb where every
+        // declared rung states them in bp. The two never meet: the one caller
+        // (`interactionHandler._applyStateChange`) runs this only when
+        // `resolutionChanged` is false, and moving on or off the sentinel is
+        // always a resolution change. ADR-0010 decision 3.
         const view = this.browser.dataset.matrixViewForZoom(state.chr1, state.chr2, state.zoom);
         const matrices = await getMatrices.call(this, view.chr1, view.chr2);
 

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -421,7 +421,7 @@ class HICBrowser {
         // intersection to keep. It needs none -- genomes must match
         // (`dataLoader.js:356`), so both datasets compute the same
         // `wholeGenomeResolution`. ADR-0010.
-        if (this.dataset.isSingleChromosome && this.dataset.isSingleChromosome()) {
+        if (this.dataset.isSingleChromosome()) {
             resolutions = [...resolutions, {index: SENTINEL_ZOOM, binSize: this.dataset.wholeGenomeResolution}]
         }
 
@@ -439,6 +439,10 @@ class HICBrowser {
      * `dataset.bpResolutions[state.zoom]` directly, and ADR-0010 decision 2
      * converts only the ones the sentinel path can reach; the rest are left to
      * the refactor that owns them, rather than folded into this ticket's diff.
+     *
+     * Delegation, and the split is deliberate: whatever holds a browser reads it
+     * here, and `State` -- which is handed a dataset and, in `getLocus` and
+     * `clampXY`, no browser at all -- reads `dataset.binSizeForZoom` directly.
      */
     binSizeForZoom(zoom = this.state.zoom) {
         return this.dataset.binSizeForZoom(zoom)

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -39,6 +39,7 @@ import DataLoader from "./dataLoader.js"
 import {normalizeTrackConfigs} from "./normalizeSession.js"
 import {unmappedUrl, unmappedIndexUrl} from "./urlMapper.js"
 import {isSynchable} from "./syncGroup.js"
+import {SENTINEL_ZOOM} from "./sentinelZoom.js"
 
 const DEFAULT_PIXEL_SIZE = 1
 const MAX_PIXEL_SIZE = 128
@@ -408,12 +409,39 @@ class HICBrowser {
         const baseResolutions = this.dataset.bpResolutions.map(function (resolution, index) {
             return {index: index, binSize: resolution}
         })
+
+        let resolutions = baseResolutions
         if (this.controlDataset) {
-            let controlResolutions = new Set(this.controlDataset.bpResolutions)
-            return baseResolutions.filter(base => controlResolutions.has(base.binSize))
-        } else {
-            return baseResolutions
+            const controlResolutions = new Set(this.controlDataset.bpResolutions)
+            resolutions = baseResolutions.filter(base => controlResolutions.has(base.binSize))
         }
+
+        // The sentinel rung is appended *after* the intersection rather than
+        // passed through it: a B map declares no whole-genome resolution for the
+        // intersection to keep. It needs none -- genomes must match
+        // (`dataLoader.js:356`), so both datasets compute the same
+        // `wholeGenomeResolution`. ADR-0010.
+        if (this.dataset.isSingleChromosome && this.dataset.isSingleChromosome()) {
+            resolutions = [...resolutions, {index: SENTINEL_ZOOM, binSize: this.dataset.wholeGenomeResolution}]
+        }
+
+        // Sorted by bin size, coarsest first, rather than trusted to arrive that
+        // way. `interactionHandler` reads `resolutions[0]` as the coarsest rung
+        // and the last entry as the finest, and the sentinel's index does not
+        // put it at either end. ADR-0010 decision 1.
+        return resolutions.sort((a, b) => b.binSize - a.binSize)
+    }
+
+    /**
+     * The bin size, in bp, of a zoom rung -- the sentinel rung included.
+     *
+     * The landing pad for #398. Some twenty sites index
+     * `dataset.bpResolutions[state.zoom]` directly, and ADR-0010 decision 2
+     * converts only the ones the sentinel path can reach; the rest are left to
+     * the refactor that owns them, rather than folded into this ticket's diff.
+     */
+    binSizeForZoom(zoom = this.state.zoom) {
+        return this.dataset.binSizeForZoom(zoom)
     }
 
     isWholeGenome() {
@@ -491,7 +519,7 @@ class HICBrowser {
     genomicState(axis) {
 
         let width = this.contactMatrixView.getViewDimensions().width
-        let resolution = this.dataset.bpResolutions[this.state.zoom]
+        let resolution = this.binSizeForZoom(this.state.zoom)
         const bpp =
             (this.dataset.chromosomes[this.state.chr1].name.toLowerCase() === "all") ?
                 this.genome.getGenomeLength() / width :
@@ -1254,7 +1282,7 @@ class HICBrowser {
     }
 
     resolution() {
-        return this.dataset.bpResolutions[this.state.zoom]
+        return this.binSizeForZoom()
     };
 
     /**
@@ -1384,6 +1412,15 @@ class HICBrowser {
         const { width, height } = this.contactMatrixView.getViewDimensions()
         const binSize = Math.max(chromosome1.size / width, chromosome2.size / height)
 
+        // `findZoomForResolution` floors at the coarsest *declared* bin, so on a
+        // large single scaffold it answers with a rung that cannot frame the
+        // thing at all. The only coarser data in the file is the whole-genome
+        // matrix, which for this assembly is the same picture -- so the fit
+        // falls through to the sentinel rung. ADR-0010 fact 3.
+        if (this.dataset.isSingleChromosome() && Math.max(...this.dataset.bpResolutions) < binSize) {
+            return SENTINEL_ZOOM
+        }
+
         const matrix = await this.dataset.getMatrix(chr1, chr2)
         if (!matrix) {
             throw new Error(`Data not avaiable for chromosomes ${chromosome1.name} - ${chromosome2.name}`)
@@ -1406,6 +1443,18 @@ class HICBrowser {
 
         const chr1Length = this.dataset.chromosomes[chr1].size
         const chr2Length = this.dataset.chromosomes[chr2].size
+
+        // The sentinel rung is sized against the scaffold, not against the
+        // whole-genome matrix's own zoom record. Both describe the same 500-bin
+        // span, but the matrix states it in the kb it stores its coordinates in
+        // while `chr1Length` here is bp -- reading the record would divide one
+        // unit by the other. `wholeGenomeResolution` is that same bin in bp,
+        // which is what makes this a unit match. ADR-0010 fact 4.
+        if (SENTINEL_ZOOM === zoomIndex) {
+            const binSize = this.dataset.wholeGenomeResolution
+            const { width, height } = this.contactMatrixView.getViewDimensions();
+            return Math.min(width / (chr1Length / binSize), height / (chr2Length / binSize));
+        }
 
         const matrix = await this.dataset.getMatrix(chr1, chr2)
         if (!matrix) {

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -1421,8 +1421,18 @@ class HICBrowser {
         // thing at all. The only coarser data in the file is the whole-genome
         // matrix, which for this assembly is the same picture -- so the fit
         // falls through to the sentinel rung. ADR-0010 fact 3.
-        if (this.dataset.isSingleChromosome() && Math.max(...this.dataset.bpResolutions) < binSize) {
-            return SENTINEL_ZOOM
+        //
+        // Asked of the rungs actually on offer, not of the primary map's raw
+        // ladder: on an A/B map the coarsest *common* bin can be finer than the
+        // primary's coarsest, and a scaffold that map cannot frame either has
+        // to fall through too. The list is sorted coarsest-first, and the
+        // sentinel is filtered back out so the question stays "is anything
+        // declared coarse enough".
+        if (this.dataset.isSingleChromosome()) {
+            const declared = this.getResolutions().filter(({index}) => SENTINEL_ZOOM !== index)
+            if (0 === declared.length || declared[0].binSize < binSize) {
+                return SENTINEL_ZOOM
+            }
         }
 
         const matrix = await this.dataset.getMatrix(chr1, chr2)

--- a/js/hicDataset.js
+++ b/js/hicDataset.js
@@ -29,6 +29,7 @@
 import {isFile} from "./fileUtils.js"
 import {getUrlMapper} from "./urlMapper.js"
 import Straw from 'hic-straw'
+import {SENTINEL_ZOOM} from './sentinelZoom.js'
 
 const knownGenomes = {
 
@@ -190,6 +191,64 @@ class Dataset {
      */
     isWholeGenome(chrIndex) {
         return (this.wholeGenomeChromosome != null && this.wholeGenomeChromosome.index === chrIndex);
+    }
+
+    /**
+     * True when the assembly holds the `All` pseudo-chromosome and exactly one
+     * real chromosome, so the whole-genome view and that chromosome describe the
+     * same picture.
+     *
+     * `All` is identified by `wholeGenomeChromosome` identity rather than by the
+     * name test `genome.js:49` and `ruler.js:93` use. The predicate gates a
+     * change of vocabulary, and it must stay false for every real genome --
+     * a two-entry chromosome table is the whole claim. ADR-0010.
+     */
+    isSingleChromosome() {
+        return this.wholeGenomeChromosome != null && this.chromosomes.length === 2;
+    }
+
+    /**
+     * The one real chromosome of a single-chromosome assembly -- the scaffold
+     * `All` is a duplicate of. Undefined for every other dataset.
+     */
+    soleChromosome() {
+        if (!this.isSingleChromosome()) return undefined;
+        return this.chromosomes.find(chr => chr !== this.wholeGenomeChromosome);
+    }
+
+    /**
+     * Bin size in bp for a zoom index, the sentinel rung included.
+     *
+     * At the sentinel the answer is `wholeGenomeResolution`, which is the
+     * whole-genome bin expressed in bp rather than in the kb the whole-genome
+     * matrix stores its own coordinates in. For a one-chromosome genome the
+     * cumulative offset is zero, so that bin divides the sole scaffold's bp
+     * exactly -- ADR-0010 fact 4, and the reason this is a unit match rather
+     * than a conversion.
+     */
+    binSizeForZoom(zoom) {
+        return SENTINEL_ZOOM === zoom ? this.wholeGenomeResolution : this.bpResolutions[zoom];
+    }
+
+    /**
+     * The matrix coordinates and resolution index that carry a view's *data*.
+     *
+     * Identity for a declared rung. At the sentinel it answers with the
+     * whole-genome matrix at its only resolution: the rung is synthesised, but
+     * the data behind it is the `All` matrix, queried in the `All` matrix's own
+     * coordinates exactly as the whole-genome view queries it today.
+     *
+     * This is why `imageTileSource`'s `0 === zd.chr1.index` stays true at the
+     * sentinel while `browser.isWholeGenome()` is false. The two whole-genome
+     * tests are divergent **by design** -- ADR-0010 decisions 3 and 4. Do not
+     * "fix" them into agreement.
+     */
+    matrixViewForZoom(chr1, chr2, zoom) {
+        if (SENTINEL_ZOOM !== zoom) {
+            return {chr1, chr2, zoomIndex: zoom};
+        }
+        const {index} = this.wholeGenomeChromosome;
+        return {chr1: index, chr2: index, zoomIndex: 0};
     }
 
     /**

--- a/js/hicResolutionSelector.js
+++ b/js/hicResolutionSelector.js
@@ -126,8 +126,11 @@ class ResolutionSelector {
      * @param {number} zoomIndex - The zoom index to select
      */
     setSelectedResolution(zoomIndex) {
-        Array.from(this.resolutionSelectorElement.options).forEach((option, index) => {
-            option.selected = index === zoomIndex;
+        // Matched on the option's value, which is the zoom index. Its position
+        // in the list is a different number whenever a rung has been filtered
+        // out (an A/B map) or synthesised in (the sentinel rung, ADR-0010).
+        Array.from(this.resolutionSelectorElement.options).forEach(option => {
+            option.selected = parseInt(option.value, 10) === zoomIndex;
         });
     }
 }

--- a/js/hicState.js
+++ b/js/hicState.js
@@ -27,6 +27,7 @@
  */
 
 import {DEFAULT_PIXEL_SIZE, MAX_PIXEL_SIZE} from "./hicBrowser.js"
+import {SENTINEL_ZOOM} from "./sentinelZoom.js"
 
 /**
  * State holds the canonical six fields that fully specify the view:
@@ -186,14 +187,44 @@ class State {
             [x, y] = [y, x];
         }
 
+        // `All` is not a chromosome a single-chromosome assembly can be at
+        // (ADR-0010 decision 5). Every entry point that can name it -- the
+        // pulldown, the locus box, a saved session, a pasted URL -- reaches the
+        // state through here, so the redirect lives at the chokepoint rather
+        // than at four call sites, and an eight-year-old link naming `chr 0`
+        // opens instead of throwing (ADR-0009: coerce, never reject).
+        //
+        // It is silent. By the premise of #236 there is no user-visible
+        // difference between the two views, so there is nothing to warn about.
+        //
+        // x, y and pixelSize carry over untouched: the whole-genome bin and the
+        // sentinel bin are the same bin, offset zero (ADR-0010 fact 4).
+        let redirected = false;
+        if (dataset && dataset.isSingleChromosome && dataset.isSingleChromosome() && dataset.isWholeGenome(chr1)) {
+            chr1 = chr2 = dataset.soleChromosome().index;
+            zoom = SENTINEL_ZOOM;
+            redirected = true;
+        }
+
         const chrChanged = this._detectChromosomeChange(chr1, chr2);
         const resolutionChanged = this._detectResolutionChange(zoom);
+
+        // A redirected view is sized against the pair it lands on, not the pair
+        // it arrived as. `_adjustPixelSize` consults `minPixelSize` with the
+        // *outgoing* chromosomes by the convention noted below, and the outgoing
+        // pair here is `All`, whose size is in kb -- divided by a sentinel bin
+        // stated in bp it yields half a bin and a pixelSize pinned to the cap.
+        // The scaffold and the sentinel bin are both bp (ADR-0010 fact 4).
+        let sizedAgainst = minPixelSize;
+        if (redirected && undefined === sizedAgainst && adjustPixelSize && browser) {
+            sizedAgainst = await browser.minPixelSize(chr1, chr2, zoom);
+        }
 
         // Adjust pixelSize BEFORE mutating chr1/chr2 — preserves the existing convention
         // that browser.minPixelSize is consulted with the pre-mutation chr1/chr2 (and the
         // post-mutation zoom).
         const adjustedPixelSize = adjustPixelSize
-            ? await this._adjustPixelSize(pixelSize, browser, zoom, { useDefaultMin, minPixelSize })
+            ? await this._adjustPixelSize(pixelSize, browser, zoom, { useDefaultMin, minPixelSize: sizedAgainst })
             : pixelSize;
 
         this.chr1 = chr1;
@@ -212,9 +243,9 @@ class State {
 
     clampXY(dataset, viewDimensions) {
         const { width, height } = viewDimensions
-        const { chromosomes, bpResolutions } = dataset;
+        const { chromosomes } = dataset;
 
-        const binSize = bpResolutions[this.zoom];
+        const binSize = dataset.binSizeForZoom(this.zoom);
         const maxX = Math.max(0, chromosomes[this.chr1].size / binSize -  width / this.pixelSize);
         const maxY = Math.max(0, chromosomes[this.chr2].size / binSize - height / this.pixelSize);
 
@@ -222,13 +253,19 @@ class State {
         this.y = Math.min(Math.max(0, this.y), maxY);
     }
 
-    async panWithZoom(zoom, pixelSize, anchorPx, anchorPy, binSize, browser, dataset, viewDimensions, bpResolutions) {
+    async panWithZoom(zoom, pixelSize, anchorPx, anchorPy, binSize, browser, dataset, viewDimensions) {
         // The translator owns anchor-preservation math because it depends on the adjusted
         // pixelSize: the new x/y must be computed against the post-adjust pixelSize so the
         // genomic position at (anchorPx, anchorPy) is invariant across the call.
+        //
+        // The outgoing bin size is read off the dataset rather than out of a
+        // resolution array the caller passes in. Position and zoom index are not
+        // the same number once a rung is filtered (an A/B map) or synthesised
+        // (the sentinel), and this used to index one by the other.
         const adjustedPixelSize = await this._adjustPixelSize(pixelSize, browser, zoom)
-        const gx = (this.x + anchorPx / this.pixelSize) * bpResolutions[this.zoom].binSize
-        const gy = (this.y + anchorPy / this.pixelSize) * bpResolutions[this.zoom].binSize
+        const currentBinSize = dataset.binSizeForZoom(this.zoom)
+        const gx = (this.x + anchorPx / this.pixelSize) * currentBinSize
+        const gy = (this.y + anchorPy / this.pixelSize) * currentBinSize
         const newX = gx / binSize - anchorPx / adjustedPixelSize
         const newY = gy / binSize - anchorPy / adjustedPixelSize
 
@@ -258,8 +295,8 @@ class State {
         const xCenter = this.x + (width / 2) / this.pixelSize
         const yCenter = this.y + (height / 2) / this.pixelSize
 
-        const binSize = dataset.bpResolutions[this.zoom]
-        const binSizeNew = dataset.bpResolutions[zoom]
+        const binSize = dataset.binSizeForZoom(this.zoom)
+        const binSizeNew = dataset.binSizeForZoom(zoom)
         const scaleFactor = binSize / binSizeNew
         const xCenterNew = xCenter * scaleFactor
         const yCenterNew = yCenter * scaleFactor
@@ -286,7 +323,7 @@ class State {
      * reflects what is actually on screen, derived from chr1/chr2/x/y/zoom/pixelSize.
      */
     getLocus(dataset, viewDimensions) {
-        const bpPerBin = dataset.bpResolutions[this.zoom];
+        const bpPerBin = dataset.binSizeForZoom(this.zoom);
         const startBP1 = Math.round(this.x * bpPerBin);
         const startBP2 = Math.round(this.y * bpPerBin);
         const chr1 = dataset.chromosomes[this.chr1];
@@ -318,7 +355,7 @@ class State {
         const zoomNew = (true === browser.resolutionLocked)
             ? this.zoom
             : browser.findMatchingZoomIndex(bpPerPixelTarget, bpResolutions)
-        const { binSize: binSizeNew } = bpResolutions[zoomNew]
+        const binSizeNew = browser.binSizeForZoom(zoomNew)
 
         return await this.setView(
             chr1Index, chr2Index,
@@ -439,7 +476,7 @@ class State {
         return {
             chr1Name: dataset.chromosomes[this.chr1].name,
             chr2Name: dataset.chromosomes[this.chr2].name,
-            binSize: dataset.bpResolutions[this.zoom],
+            binSize: dataset.binSizeForZoom(this.zoom),
             binX: this.x,
             binY: this.y,
             pixelSize: this.pixelSize
@@ -451,8 +488,12 @@ class State {
         const chr2 = genome.getChromosome(targetState.chr2Name)
 
         const bpPerPixelTarget = targetState.binSize / targetState.pixelSize
-        const zoomNew = browser.findMatchingZoomIndex(bpPerPixelTarget, dataset.bpResolutions)
-        const binSizeNew = dataset.bpResolutions[zoomNew]
+        // Matched against `browser.getResolutions()` rather than the raw
+        // `bpResolutions` array so a peer sitting at the sentinel rung is a rung
+        // this browser can follow it to. Same reason as everywhere else: array
+        // position and zoom index are not the same number.
+        const zoomNew = browser.findMatchingZoomIndex(bpPerPixelTarget, browser.getResolutions())
+        const binSizeNew = browser.binSizeForZoom(zoomNew)
 
         const xBinNew = targetState.binX * (targetState.binSize / binSizeNew)
         const yBinNew = targetState.binY * (targetState.binSize / binSizeNew)
@@ -529,11 +570,20 @@ class State {
         }
     }
 
+    /**
+     * The sentinel rung never crosses the process boundary (ADR-0010 decision
+     * 6). A view sitting on it is written out as the whole-genome view --
+     * `chr1: 0, chr2: 0, zoom: 0` -- which for a single-chromosome assembly is
+     * pixel-for-pixel the same picture, is a wire value every existing consumer
+     * already renders, and is redirected straight back to the sentinel by
+     * `setView` on the way in.
+     */
     toJSON() {
+        const wholeGenome = SENTINEL_ZOOM === this.zoom;
         return {
-            chr1: this.chr1,
-            chr2: this.chr2,
-            zoom: this.zoom,
+            chr1: wholeGenome ? 0 : this.chr1,
+            chr2: wholeGenome ? 0 : this.chr2,
+            zoom: wholeGenome ? 0 : this.zoom,
             x: this.x,
             y: this.y,
             pixelSize: this.pixelSize,

--- a/js/hicState.js
+++ b/js/hicState.js
@@ -200,7 +200,7 @@ class State {
         // x, y and pixelSize carry over untouched: the whole-genome bin and the
         // sentinel bin are the same bin, offset zero (ADR-0010 fact 4).
         let redirected = false;
-        if (dataset && dataset.isSingleChromosome && dataset.isSingleChromosome() && dataset.isWholeGenome(chr1)) {
+        if (dataset && dataset.isSingleChromosome() && dataset.isWholeGenome(chr1)) {
             chr1 = chr2 = dataset.soleChromosome().index;
             zoom = SENTINEL_ZOOM;
             redirected = true;
@@ -355,6 +355,8 @@ class State {
         const zoomNew = (true === browser.resolutionLocked)
             ? this.zoom
             : browser.findMatchingZoomIndex(bpPerPixelTarget, bpResolutions)
+        // Off the browser rather than off a dataset, uniquely here: this is the
+        // one translator handed no dataset of its own.
         const binSizeNew = browser.binSizeForZoom(zoomNew)
 
         return await this.setView(
@@ -493,7 +495,7 @@ class State {
         // this browser can follow it to. Same reason as everywhere else: array
         // position and zoom index are not the same number.
         const zoomNew = browser.findMatchingZoomIndex(bpPerPixelTarget, browser.getResolutions())
-        const binSizeNew = browser.binSizeForZoom(zoomNew)
+        const binSizeNew = dataset.binSizeForZoom(zoomNew)
 
         const xBinNew = targetState.binX * (targetState.binSize / binSizeNew)
         const yBinNew = targetState.binY * (targetState.binSize / binSizeNew)
@@ -579,11 +581,14 @@ class State {
      * `setView` on the way in.
      */
     toJSON() {
-        const wholeGenome = SENTINEL_ZOOM === this.zoom;
+        // Named for where the state *is*, not for what it is written as. The
+        // sentinel is deliberately not a whole-genome view (decision 4); what
+        // decision 6 says is that it is written out as one.
+        const atSentinel = SENTINEL_ZOOM === this.zoom;
         return {
-            chr1: wholeGenome ? 0 : this.chr1,
-            chr2: wholeGenome ? 0 : this.chr2,
-            zoom: wholeGenome ? 0 : this.zoom,
+            chr1: atSentinel ? 0 : this.chr1,
+            chr2: atSentinel ? 0 : this.chr2,
+            zoom: atSentinel ? 0 : this.zoom,
             x: this.x,
             y: this.y,
             pixelSize: this.pixelSize,

--- a/js/imageTileCore.js
+++ b/js/imageTileCore.js
@@ -33,6 +33,8 @@
  * it can be exercised directly from tests. See CONTEXT.md.
  */
 
+import {SENTINEL_ZOOM} from "./sentinelZoom.js"
+
 /**
  * Cache key for a single image tile.
  *
@@ -109,6 +111,11 @@ function tileGrid(state, viewDimensions, tileDimension) {
  *         bin size is not present on the control map
  */
 function bZoomIndex(dataset, controlDataset, zoom) {
+
+    // The sentinel rung is synthesised identically on both maps: genomes must
+    // match, so both compute the same `wholeGenomeResolution`. There is no
+    // declared bin size to look up on either side. ADR-0010.
+    if (SENTINEL_ZOOM === zoom) return SENTINEL_ZOOM
 
     const binSize = dataset.getBinSizeForZoomIndex(zoom)
     if (!binSize) throw new Error(`Invalid zoom (resolution) index: ${zoom}`)

--- a/js/imageTileSource.js
+++ b/js/imageTileSource.js
@@ -166,13 +166,22 @@ class ImageTileSource {
         const {ds, dsControl, zoom, controlZoom} =
             resolveDisplayMode(dataset, controlDataset, state.zoom, displayMode)
 
-        const matrix = await ds.getMatrix(state.chr1, state.chr2)
-        const zd = matrix.getZoomDataByIndex(zoom, "BP")
+        // Which matrix carries the view, and at which of its resolutions. An
+        // identity for a declared rung; at the sentinel it is the whole-genome
+        // matrix, queried in the whole-genome matrix's own coordinates exactly
+        // as the `All` view queries it. That is what keeps `0 === zd.chr1.index`
+        // -- and so the x4 auto-threshold below -- true at the sentinel, while
+        // `browser.isWholeGenome()` is false. Divergent by design; see
+        // ADR-0010 decisions 3 and 4 before reconciling them.
+        const view = ds.matrixViewForZoom(state.chr1, state.chr2, zoom)
+        const matrix = await ds.getMatrix(view.chr1, view.chr2)
+        const zd = matrix.getZoomDataByIndex(view.zoomIndex, "BP")
 
         let zdControl = null
         if (dsControl) {
-            const matrixControl = await dsControl.getMatrix(state.chr1, state.chr2)
-            zdControl = matrixControl.getZoomDataByIndex(controlZoom, "BP")
+            const controlView = dsControl.matrixViewForZoom(state.chr1, state.chr2, controlZoom)
+            const matrixControl = await dsControl.getMatrix(controlView.chr1, controlView.chr2)
+            zdControl = matrixControl.getZoomDataByIndex(controlView.zoomIndex, "BP")
         }
 
         const {row1, row2, col1, col2} = tileGrid(state, viewDimensions, this.tileDimension)

--- a/js/interactionHandler.js
+++ b/js/interactionHandler.js
@@ -45,6 +45,19 @@ class InteractionHandler {
     }
 
     /**
+     * The rung carrying a zoom index, looked up by index rather than by array
+     * position.
+     *
+     * The two are not the same number. An A/B map's `getResolutions()` is a
+     * filtered list, and a single-chromosome assembly's carries a synthetic rung
+     * sorted to the coarse end (ADR-0010 decision 1). Position-indexing the list
+     * read the wrong rung in both cases.
+     */
+    _resolutionForZoom(resolutions, zoom) {
+        return resolutions.find(resolution => resolution.index === zoom);
+    }
+
+    /**
      * Validate that the dataset is available.
      * 
      * @returns {boolean} - True if dataset is valid, false otherwise
@@ -160,7 +173,15 @@ class InteractionHandler {
             this.browser.startSpinner();
 
             const bpResolutions = this.browser.getResolutions();
-            const currentResolution = bpResolutions[this.browser.state.zoom];
+            const currentResolution = this._resolutionForZoom(bpResolutions, this.browser.state.zoom);
+
+            // The list is sorted coarsest-first, so the finest rung is the last
+            // entry and the coarsest is the first. Both guards used to be written
+            // as the array positions those ends happen to have when index and
+            // position agree, which stopped being true once a rung could be
+            // filtered out or synthesised in. ADR-0010 decision 1.
+            const finest = bpResolutions[bpResolutions.length - 1];
+            const coarsest = bpResolutions[0];
 
             let newBinSize;
             let newZoom;
@@ -168,8 +189,8 @@ class InteractionHandler {
             let resolutionChanged;
 
             if (this.browser.resolutionLocked ||
-                (this.browser.state.zoom === bpResolutions.length - 1 && scaleFactor > 1) ||
-                (this.browser.state.zoom === 0 && scaleFactor < 1)) {
+                (this.browser.state.zoom === finest.index && scaleFactor > 1) ||
+                (this.browser.state.zoom === coarsest.index && scaleFactor < 1)) {
                 // Can't change resolution level, must adjust pixel size
                 newBinSize = currentResolution.binSize;
                 newPixelSize = Math.min(MAX_PIXEL_SIZE, this.browser.state.pixelSize * scaleFactor);
@@ -178,14 +199,19 @@ class InteractionHandler {
             } else {
                 const targetBinSize = (currentResolution.binSize / this.browser.state.pixelSize) / scaleFactor;
                 newZoom = this.findMatchingZoomIndex(targetBinSize, bpResolutions);
-                newBinSize = bpResolutions[newZoom].binSize;
+                newBinSize = this._resolutionForZoom(bpResolutions, newZoom).binSize;
                 resolutionChanged = newZoom !== this.browser.state.zoom;
                 newPixelSize = Math.min(MAX_PIXEL_SIZE, newBinSize / targetBinSize);
             }
 
             const z = await this.browser.minZoom(this.browser.state.chr1, this.browser.state.chr2);
 
-            if (!this.browser.resolutionLocked && scaleFactor < 1 && newZoom < z) {
+            // A single-chromosome assembly has no whole-genome view to fall out
+            // to: `All` is the sentinel rung of the scaffold now, and zooming
+            // past the last declared rung already lands there. ADR-0010.
+            const canLeaveForWholeGenome = !this.browser.dataset.isSingleChromosome();
+
+            if (canLeaveForWholeGenome && !this.browser.resolutionLocked && scaleFactor < 1 && newZoom < z) {
                 // Zoom out to whole genome
                 const xLocus = this.parseLocusString('1');
                 const yLocus = { xLocus };
@@ -194,8 +220,7 @@ class InteractionHandler {
                 await this.browser.state.panWithZoom(
                     newZoom, newPixelSize, anchorPx, anchorPy, newBinSize,
                     this.browser, this.browser.dataset,
-                    this.browser.contactMatrixView.getViewDimensions(),
-                    bpResolutions
+                    this.browser.contactMatrixView.getViewDimensions()
                 );
 
                 await this._applyStateChange({
@@ -280,7 +305,15 @@ class InteractionHandler {
             this.browser.startSpinner();
 
             const bpResolutions = this.browser.getResolutions();
-            const currentResolution = bpResolutions[this.browser.state.zoom];
+            const currentResolution = this._resolutionForZoom(bpResolutions, this.browser.state.zoom);
+
+            // The list is sorted coarsest-first, so the finest rung is the last
+            // entry and the coarsest is the first. Both guards used to be written
+            // as the array positions those ends happen to have when index and
+            // position agree, which stopped being true once a rung could be
+            // filtered out or synthesised in. ADR-0010 decision 1.
+            const finest = bpResolutions[bpResolutions.length - 1];
+            const coarsest = bpResolutions[0];
 
             let newBinSize;
             let newZoom;
@@ -288,8 +321,8 @@ class InteractionHandler {
             let resolutionChanged;
 
             if (this.browser.resolutionLocked ||
-                (this.browser.state.zoom === bpResolutions.length - 1 && scaleFactor > 1) ||
-                (this.browser.state.zoom === 0 && scaleFactor < 1)) {
+                (this.browser.state.zoom === finest.index && scaleFactor > 1) ||
+                (this.browser.state.zoom === coarsest.index && scaleFactor < 1)) {
                 // Can't change resolution level, must adjust pixel size
                 newBinSize = currentResolution.binSize;
                 newPixelSize = Math.min(MAX_PIXEL_SIZE, this.browser.state.pixelSize * scaleFactor);
@@ -298,14 +331,19 @@ class InteractionHandler {
             } else {
                 const targetBinSize = (currentResolution.binSize / this.browser.state.pixelSize) / scaleFactor;
                 newZoom = this.findMatchingZoomIndex(targetBinSize, bpResolutions);
-                newBinSize = bpResolutions[newZoom].binSize;
+                newBinSize = this._resolutionForZoom(bpResolutions, newZoom).binSize;
                 resolutionChanged = newZoom !== this.browser.state.zoom;
                 newPixelSize = Math.min(MAX_PIXEL_SIZE, newBinSize / targetBinSize);
             }
 
             const z = await this.browser.minZoom(this.browser.state.chr1, this.browser.state.chr2);
 
-            if (!this.browser.resolutionLocked && scaleFactor < 1 && newZoom < z) {
+            // A single-chromosome assembly has no whole-genome view to fall out
+            // to: `All` is the sentinel rung of the scaffold now, and zooming
+            // past the last declared rung already lands there. ADR-0010.
+            const canLeaveForWholeGenome = !this.browser.dataset.isSingleChromosome();
+
+            if (canLeaveForWholeGenome && !this.browser.resolutionLocked && scaleFactor < 1 && newZoom < z) {
                 // Zoom out to whole genome
                 const xLocus = this.parseLocusString('All');
                 const yLocus = { ...xLocus };
@@ -314,8 +352,7 @@ class InteractionHandler {
                 await this.browser.state.panWithZoom(
                     newZoom, newPixelSize, anchorPx, anchorPy, newBinSize,
                     this.browser, this.browser.dataset,
-                    this.browser.contactMatrixView.getViewDimensions(),
-                    bpResolutions
+                    this.browser.contactMatrixView.getViewDimensions()
                 );
 
                 await this._applyStateChange({
@@ -443,7 +480,10 @@ class InteractionHandler {
                 return index;
             }
         }
-        return 0;
+        // Nothing was coarse enough: fall back to the coarsest rung, which is
+        // the first entry. Its *index* is 0 only when index and array position
+        // agree -- they do not once the list carries a sentinel rung.
+        return isObject ? resolutionArray[0].index : 0;
     }
 
     /**

--- a/js/ruler.js
+++ b/js/ruler.js
@@ -246,9 +246,13 @@ class Ruler {
             { fillStyle: IGVColor.rgbColor(255, 255, 255) }
         );
 
-        config.bpPerPixel = browser.dataset.bpResolutions[browser.state.zoom] / browser.state.pixelSize;
+        // Scaffold coordinates at the sentinel rung, not whole-genome ones: the
+        // ruler follows the *state*, and the state is at the sole chromosome.
+        // ADR-0010 decision 4.
+        const bpPerBin = browser.binSizeForZoom(browser.state.zoom);
+        config.bpPerPixel = bpPerBin / browser.state.pixelSize;
         const bin = this.axis === 'x' ? browser.state.x : browser.state.y;
-        config.bpStart = bin * browser.dataset.bpResolutions[browser.state.zoom];
+        config.bpStart = bin * bpPerBin;
 
         config.rulerTickMarkReferencePixels = Math.max(
             this.canvasElement.width,

--- a/js/scrollbarWidget.js
+++ b/js/scrollbarWidget.js
@@ -66,7 +66,8 @@ class ScrollbarWidget {
 
             const { chr1, chr2, zoom, pixelSize, x, y } = state;
 
-            const chromosomeLengthsBin = [chr1, chr2].map(chr => dataset.chromosomes[chr].size / dataset.bpResolutions[zoom]);
+            const binSize = dataset.binSizeForZoom(zoom);
+            const chromosomeLengthsBin = [chr1, chr2].map(chr => dataset.chromosomes[chr].size / binSize);
             const chromosomeLengthsPixel = chromosomeLengthsBin.map(bin => bin * pixelSize);
             const { width, height } = this.browser.contactMatrixView.getViewDimensions();
             const pixels = [width, height];

--- a/js/scrollbarWidget.js
+++ b/js/scrollbarWidget.js
@@ -66,7 +66,7 @@ class ScrollbarWidget {
 
             const { chr1, chr2, zoom, pixelSize, x, y } = state;
 
-            const binSize = dataset.binSizeForZoom(zoom);
+            const binSize = this.browser.binSizeForZoom(zoom);
             const chromosomeLengthsBin = [chr1, chr2].map(chr => dataset.chromosomes[chr].size / binSize);
             const chromosomeLengthsPixel = chromosomeLengthsBin.map(bin => bin * pixelSize);
             const { width, height } = this.browser.contactMatrixView.getViewDimensions();

--- a/js/sentinelZoom.js
+++ b/js/sentinelZoom.js
@@ -1,0 +1,14 @@
+/**
+ * The zoom index of a resolution rung juicebox synthesises rather than reads out
+ * of the `.hic` file.
+ *
+ * Reserved so it can never collide with an index into `bpResolutions`, and never
+ * serialized -- `State.toJSON` writes the whole-genome view in its place. It has
+ * a module of its own, importing nothing, because `imageTileCore.js` needs it
+ * and is deliberately free of dataset and browser dependencies.
+ *
+ * See CONTEXT.md "Sentinel zoom" and ADR-0010.
+ */
+const SENTINEL_ZOOM = -1
+
+export {SENTINEL_ZOOM}

--- a/js/sweepZoom.js
+++ b/js/sweepZoom.js
@@ -53,8 +53,8 @@ class SweepZoom {
         this.rulerSweeperElement.style.display = 'none';
 
         const state = this.browser.state;
-        const { chromosomes, bpResolutions } = this.browser.dataset;
-        const bpResolution = bpResolutions[state.zoom];
+        const { chromosomes } = this.browser.dataset;
+        const bpResolution = this.browser.binSizeForZoom(state.zoom);
 
         // bp = ((bin + pixel/pixel-per-bin) / bp-per-bin)
         const xBP = (state.x + (xPixel / state.pixelSize)) * bpResolution

--- a/test/testImageTileCore.js
+++ b/test/testImageTileCore.js
@@ -171,6 +171,16 @@ describe('bZoomIndex', () => {
         expect(bZoomIndex(datasetWith(res), datasetWith(res), 1)).toBe(1)
     })
 
+    it('carries the sentinel rung through unchanged', () => {
+        // Both maps synthesise it from their own `wholeGenomeResolution`, and
+        // genomes must match, so there is nothing to look up on either side --
+        // and nothing for the "absent from the primary map" throw to catch.
+        // ADR-0010.
+        const a = datasetWith([1000000, 500000])
+        const b = datasetWith([500000, 100000])
+        expect(bZoomIndex(a, b, -1)).toBe(-1)
+    })
+
     it('throws when the zoom index is absent from the primary map', () => {
         const a = datasetWith([1000000])
         const b = datasetWith([1000000])

--- a/test/testImageTileSource.js
+++ b/test/testImageTileSource.js
@@ -64,6 +64,9 @@ const dataset = ({
         getZoomIndexForBinSize: (b) => resolutions.indexOf(b),
         hasNormalizationVector: (norm) => normalizations.includes(norm),
         getMatrix: async () => ({getZoomDataByIndex: () => zd}),
+        // A declared rung is an identity here; the sentinel path has its own
+        // suite. See ADR-0010.
+        matrixViewForZoom: (chr1, chr2, zoom) => ({chr1, chr2, zoomIndex: zoom}),
         getContactRecords: async (norm, r1, r2, unit, binSize, forScale) => {
             calls.push({norm, r1, r2, unit, binSize, forScale: !!forScale})
             return records
@@ -162,6 +165,33 @@ describe('ImageTileSource.tilesFor', () => {
         const origin = tiles.find(t => t.row === 0 && t.column === 0)
         const i = (3 + 4 * TILE) * 4
         expect([origin.image.buf.data[i], origin.image.buf.data[i + 3]]).toEqual([99, 255])
+    })
+
+    it('reads the whole-genome matrix at the sentinel rung', async () => {
+        // ADR-0010 decision 3. The rung is synthesised, but the data behind it
+        // is the `All` matrix -- queried in the `All` matrix's own coordinates,
+        // exactly as the whole-genome view queries it today. The source asks the
+        // dataset which matrix carries the view rather than assuming the state's
+        // chromosomes do.
+        const asked = []
+        const wholeGenomeZd = zoomData({binSize: 4800, chr1Index: 0, chr2Index: 0})
+        const ds = {
+            ...dataset(),
+            matrixViewForZoom: (chr1, chr2, zoom) =>
+                -1 === zoom ? {chr1: 0, chr2: 0, zoomIndex: 0} : {chr1, chr2, zoomIndex: zoom},
+            getMatrix: async (chr1, chr2) => {
+                asked.push([chr1, chr2])
+                return {getZoomDataByIndex: () => wholeGenomeZd}
+            }
+        }
+
+        const tiles = await collect(makeSource().tilesFor(request({
+            dataset: ds,
+            state: {chr1: 1, chr2: 1, zoom: -1, x: 0, y: 0, pixelSize: 1, normalization: 'NONE'}
+        })))
+
+        expect(asked).toEqual([[0, 0]])
+        expect(tiles.every(t => t.binSize === 4800)).toBe(true)
     })
 
     it('does not request a raster context when there are no records', async () => {

--- a/test/testRender2DTracks.js
+++ b/test/testRender2DTracks.js
@@ -104,7 +104,12 @@ function createView({ chr1, chr2, features, displayMode }) {
         strokeRect: (x, y, w, h) => strokeRects.push({ x, y, w, h }),
     }
 
-    const dataset = { chromosomes, getMatrix: async () => ({ getZoomDataByIndex: () => zoomData }) }
+    const dataset = {
+        chromosomes,
+        getMatrix: async () => ({ getZoomDataByIndex: () => zoomData }),
+        // An identity at a declared rung. The sentinel rung has its own suite.
+        matrixViewForZoom: (chr1, chr2, zoom) => ({ chr1, chr2, zoomIndex: zoom }),
+    }
     const state = { chr1, chr2, zoom: 0, x: 0, y: 0, pixelSize: PIXEL_SIZE }
 
     const track2D = {

--- a/test/testSingleChromosomeAll.js
+++ b/test/testSingleChromosomeAll.js
@@ -1,0 +1,211 @@
+/**
+ * `All` is a zoom rung, not a chromosome -- #236, ADR-0010.
+ *
+ * The five claims the ADR's test plan names, driven end to end through a real
+ * browser and a real `loadHicFile`: the pulldown omits `All`, a saved session
+ * naming `chr 0` lands on the scaffold, the sentinel rung frames the whole
+ * scaffold, the sentinel round-trips through save as the whole-genome view, and
+ * -- the regression that matters -- a multi-chromosome dataset is provably
+ * unchanged. Everything here is gated on a predicate that must stay false for
+ * every real genome, so the last one is not a formality.
+ *
+ * Two datasets, told apart by URL, so the changed and unchanged cases run on the
+ * same harness and the same stubs. Both come from
+ * `test/utils/restoreDataset.js`, whose single-chromosome variant is faithful
+ * about the one thing this ticket's arithmetic turns on: the `All` entry's size
+ * is in kb and `wholeGenomeResolution` is that same bin in bp.
+ *
+ * The viewport is `restoreFixture`'s stated 800x800 -- JSDOM does no layout, so
+ * a measured one is {0, 0} and every framing claim below would be vacuous.
+ */
+import {describe, expect, test, vi} from 'vitest'
+import State from '../js/hicState.js'
+import {SENTINEL_ZOOM} from '../js/sentinelZoom.js'
+import {restoreFixture, VIEWPORT} from './utils/restoreFixture.js'
+
+vi.mock('../js/hicDataset.js', async () => {
+    const {restoreDataset, singleChromosomeDataset, datasetModule} = await import('./utils/restoreDataset.js')
+    return datasetModule(config =>
+        String(config.url).includes('single') ? singleChromosomeDataset(config) : restoreDataset(config))
+})
+
+const {default: HICBrowser} = await import('../js/hicBrowser.js')
+
+const SINGLE_URL = 'https://example.org/single-chromosome.hic'
+const MULTI_URL = 'https://example.org/multi-chromosome.hic'
+
+/** The sole scaffold's index in the single-chromosome table, and its size. */
+const SCAFFOLD = 1
+const SCAFFOLD_SIZE = 2400000000
+
+/** Five hundred bins across the scaffold -- `wholeGenomeResolution` by construction. */
+const WHOLE_GENOME_BINS = 500
+
+/** The whole-genome view as every saved session and pasted URL spells it. */
+const wholeGenomeState = () => State.fromJSON({chr1: 0, chr2: 0, zoom: 0, x: 0, y: 0, pixelSize: 1})
+
+const {embed} = restoreFixture(HICBrowser, {suite: 'single-chromosome', url: SINGLE_URL})
+
+/** One embed, one load. `state` is optional -- omitted, the default view is taken. */
+async function load(url, state) {
+    const browser = embed()
+    await browser.loadHicFile(state ? {url, state} : {url}, true)
+    return browser
+}
+
+const optionValues = select => Array.from(select.options).map(option => option.value)
+
+describe('a single-chromosome assembly', () => {
+
+    test('drops All from the chromosome pulldown', async () => {
+        const browser = await load(SINGLE_URL)
+        const {xAxisSelector, yAxisSelector} = browser.coordinator.widgets.chromosomeSelector
+
+        expect(Array.from(xAxisSelector.options).map(o => o.textContent)).toEqual(['scaffold_1'])
+        expect(optionValues(xAxisSelector)).toEqual([String(SCAFFOLD)])
+        expect(optionValues(yAxisSelector)).toEqual([String(SCAFFOLD)])
+    })
+
+    test('offers the whole-genome resolution as the coarsest rung', async () => {
+        const browser = await load(SINGLE_URL)
+        const resolutions = browser.getResolutions()
+
+        // Coarsest first, and the coarsest is the synthetic one. Sorted by bin
+        // size rather than by position, which is what keeps the direction guards
+        // in `interactionHandler` reading the right ends.
+        expect(resolutions[0]).toEqual({index: SENTINEL_ZOOM, binSize: browser.dataset.wholeGenomeResolution})
+        expect(resolutions.map(r => r.binSize)).toEqual([...resolutions.map(r => r.binSize)].sort((a, b) => b - a))
+        expect(resolutions.filter(r => r.index === SENTINEL_ZOOM)).toHaveLength(1)
+    })
+
+    test('lands a session naming chr 0 on the scaffold, at the sentinel rung', async () => {
+        const browser = await load(SINGLE_URL, wholeGenomeState())
+
+        expect(browser.state.chr1).toBe(SCAFFOLD)
+        expect(browser.state.chr2).toBe(SCAFFOLD)
+        expect(browser.state.zoom).toBe(SENTINEL_ZOOM)
+        expect(browser.isWholeGenome()).toBe(false)
+    })
+
+    test('frames the whole scaffold at the sentinel rung', async () => {
+        const browser = await load(SINGLE_URL, wholeGenomeState())
+        const {x, y, pixelSize} = browser.state
+
+        // The scaffold is 500 sentinel bins wide, and the view is 800px, so one
+        // bin is 1.6px and the whole thing is on screen from the origin. At the
+        // coarsest *declared* bin -- 2.5mb -- it would need 3mb/px and could not
+        // be framed at all, which is fact 3 of the ADR and the whole reason the
+        // rung exists.
+        expect(x).toBe(0)
+        expect(y).toBe(0)
+        expect(pixelSize).toBeCloseTo(VIEWPORT.width / WHOLE_GENOME_BINS, 10)
+        expect(pixelSize * WHOLE_GENOME_BINS).toBeCloseTo(VIEWPORT.width, 10)
+
+        const locus = browser.state.getLocus(browser.dataset, VIEWPORT)
+        expect(locus.x).toEqual({chr: 'scaffold_1', start: 0, end: SCAFFOLD_SIZE})
+    })
+
+    test('falls through to the sentinel when no declared bin can frame the scaffold', async () => {
+        const browser = await load(SINGLE_URL)
+        expect(await browser.minZoom(SCAFFOLD, SCAFFOLD)).toBe(SENTINEL_ZOOM)
+    })
+
+    test('redirects the locus box typing "All" to the scaffold', async () => {
+        // Fact 2 of the ADR: filtering the pulldown alone would leave `All`
+        // reachable by three other paths, of which the locus box is one. The
+        // redirect is at the state layer for exactly this reason.
+        const browser = await load(SINGLE_URL)
+        await browser.parseGotoInput('All')
+
+        expect(browser.state.chr1).toBe(SCAFFOLD)
+        expect(browser.state.chr2).toBe(SCAFFOLD)
+        expect(browser.state.zoom).toBe(SENTINEL_ZOOM)
+
+        // And the locus box shows a real range back, not the word "All":
+        // the vocabulary follows the state (decision 4).
+        browser.coordinator.widgets.locusGoto.updateForState(browser.state)
+        expect(browser.coordinator.widgets.locusGoto.resolutionSelectorElement.value)
+            .toMatch(/^scaffold_1:/)
+    })
+
+    test('writes the sentinel out as the whole-genome view, and reads it back', async () => {
+        const browser = await load(SINGLE_URL, wholeGenomeState())
+        expect(browser.state.zoom).toBe(SENTINEL_ZOOM)
+
+        // Decision 6: the sentinel never crosses the process boundary. What is
+        // saved is a wire value every existing consumer already renders -- and
+        // for this genome it is pixel-for-pixel the same picture.
+        const saved = browser.state.toJSON()
+        expect(saved).toMatchObject({chr1: 0, chr2: 0, zoom: 0})
+
+        const reopened = await load(SINGLE_URL, State.fromJSON(saved))
+        expect(reopened.state.chr1).toBe(SCAFFOLD)
+        expect(reopened.state.zoom).toBe(SENTINEL_ZOOM)
+        expect(reopened.state.pixelSize).toBeCloseTo(browser.state.pixelSize, 10)
+    })
+
+    test('leaves a declared rung serialized as itself', async () => {
+        const browser = await load(SINGLE_URL, State.fromJSON({chr1: 1, chr2: 1, zoom: 4, x: 10, y: 20, pixelSize: 2}))
+        expect(browser.state.zoom).toBe(4)
+        expect(browser.state.toJSON()).toMatchObject({chr1: 1, chr2: 1, zoom: 4})
+    })
+})
+
+describe('a multi-chromosome assembly is unchanged', () => {
+
+    test('keeps All in the chromosome pulldown', async () => {
+        const browser = await load(MULTI_URL)
+        const {xAxisSelector} = browser.coordinator.widgets.chromosomeSelector
+
+        expect(Array.from(xAxisSelector.options).map(o => o.textContent)[0]).toBe('All')
+        expect(xAxisSelector.options).toHaveLength(browser.dataset.chromosomes.length)
+    })
+
+    test('offers only the declared resolutions, still coarsest first', async () => {
+        const browser = await load(MULTI_URL)
+        expect(browser.getResolutions()).toEqual(
+            browser.dataset.bpResolutions.map((binSize, index) => ({index, binSize})))
+    })
+
+    test('keeps a session naming chr 0 in the whole-genome view', async () => {
+        const browser = await load(MULTI_URL, wholeGenomeState())
+
+        expect(browser.state.chr1).toBe(0)
+        expect(browser.state.chr2).toBe(0)
+        expect(browser.state.zoom).toBe(0)
+        expect(browser.isWholeGenome()).toBe(true)
+    })
+
+    test('never answers the sentinel from minZoom', async () => {
+        const browser = await load(MULTI_URL)
+        // chr1, hg19 -- 249mb over an 800px viewport wants 311kb bins, and the
+        // declared ladder has 500kb. Nothing falls through.
+        expect(await browser.minZoom(1, 1)).toBeGreaterThanOrEqual(0)
+    })
+})
+
+describe('rung lookup by index rather than by array position', () => {
+
+    test('answers the sentinel when nothing declared is coarse enough', async () => {
+        const browser = await load(SINGLE_URL)
+        const resolutions = browser.getResolutions()
+
+        // A target coarser than every rung falls back to the coarsest, which is
+        // the first entry. Reading its *position* rather than its index -- what
+        // the fallback used to do -- would answer 0, the 2.5mb declared rung.
+        expect(browser.findMatchingZoomIndex(Number.MAX_SAFE_INTEGER, resolutions)).toBe(SENTINEL_ZOOM)
+        expect(resolutions[0].index).toBe(SENTINEL_ZOOM)
+    })
+
+    test('selects the sentinel option in the resolution pulldown', async () => {
+        const browser = await load(SINGLE_URL, wholeGenomeState())
+        const {resolutionSelectorElement} = browser.coordinator.widgets.resolutionSelector
+
+        browser.coordinator.widgets.resolutionSelector.setSelectedResolution(SENTINEL_ZOOM)
+        const selected = Array.from(resolutionSelectorElement.options).filter(o => o.selected)
+
+        // The sentinel's option sits at position 0 and carries value "-1".
+        // Selecting by position would have needed index -1 to be a position.
+        expect(selected.map(o => o.value)).toEqual([String(SENTINEL_ZOOM)])
+    })
+})

--- a/test/testSingleChromosomeAll.js
+++ b/test/testSingleChromosomeAll.js
@@ -184,6 +184,56 @@ describe('a multi-chromosome assembly is unchanged', () => {
     })
 })
 
+describe('an A/B map', () => {
+
+    test('falls through to the sentinel on the coarsest rung the two maps share', async () => {
+        // Sized so the two answers differ. Over a 2400px viewport the scaffold
+        // wants 1mb bins: the primary map's own coarsest is 2.5mb and would say
+        // "coarse enough", but 2.5mb is not a rung this browser can render at
+        // all once the control map's ladder starts at 500kb. Asking the raw
+        // ladder floors the fit at a bin no pass will ever use.
+        const browser = await load(SINGLE_URL)
+        vi.spyOn(browser.contactMatrixView, 'getViewDimensions').mockReturnValue({width: 2400, height: 2400})
+
+        expect(await browser.minZoom(SCAFFOLD, SCAFFOLD)).toBeGreaterThanOrEqual(0)
+
+        browser.controlDataset = {bpResolutions: browser.dataset.bpResolutions.slice(2)}
+        expect(browser.getResolutions().filter(r => r.index !== SENTINEL_ZOOM)[0].binSize).toBe(500000)
+        expect(await browser.minZoom(SCAFFOLD, SCAFFOLD)).toBe(SENTINEL_ZOOM)
+    })
+})
+
+describe('cross-browser sync', () => {
+
+    test('is unchanged for a browser with no control map', async () => {
+        // `State.sync` now matches against `getResolutions()` rather than the
+        // raw ladder, so that a peer sitting at the sentinel is a rung this
+        // browser can follow it to. For a single-map browser the two lists carry
+        // the same bin sizes, so the rung chosen is the rung it always was.
+        const browser = await load(MULTI_URL, State.fromJSON({chr1: 1, chr2: 1, zoom: 3, x: 0, y: 0, pixelSize: 2}))
+        const offered = browser.getResolutions().map(r => r.binSize)
+
+        expect(offered).toEqual(browser.dataset.bpResolutions)
+        expect(browser.getResolutions().every(r => r.index === offered.indexOf(r.binSize))).toBe(true)
+    })
+
+    test('hands a peer the sentinel bin size, and takes it back', async () => {
+        const browser = await load(SINGLE_URL, wholeGenomeState())
+        const sync = browser.state.getSyncState(browser.dataset)
+
+        // Named by the scaffold, sized by the sentinel bin -- so a peer over the
+        // same assembly resolves it back to the sentinel rather than to the
+        // coarsest declared one.
+        expect(sync.chr1Name).toBe('scaffold_1')
+        expect(sync.binSize).toBe(browser.dataset.wholeGenomeResolution)
+
+        const peer = await load(SINGLE_URL)
+        await peer.state.sync(sync, peer, peer.genome, peer.dataset)
+        expect(peer.state.zoom).toBe(SENTINEL_ZOOM)
+        expect(peer.state.chr1).toBe(SCAFFOLD)
+    })
+})
+
 describe('rung lookup by index rather than by array position', () => {
 
     test('answers the sentinel when nothing declared is coarse enough', async () => {

--- a/test/testSingleChromosomeDataset.js
+++ b/test/testSingleChromosomeDataset.js
@@ -1,0 +1,123 @@
+/**
+ * The predicate and the two accessors ADR-0010 rests on, asserted against the
+ * real `Dataset` rather than a stand-in.
+ *
+ * Everything else in the ticket is gated on `isSingleChromosome()`, so what
+ * matters most here is the negative: it must stay false for every real genome.
+ * A predicate that creeps true is not a bug that shows up as a broken
+ * single-scaffold view -- it shows up as hg19 losing its whole-genome
+ * chromosome, which is why the "dominates" reading was rejected outright.
+ */
+import {describe, expect, test} from 'vitest'
+import Dataset from '../js/hicDataset.js'
+import {SENTINEL_ZOOM} from '../js/sentinelZoom.js'
+
+/**
+ * A `Dataset` carrying the four fields `init()` reads off the file, and nothing
+ * else. Subclassed rather than faked so the methods under test are the shipped
+ * ones.
+ */
+class StandIn extends Dataset {
+    constructor(chromosomes, {bpResolutions = [2500000, 500000], wholeGenomeResolution} = {}) {
+        super({name: 'stand-in'})
+        this.chromosomes = chromosomes
+        this.bpResolutions = bpResolutions
+        this.wholeGenomeChromosome = chromosomes.find(chr => 'All' === chr.name)
+        this.wholeGenomeResolution = wholeGenomeResolution
+    }
+}
+
+const all = {index: 0, name: 'All', size: 2400000}
+const scaffold = {index: 1, name: 'scaffold_1', size: 2400000000}
+
+/** `All` plus one real scaffold -- the assembly #236 is about. */
+const single = () => new StandIn([all, scaffold], {wholeGenomeResolution: 4800000})
+
+/** `All` plus three, standing for every real genome. */
+const multi = () => new StandIn([
+    all,
+    {index: 1, name: 'chr1', size: 249250621},
+    {index: 2, name: 'chr2', size: 243199373},
+    {index: 3, name: 'chr3', size: 198022430},
+], {wholeGenomeResolution: 6000000})
+
+describe('isSingleChromosome', () => {
+
+    test('is true for the All entry plus exactly one real chromosome', () => {
+        expect(single().isSingleChromosome()).toBe(true)
+    })
+
+    test('is false for a multi-chromosome genome', () => {
+        expect(multi().isSingleChromosome()).toBe(false)
+    })
+
+    test('is false for a two-entry table with no whole-genome chromosome', () => {
+        // Two entries is the arithmetic; `All` being one of them is the claim.
+        // A file declaring two real scaffolds and no `All` is not this case, and
+        // has no whole-genome matrix to synthesise a rung from.
+        const noAll = new StandIn([
+            {index: 0, name: 'scaffold_1', size: 1000},
+            {index: 1, name: 'scaffold_2', size: 2000},
+        ])
+        expect(noAll.isSingleChromosome()).toBe(false)
+    })
+
+    test('identifies All by whole-genome identity, not by name', () => {
+        // A scaffold that happens to be named "all" is still a scaffold. The
+        // name test `genome.js` and `ruler.js` use would take this one.
+        const named = new StandIn([
+            {index: 0, name: 'all', size: 1000},
+            {index: 1, name: 'chr1', size: 2000},
+        ])
+        expect(named.isSingleChromosome()).toBe(false)
+    })
+})
+
+describe('soleChromosome', () => {
+
+    test('is the one entry that is not the whole-genome chromosome', () => {
+        expect(single().soleChromosome()).toBe(scaffold)
+    })
+
+    test('is undefined for a multi-chromosome genome', () => {
+        expect(multi().soleChromosome()).toBeUndefined()
+    })
+})
+
+describe('binSizeForZoom', () => {
+
+    test('reads the declared ladder at a declared rung', () => {
+        expect(single().binSizeForZoom(1)).toBe(500000)
+    })
+
+    test('answers the whole-genome resolution at the sentinel', () => {
+        // In bp, not in the kb the whole-genome matrix states its own
+        // coordinates in -- ADR-0010 fact 4, and the reason the sentinel bin
+        // divides the scaffold's bp exactly.
+        expect(single().binSizeForZoom(SENTINEL_ZOOM)).toBe(4800000)
+        expect(scaffold.size / single().binSizeForZoom(SENTINEL_ZOOM)).toBe(500)
+    })
+})
+
+describe('matrixViewForZoom', () => {
+
+    test('is the identity at a declared rung', () => {
+        expect(single().matrixViewForZoom(1, 1, 3)).toEqual({chr1: 1, chr2: 1, zoomIndex: 3})
+    })
+
+    test('answers the whole-genome matrix at its only resolution at the sentinel', () => {
+        expect(single().matrixViewForZoom(1, 1, SENTINEL_ZOOM))
+            .toEqual({chr1: 0, chr2: 0, zoomIndex: 0})
+    })
+
+    test('the two whole-genome tests diverge at the sentinel, by design', () => {
+        // ADR-0010 decisions 3 and 4. The data test -- what the tile source
+        // reads as `0 === zd.chr1.index` -- is true, because the rung is served
+        // from the whole-genome matrix. The vocabulary test, which reads the
+        // state's chromosome, is false. Reconciling them is the "fix" the ADR
+        // exists to warn off.
+        const dataset = single()
+        expect(dataset.matrixViewForZoom(1, 1, SENTINEL_ZOOM).chr1).toBe(0)
+        expect(dataset.isWholeGenome(1)).toBe(false)
+    })
+})

--- a/test/testState.js
+++ b/test/testState.js
@@ -41,6 +41,7 @@ export function createMockBrowser(overrides = {}) {
         resolutionLocked: overrides.resolutionLocked ?? false,
         minPixelSize: overrides.minPixelSize ?? (async () => 1),
         getResolutions: overrides.getResolutions ?? (() => resolutions),
+        binSizeForZoom: overrides.binSizeForZoom ?? (zoom => binSizes[zoom]),
         // Mirrors the real interactionHandler.findMatchingZoomIndex, which accepts
         // both shapes: an array of {binSize, index} objects (browser.getResolutions())
         // and a flat array of numbers (dataset.bpResolutions). State.sync passes the
@@ -52,7 +53,7 @@ export function createMockBrowser(overrides = {}) {
                 const index = isObject ? res[z].index : z
                 if (binSize >= targetResolution) return index
             }
-            return 0
+            return isObject ? res[0].index : 0
         }),
         genome: overrides.genome ?? {
             getChromosome: (name) => chromosomes.find(c => c.name === name)
@@ -64,9 +65,20 @@ export function createMockBrowser(overrides = {}) {
 }
 
 export function createMockDataset(overrides = {}) {
+    const chromosomes = overrides.chromosomes ?? DEFAULT_CHROMOSOMES
+    const binSizes = overrides.bpResolutions ?? DEFAULT_BIN_SIZES
     return {
-        chromosomes: overrides.chromosomes ?? DEFAULT_CHROMOSOMES,
-        bpResolutions: overrides.bpResolutions ?? DEFAULT_BIN_SIZES,
+        chromosomes,
+        bpResolutions: binSizes,
+        // ADR-0010's four. The default table is a whole genome, so the predicate
+        // is false and `binSizeForZoom` is a plain array read -- which is what
+        // every claim in this file is made against.
+        wholeGenomeChromosome: chromosomes[0],
+        isWholeGenome: overrides.isWholeGenome ?? (chrIndex => 0 === chrIndex),
+        isSingleChromosome: overrides.isSingleChromosome ?? (() => 2 === chromosomes.length),
+        soleChromosome: () => chromosomes[1],
+        binSizeForZoom: overrides.binSizeForZoom ?? (zoom => binSizes[zoom]),
+        matrixViewForZoom: (chr1, chr2, zoom) => ({chr1, chr2, zoomIndex: zoom}),
     }
 }
 
@@ -452,7 +464,7 @@ describe('State.panWithZoom', () => {
         // Zoom to zoom=4 (binSize=100000) at pixelSize=8.
         const newZoom = 4
         const newBinSize = bpResolutions[newZoom].binSize
-        await state.panWithZoom(newZoom, 8, anchorPx, anchorPy, newBinSize, browser, dataset, DEFAULT_VIEW_DIMENSIONS, bpResolutions)
+        await state.panWithZoom(newZoom, 8, anchorPx, anchorPy, newBinSize, browser, dataset, DEFAULT_VIEW_DIMENSIONS)
 
         const gxAfter = (state.x + anchorPx / state.pixelSize) * newBinSize
         const gyAfter = (state.y + anchorPy / state.pixelSize) * newBinSize
@@ -467,7 +479,7 @@ describe('State.panWithZoom', () => {
         const bpResolutions = browser.getResolutions()
         const state = createState({ chr1: 1, chr2: 2, zoom: 3, x: 200, y: 200, pixelSize: 4 })
 
-        await state.panWithZoom(4, 8, 400, 400, bpResolutions[4].binSize, browser, dataset, DEFAULT_VIEW_DIMENSIONS, bpResolutions)
+        await state.panWithZoom(4, 8, 400, 400, bpResolutions[4].binSize, browser, dataset, DEFAULT_VIEW_DIMENSIONS)
 
         expect(state.zoom).toBe(4)
         expect(state.pixelSize).toBe(8) // 8 > min (1), 8 < MAX_PIXEL_SIZE (128)
@@ -479,7 +491,7 @@ describe('State.panWithZoom', () => {
         const bpResolutions = browser.getResolutions()
         const state = createState({ chr1: 1, chr2: 2, zoom: 3, x: 200, y: 200, pixelSize: 4 })
 
-        await state.panWithZoom(4, 8, 400, 400, bpResolutions[4].binSize, browser, dataset, DEFAULT_VIEW_DIMENSIONS, bpResolutions)
+        await state.panWithZoom(4, 8, 400, 400, bpResolutions[4].binSize, browser, dataset, DEFAULT_VIEW_DIMENSIONS)
 
         // Under the field-based design panWithZoom left state.locus stale until
         // interactionHandler called configureLocus separately. With getLocus the
@@ -498,7 +510,7 @@ describe('State.panWithZoom', () => {
         // Start near origin so the anchor preservation math would push x negative.
         const state = createState({ chr1: 1, chr2: 2, zoom: 3, x: 0, y: 0, pixelSize: 4 })
 
-        await state.panWithZoom(4, 8, 400, 400, bpResolutions[4].binSize, browser, dataset, DEFAULT_VIEW_DIMENSIONS, bpResolutions)
+        await state.panWithZoom(4, 8, 400, 400, bpResolutions[4].binSize, browser, dataset, DEFAULT_VIEW_DIMENSIONS)
 
         expect(state.x).toBeGreaterThanOrEqual(0)
         expect(state.y).toBeGreaterThanOrEqual(0)
@@ -512,7 +524,7 @@ describe('State.panWithZoom', () => {
         const bpResolutions = browser.getResolutions()
         const state = createState({ chr1: 1, chr2: 2, zoom: 3, x: 200, y: 200, pixelSize: 4 })
 
-        await state.panWithZoom(4, 2, 400, 400, bpResolutions[4].binSize, browser, dataset, DEFAULT_VIEW_DIMENSIONS, bpResolutions)
+        await state.panWithZoom(4, 2, 400, 400, bpResolutions[4].binSize, browser, dataset, DEFAULT_VIEW_DIMENSIONS)
 
         expect(state.pixelSize).toBe(5)
     })

--- a/test/utils/restoreDataset.js
+++ b/test/utils/restoreDataset.js
@@ -45,6 +45,27 @@ function chromosomes() {
 }
 
 /**
+ * The single-chromosome assembly ADR-0010 is about: the `All` entry plus one
+ * real scaffold, 2.4 Gbp -- the size #398 reports, and the size at which no
+ * declared bin can frame the thing.
+ *
+ * Two numbers here are faithful to the format in a way the hg19 stand-in above
+ * is not, because ADR-0010's arithmetic reads them:
+ *
+ * - the `All` entry's `size` is in **kb** (`hic-straw/src/hicFile.js:141`), so
+ *   it is the genome length over 1000.
+ * - `wholeGenomeResolution` is that same bin expressed in **bp**: `size * 2`,
+ *   which is the genome length over 500. Five hundred bins across the scaffold.
+ */
+const SOLE_SCAFFOLD_SIZE = 2400000000
+
+function singleChromosomes() {
+    const scaffold = {index: 1, name: 'scaffold_1', size: SOLE_SCAFFOLD_SIZE}
+    const wholeGenome = {index: 0, name: 'All', size: SOLE_SCAFFOLD_SIZE / 1000}
+    return [wholeGenome, scaffold]
+}
+
+/**
  * The zoom record `minPixelSize` and `minZoom` read. `findZoomForResolution`
  * mirrors `browser.findMatchingZoomIndex`: the finest index whose bin is still
  * no smaller than the target, floored at the whole-genome resolution.
@@ -69,8 +90,44 @@ function matrix() {
  *   dataset can echo the identity `loadHicFile` then reads back off it.
  */
 export function restoreDataset(config = {}) {
+    return buildDataset(chromosomes(), config)
+}
 
-    const chrs = chromosomes()
+/**
+ * The same stand-in over a one-scaffold assembly (#236, ADR-0010). Everything
+ * the sentinel path reads is real here: the predicate answers true, the
+ * whole-genome matrix answers at its own single resolution, and
+ * `wholeGenomeResolution` is the bp bin the sentinel rung carries.
+ */
+export function singleChromosomeDataset(config = {}) {
+    const chrs = singleChromosomes()
+    return {
+        ...buildDataset(chrs, config),
+        genomeId: config.genomeId || 'sole-scaffold',
+        wholeGenomeResolution: chrs[0].size * 2,
+        // The whole-genome matrix carries exactly one BP resolution, stated in
+        // the kb its own coordinates are in -- `wholeGenomeResolution / 1000`.
+        async getMatrix(chr1, chr2) {
+            if (0 === chr1 && 0 === chr2) return wholeGenomeMatrix(chrs[0].size * 2 / 1000)
+            return matrix()
+        },
+    }
+}
+
+function wholeGenomeMatrix(binSize) {
+    return {
+        getZoomDataByIndex(index, unit) {
+            return 0 === index
+                ? {zoom: {index, unit: unit || 'BP', binSize}, chr1: {index: 0, name: 'All'}, chr2: {index: 0, name: 'All'}}
+                : undefined
+        },
+        findZoomForResolution() {
+            return 0
+        },
+    }
+}
+
+function buildDataset(chrs, config) {
 
     return {
         url: config.url,
@@ -85,8 +142,23 @@ export function restoreDataset(config = {}) {
         isCompatible(other) {
             return other?.genomeId === this.genomeId
         },
+        wholeGenomeChromosome: chrs[0],
         isWholeGenome(chrIndex) {
             return chrIndex === 0
+        },
+        // The four ADR-0010 methods, implemented rather than stubbed, so a
+        // fixture over a different chromosome table answers honestly.
+        isSingleChromosome() {
+            return 2 === chrs.length
+        },
+        soleChromosome() {
+            return 2 === chrs.length ? chrs[1] : undefined
+        },
+        binSizeForZoom(zoom) {
+            return -1 === zoom ? this.wholeGenomeResolution : BP_RESOLUTIONS[zoom]
+        },
+        matrixViewForZoom(chr1, chr2, zoom) {
+            return -1 === zoom ? {chr1: 0, chr2: 0, zoomIndex: 0} : {chr1, chr2, zoomIndex: zoom}
         },
         getChrIndexFromName(name) {
             const found = chrs.find(c => c.name.toLowerCase() === String(name).toLowerCase())


### PR DESCRIPTION
Closes #236. Implements ADR-0010 (`docs/adr/0010-all-is-a-zoom-rung-not-a-chromosome.md`).

On a dataset whose chromosome table is the `All` entry plus one real chromosome, `All` stops being a chromosome the user can pick and becomes the sole scaffold's coarsest zoom rung. It survives as *data* and as *wire format*; what disappears is the vocabulary.

## What landed

- **`Dataset.isSingleChromosome()` / `soleChromosome()`** — the predicate, on `wholeGenomeChromosome` identity rather than the name test `genome.js` and `ruler.js` use.
- **`SENTINEL_ZOOM = -1`**, in `js/sentinelZoom.js` — its own module so `imageTileCore.js` can have it without a dataset dependency. `getResolutions()` appends the synthetic rung *after* the A/B intersection and sorts by descending bin size, which also fixes `interactionHandler`'s direction guards.
- **`dataset.binSizeForZoom()` / `browser.binSizeForZoom()`** — the landing pad for #398. Only sites the sentinel path reaches are converted; seven direct-index sites remain.
- **`dataset.matrixViewForZoom()`** resolves a view to the matrix carrying its data. At the sentinel that is the whole-genome matrix, so `0 === zd.chr1.index` stays true while `browser.isWholeGenome()` is false — **divergent by design** (decisions 3 and 4). Do not reconcile them without reading the ADR.
- **One redirect, at `State.setView`** — pulldown, locus box, session and URL all funnel through it, silently, coercing rather than rejecting (ADR-0009). `State.toJSON` writes the sentinel back out as `chr1: 0, chr2: 0, zoom: 0`, so nothing crosses the process boundary and **no juicebox-web or Spacewalk coordination is needed**.

## Beyond the ticket

Several lookups indexed a resolution *array position* by a zoom *index*. Those were already wrong for an A/B map, whose list is filtered — fixed here rather than left to break on the sentinel. `State.panWithZoom` loses its trailing `bpResolutions` parameter as a result; `docs/state-manipulation.md` is updated.

ADR-0010 gains an amendments section recording three things the decision did not anticipate: the real width of decision 2's blast radius (13 conversions, not the 5 budgeted), 2D annotations drawing nothing at the sentinel, and why `State.sync` had to be told about the rung.

## Tests

1028 passing, up from 998. Two new suites — `testSingleChromosomeDataset.js` (the predicate and accessors, against the real `Dataset`) and `testSingleChromosomeAll.js` (end to end through a real browser and a real `loadHicFile`).

The regression that matters is asserted explicitly: **a multi-chromosome dataset is unchanged on every claim** — pulldown keeps `All`, the resolution list carries no sentinel, a session naming `chr 0` stays in the whole-genome view, and `minZoom` never answers the sentinel. Everything here is gated on a predicate that must stay false for every real genome.

Reviewed on both axes (`/code-review`); the standards and spec findings are addressed in the two follow-up commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)