### PR TITLE
Fix pinch zoom-out to whole genome (#589)

### DIFF
--- a/js/interactionHandler.js
+++ b/js/interactionHandler.js
@@ -169,6 +169,23 @@ class InteractionHandler {
             return;
         }
 
+        await this._zoomByScaleFactor(anchorPx, anchorPy, scaleFactor);
+    }
+
+    /**
+     * Zoom about an anchor by a scale factor -- the behaviour pinch and wheel
+     * gestures share, once each has decided the gesture is a zoom at all.
+     *
+     * The two used to carry a copy of this each, and the copies drifted: the
+     * pinch one asked for chromosome `1` where the comment said whole genome,
+     * and handed `setChromosomes` a `{ xLocus }` wrapper rather than a locus
+     * (#589). One copy now, so a fix to either gesture is a fix to both.
+     *
+     * @param {number} anchorPx - Anchor X position in pixels
+     * @param {number} anchorPy - Anchor Y position in pixels
+     * @param {number} scaleFactor - Scale factor (>1 = zoom in, <1 = zoom out)
+     */
+    async _zoomByScaleFactor(anchorPx, anchorPy, scaleFactor) {
         try {
             this.browser.startSpinner();
 
@@ -213,8 +230,8 @@ class InteractionHandler {
 
             if (canLeaveForWholeGenome && !this.browser.resolutionLocked && scaleFactor < 1 && newZoom < z) {
                 // Zoom out to whole genome
-                const xLocus = this.parseLocusString('1');
-                const yLocus = { xLocus };
+                const xLocus = this.parseLocusString('All');
+                const yLocus = { ...xLocus };
                 await this.setChromosomes(xLocus, yLocus);
             } else {
                 await this.browser.state.panWithZoom(
@@ -301,69 +318,7 @@ class InteractionHandler {
             return;
         }
 
-        try {
-            this.browser.startSpinner();
-
-            const bpResolutions = this.browser.getResolutions();
-            const currentResolution = this._resolutionForZoom(bpResolutions, this.browser.state.zoom);
-
-            // The list is sorted coarsest-first, so the finest rung is the last
-            // entry and the coarsest is the first. Both guards used to be written
-            // as the array positions those ends happen to have when index and
-            // position agree, which stopped being true once a rung could be
-            // filtered out or synthesised in. ADR-0010 decision 1.
-            const finest = bpResolutions[bpResolutions.length - 1];
-            const coarsest = bpResolutions[0];
-
-            let newBinSize;
-            let newZoom;
-            let newPixelSize;
-            let resolutionChanged;
-
-            if (this.browser.resolutionLocked ||
-                (this.browser.state.zoom === finest.index && scaleFactor > 1) ||
-                (this.browser.state.zoom === coarsest.index && scaleFactor < 1)) {
-                // Can't change resolution level, must adjust pixel size
-                newBinSize = currentResolution.binSize;
-                newPixelSize = Math.min(MAX_PIXEL_SIZE, this.browser.state.pixelSize * scaleFactor);
-                newZoom = this.browser.state.zoom;
-                resolutionChanged = false;
-            } else {
-                const targetBinSize = (currentResolution.binSize / this.browser.state.pixelSize) / scaleFactor;
-                newZoom = this.findMatchingZoomIndex(targetBinSize, bpResolutions);
-                newBinSize = this._resolutionForZoom(bpResolutions, newZoom).binSize;
-                resolutionChanged = newZoom !== this.browser.state.zoom;
-                newPixelSize = Math.min(MAX_PIXEL_SIZE, newBinSize / targetBinSize);
-            }
-
-            const z = await this.browser.minZoom(this.browser.state.chr1, this.browser.state.chr2);
-
-            // A single-chromosome assembly has no whole-genome view to fall out
-            // to: `All` is the sentinel rung of the scaffold now, and zooming
-            // past the last declared rung already lands there. ADR-0010.
-            const canLeaveForWholeGenome = !this.browser.dataset.isSingleChromosome();
-
-            if (canLeaveForWholeGenome && !this.browser.resolutionLocked && scaleFactor < 1 && newZoom < z) {
-                // Zoom out to whole genome
-                const xLocus = this.parseLocusString('All');
-                const yLocus = { ...xLocus };
-                await this.setChromosomes(xLocus, yLocus);
-            } else {
-                await this.browser.state.panWithZoom(
-                    newZoom, newPixelSize, anchorPx, anchorPy, newBinSize,
-                    this.browser, this.browser.dataset,
-                    this.browser.contactMatrixView.getViewDimensions()
-                );
-
-                await this._applyStateChange({
-                    resolutionChanged,
-                    chrChanged: false,
-                    zoomIn: true
-                });
-            }
-        } finally {
-            this.browser.stopSpinner();
-        }
+        await this._zoomByScaleFactor(anchorPx, anchorPy, scaleFactor);
     }
 
     /**

--- a/test/testZoomOutToWholeGenome.js
+++ b/test/testZoomOutToWholeGenome.js
@@ -7,10 +7,15 @@
  * `xLocus` -- where a locus was wanted. The claims below are made against both
  * entry points from the same starting state, so the two cannot drift again
  * without a red test.
+ *
+ * The gesture runs into a real `State` through the real `setChromosomes`, so
+ * what is pinned is the view arrived at, not the arguments handed onward. The
+ * one spy is on `setChromosomes` itself, in the test that has to look at the
+ * loci it receives -- the malformed `yLocus` was invisible downstream.
  */
 import {describe, expect, test, vi} from 'vitest'
 import InteractionHandler from '../js/interactionHandler.js'
-import {createInteractionBrowser} from './utils/interactionBrowser.js'
+import {createGestureBrowser, START_PIXEL_SIZE, START_ZOOM} from './utils/gestureBrowser.js'
 
 /** The two gestures, named by the method that drives them. */
 const gestures = [
@@ -21,12 +26,25 @@ const gestures = [
 /** Small enough that the matched zoom index falls below `minZoom`. */
 const ZOOM_OUT = 0.1
 
+/** The whole-genome view, as `hicState` spells it. */
+const WHOLE_GENOME_CHR = 0
+
 describe.each(gestures)('%s zoomed out past the minimum zoom', (name, gesture) => {
 
-    test('navigates to the whole-genome view on both axes', async () => {
-        const browser = createInteractionBrowser()
+    test('lands on the whole-genome view', async () => {
+        const browser = createGestureBrowser()
         const handler = new InteractionHandler(browser)
-        const setChromosomes = vi.spyOn(handler, 'setChromosomes').mockResolvedValue(undefined)
+
+        await gesture(handler, ZOOM_OUT)
+
+        expect(browser.state.chr1).toBe(WHOLE_GENOME_CHR)
+        expect(browser.state.chr2).toBe(WHOLE_GENOME_CHR)
+    })
+
+    test('asks setChromosomes for the whole genome on both axes', async () => {
+        const browser = createGestureBrowser()
+        const handler = new InteractionHandler(browser)
+        const setChromosomes = vi.spyOn(handler, 'setChromosomes')
 
         await gesture(handler, ZOOM_OUT)
 
@@ -34,40 +52,52 @@ describe.each(gestures)('%s zoomed out past the minimum zoom', (name, gesture) =
         const [xLocus, yLocus] = setChromosomes.mock.calls[0]
 
         // The whole-genome chromosome, not chromosome 1.
-        expect(xLocus.chr).toBe('all')
+        expect(xLocus.chr).toBe('All')
         // A locus, not a `{ xLocus: ... }` wrapper: same keys, same values.
         expect(Object.keys(yLocus).sort()).toEqual(Object.keys(xLocus).sort())
         expect(yLocus).toEqual(xLocus)
-        expect(yLocus.chr).toBe('all')
     })
 
-    test('stays put when the resolution is locked', async () => {
-        const browser = createInteractionBrowser({resolutionLocked: true})
+    test('both gestures reach the identical state from the identical start', async () => {
+        const pinchBrowser = createGestureBrowser()
+        const wheelBrowser = createGestureBrowser()
+
+        await new InteractionHandler(pinchBrowser).pinchZoom(400, 400, ZOOM_OUT)
+        await new InteractionHandler(wheelBrowser)._performWheelZoom(400, 400, ZOOM_OUT)
+
+        expect({...pinchBrowser.state}).toEqual({...wheelBrowser.state})
+    })
+
+    test('stays on the current chromosome pair when the resolution is locked', async () => {
+        const browser = createGestureBrowser({resolutionLocked: true})
         const handler = new InteractionHandler(browser)
-        const setChromosomes = vi.spyOn(handler, 'setChromosomes').mockResolvedValue(undefined)
 
         await gesture(handler, ZOOM_OUT)
 
-        expect(setChromosomes).not.toHaveBeenCalled()
+        expect(browser.state.chr1).toBe(1)
+        expect(browser.state.chr2).toBe(1)
+        // The locked path zooms by pixel size instead of by rung.
+        expect(browser.state.zoom).toBe(START_ZOOM)
+        expect(browser.state.pixelSize).toBeLessThan(START_PIXEL_SIZE)
     })
 
-    test('stays put when zooming in', async () => {
-        const browser = createInteractionBrowser()
+    test.each([1, 2])('stays on the current chromosome pair at scaleFactor %d', async scaleFactor => {
+        const browser = createGestureBrowser()
         const handler = new InteractionHandler(browser)
-        const setChromosomes = vi.spyOn(handler, 'setChromosomes').mockResolvedValue(undefined)
 
-        await gesture(handler, 2)
+        await gesture(handler, scaleFactor)
 
-        expect(setChromosomes).not.toHaveBeenCalled()
+        expect(browser.state.chr1).toBe(1)
+        expect(browser.state.chr2).toBe(1)
     })
 
     test('stays put on a single-chromosome assembly, whose All is a zoom rung', async () => {
-        const browser = createInteractionBrowser({isSingleChromosome: true})
+        const browser = createGestureBrowser({isSingleChromosome: true})
         const handler = new InteractionHandler(browser)
-        const setChromosomes = vi.spyOn(handler, 'setChromosomes').mockResolvedValue(undefined)
 
         await gesture(handler, ZOOM_OUT)
 
-        expect(setChromosomes).not.toHaveBeenCalled()
+        expect(browser.state.chr1).toBe(1)
+        expect(browser.state.chr2).toBe(1)
     })
 })

--- a/test/testZoomOutToWholeGenome.js
+++ b/test/testZoomOutToWholeGenome.js
@@ -1,0 +1,73 @@
+/**
+ * Zooming out past the minimum zoom lands on the whole-genome view -- #589.
+ *
+ * `pinchZoom` and `_performWheelZoom` are two gestures onto one behaviour, and
+ * the pinch copy had drifted: it asked for chromosome `1` instead of the
+ * whole-genome locus, and passed `{ xLocus }` -- an object whose only key is
+ * `xLocus` -- where a locus was wanted. The claims below are made against both
+ * entry points from the same starting state, so the two cannot drift again
+ * without a red test.
+ */
+import {describe, expect, test, vi} from 'vitest'
+import InteractionHandler from '../js/interactionHandler.js'
+import {createInteractionBrowser} from './utils/interactionBrowser.js'
+
+/** The two gestures, named by the method that drives them. */
+const gestures = [
+    ['pinchZoom', (handler, scaleFactor) => handler.pinchZoom(400, 400, scaleFactor)],
+    ['_performWheelZoom', (handler, scaleFactor) => handler._performWheelZoom(400, 400, scaleFactor)],
+]
+
+/** Small enough that the matched zoom index falls below `minZoom`. */
+const ZOOM_OUT = 0.1
+
+describe.each(gestures)('%s zoomed out past the minimum zoom', (name, gesture) => {
+
+    test('navigates to the whole-genome view on both axes', async () => {
+        const browser = createInteractionBrowser()
+        const handler = new InteractionHandler(browser)
+        const setChromosomes = vi.spyOn(handler, 'setChromosomes').mockResolvedValue(undefined)
+
+        await gesture(handler, ZOOM_OUT)
+
+        expect(setChromosomes).toHaveBeenCalledTimes(1)
+        const [xLocus, yLocus] = setChromosomes.mock.calls[0]
+
+        // The whole-genome chromosome, not chromosome 1.
+        expect(xLocus.chr).toBe('all')
+        // A locus, not a `{ xLocus: ... }` wrapper: same keys, same values.
+        expect(Object.keys(yLocus).sort()).toEqual(Object.keys(xLocus).sort())
+        expect(yLocus).toEqual(xLocus)
+        expect(yLocus.chr).toBe('all')
+    })
+
+    test('stays put when the resolution is locked', async () => {
+        const browser = createInteractionBrowser({resolutionLocked: true})
+        const handler = new InteractionHandler(browser)
+        const setChromosomes = vi.spyOn(handler, 'setChromosomes').mockResolvedValue(undefined)
+
+        await gesture(handler, ZOOM_OUT)
+
+        expect(setChromosomes).not.toHaveBeenCalled()
+    })
+
+    test('stays put when zooming in', async () => {
+        const browser = createInteractionBrowser()
+        const handler = new InteractionHandler(browser)
+        const setChromosomes = vi.spyOn(handler, 'setChromosomes').mockResolvedValue(undefined)
+
+        await gesture(handler, 2)
+
+        expect(setChromosomes).not.toHaveBeenCalled()
+    })
+
+    test('stays put on a single-chromosome assembly, whose All is a zoom rung', async () => {
+        const browser = createInteractionBrowser({isSingleChromosome: true})
+        const handler = new InteractionHandler(browser)
+        const setChromosomes = vi.spyOn(handler, 'setChromosomes').mockResolvedValue(undefined)
+
+        await gesture(handler, ZOOM_OUT)
+
+        expect(setChromosomes).not.toHaveBeenCalled()
+    })
+})

--- a/test/utils/gestureBrowser.js
+++ b/test/utils/gestureBrowser.js
@@ -1,15 +1,21 @@
 /**
- * A browser stub shaped for `InteractionHandler`'s gesture methods.
+ * A browser stub shaped for `InteractionHandler`'s gesture zoom -- `pinchZoom`,
+ * `_performWheelZoom`, and the `_zoomByScaleFactor` they share.
  *
- * Just the collaborator surface `pinchZoom` / `_performWheelZoom` touch: a real
- * `State` so the non-branching path runs real arithmetic, a chromosome table
- * whose first entry is the whole-genome one, and the spinner / update / view
- * hooks `_applyStateChange` calls.
+ * Only the collaborators that path reaches, plus the ones `setChromosomes`
+ * needs behind it, so a gesture can be driven end to end into a real `State`
+ * rather than into a spy.
+ *
+ * The chromosome table spells the whole-genome entry `All`, as every real
+ * dataset does, and the genome looks names up case-insensitively as
+ * `genome.getChromosome` does. Both matter here: `parseLocusString` branches on
+ * the exact string `'All'`, and a lowercase table would send the gesture down a
+ * `wholeChr` path production never takes.
  */
 import State from '../../js/hicState.js'
 
 const CHROMOSOMES = [
-    {index: 0, name: 'all', size: 3000000000},
+    {index: 0, name: 'All', size: 3000000000},
     {index: 1, name: 'chr1', size: 250000000},
     {index: 2, name: 'chr2', size: 240000000},
     {index: 3, name: 'chr3', size: 200000000},
@@ -22,12 +28,16 @@ const BIN_SIZES = [2500000, 1000000, 500000, 250000, 100000, 50000, 25000, 10000
 
 export const VIEW_DIMENSIONS = {width: 800, height: 800}
 
+/** The rung the gesture starts on, and the floor it is asked to fall below. */
+export const START_ZOOM = 3
+export const START_PIXEL_SIZE = 4
+
 /**
  * @param {object} [options]
  * @param {boolean} [options.resolutionLocked]
  * @param {boolean} [options.isSingleChromosome]
  */
-export function createInteractionBrowser({resolutionLocked = false, isSingleChromosome = false} = {}) {
+export function createGestureBrowser({resolutionLocked = false, isSingleChromosome = false} = {}) {
     const chromosomes = isSingleChromosome ? SOLE_SCAFFOLD : CHROMOSOMES
     const resolutions = BIN_SIZES.map((binSize, index) => ({binSize, index}))
 
@@ -39,20 +49,22 @@ export function createInteractionBrowser({resolutionLocked = false, isSingleChro
         isSingleChromosome: () => isSingleChromosome,
         soleChromosome: () => chromosomes[1],
         binSizeForZoom: zoom => BIN_SIZES[zoom],
-        matrixViewForZoom: (chr1, chr2, zoom) => ({chr1, chr2, zoomIndex: zoom}),
     }
 
     return {
         dataset,
         resolutionLocked,
-        // Zoom rung 3 with rung 3 as the floor: any coarser match falls out to
-        // the whole genome, which is the branch under test.
-        state: new State(1, 1, 3, 200, 200, 4, 'NONE'),
-        minZoom: async () => 3,
+        // Rung 3 with rung 3 as the floor: any coarser match falls below it,
+        // which is the branch these tests are about.
+        state: new State(1, 1, START_ZOOM, 200, 200, START_PIXEL_SIZE, 'NONE'),
+        minZoom: async () => START_ZOOM,
         minPixelSize: async () => 1,
         getResolutions: () => resolutions,
         binSizeForZoom: zoom => BIN_SIZES[zoom],
-        genome: {getChromosome: name => chromosomes.find(chromosome => chromosome.name === name)},
+        genome: {
+            getChromosome: name =>
+                chromosomes.find(chromosome => chromosome.name.toLowerCase() === String(name).toLowerCase()),
+        },
         contactMatrixView: {
             getViewDimensions: () => VIEW_DIMENSIONS,
             clearImageCaches: () => {},

--- a/test/utils/interactionBrowser.js
+++ b/test/utils/interactionBrowser.js
@@ -1,0 +1,66 @@
+/**
+ * A browser stub shaped for `InteractionHandler`'s gesture methods.
+ *
+ * Just the collaborator surface `pinchZoom` / `_performWheelZoom` touch: a real
+ * `State` so the non-branching path runs real arithmetic, a chromosome table
+ * whose first entry is the whole-genome one, and the spinner / update / view
+ * hooks `_applyStateChange` calls.
+ */
+import State from '../../js/hicState.js'
+
+const CHROMOSOMES = [
+    {index: 0, name: 'all', size: 3000000000},
+    {index: 1, name: 'chr1', size: 250000000},
+    {index: 2, name: 'chr2', size: 240000000},
+    {index: 3, name: 'chr3', size: 200000000},
+]
+
+/** The single-chromosome table: the whole-genome entry plus one scaffold. */
+const SOLE_SCAFFOLD = CHROMOSOMES.slice(0, 2)
+
+const BIN_SIZES = [2500000, 1000000, 500000, 250000, 100000, 50000, 25000, 10000, 5000]
+
+export const VIEW_DIMENSIONS = {width: 800, height: 800}
+
+/**
+ * @param {object} [options]
+ * @param {boolean} [options.resolutionLocked]
+ * @param {boolean} [options.isSingleChromosome]
+ */
+export function createInteractionBrowser({resolutionLocked = false, isSingleChromosome = false} = {}) {
+    const chromosomes = isSingleChromosome ? SOLE_SCAFFOLD : CHROMOSOMES
+    const resolutions = BIN_SIZES.map((binSize, index) => ({binSize, index}))
+
+    const dataset = {
+        chromosomes,
+        bpResolutions: BIN_SIZES,
+        wholeGenomeChromosome: chromosomes[0],
+        isWholeGenome: chrIndex => 0 === chrIndex,
+        isSingleChromosome: () => isSingleChromosome,
+        soleChromosome: () => chromosomes[1],
+        binSizeForZoom: zoom => BIN_SIZES[zoom],
+        matrixViewForZoom: (chr1, chr2, zoom) => ({chr1, chr2, zoomIndex: zoom}),
+    }
+
+    return {
+        dataset,
+        resolutionLocked,
+        // Zoom rung 3 with rung 3 as the floor: any coarser match falls out to
+        // the whole genome, which is the branch under test.
+        state: new State(1, 1, 3, 200, 200, 4, 'NONE'),
+        minZoom: async () => 3,
+        minPixelSize: async () => 1,
+        getResolutions: () => resolutions,
+        binSizeForZoom: zoom => BIN_SIZES[zoom],
+        genome: {getChromosome: name => chromosomes.find(chromosome => chromosome.name === name)},
+        contactMatrixView: {
+            getViewDimensions: () => VIEW_DIMENSIONS,
+            clearImageCaches: () => {},
+            zoomIn: async () => {},
+        },
+        update: async () => {},
+        coordinator: {onLocusChange: () => {}},
+        startSpinner: () => {},
+        stopSpinner: () => {},
+    }
+}


### PR DESCRIPTION
Closes #589.

`pinchZoom` and `_performWheelZoom` carried a copy each of the same zoom body, and the pinch copy had drifted on both counts the comment above it gave away: it asked `parseLocusString` for chromosome `1` rather than the whole genome, and handed `setChromosomes` a `{ xLocus }` wrapper — an object with no `chr`, `start` or `end` — where a locus was wanted.

## The fix

Extract the shared body as `_zoomByScaleFactor`, taken verbatim from the wheel copy, so there is one copy to be right. Each gesture keeps only its own `state.chr1 === 0` guard, which is where the two genuinely differ: pinch recenters unconditionally, wheel only when zooming in.

## Tests

`test/testZoomOutToWholeGenome.js` drives both gestures through the real `setChromosomes` into a real `State` (fixture: `test/utils/gestureBrowser.js`), so what is pinned is the view arrived at rather than the arguments handed onward:

- both gestures land on the whole-genome view, and on the *identical* state from the identical start
- the `yLocus` reaching `setChromosomes` has the same keys and values as the `xLocus`
- the guards hold: `resolutionLocked`, `scaleFactor` at 1 and 2, and single-chromosome assemblies (ADR-0010) all stay on the current pair, and the locked path is asserted to have zoomed by pixel size instead

Reverting the fix turns 6 of the 14 red. Full suite green: 1042 tests, 55 files.

## Review

Both axes of `/code-review` ran. No spec findings. The three standards findings were all in the test fixture and are addressed in the second commit — the substantive one being that the stub named the whole-genome chromosome `all` where production names it `All`, which sent the test down a `wholeChr` branch production never takes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)