### PR TITLE
Bump version to 4.1.0

### DIFF
--- a/js/version.js
+++ b/js/version.js
@@ -1,2 +1,2 @@
-const version = "4.0.0"
+const version = "4.1.0"
 export {version}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juicebox.js",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juicebox.js",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "devDependencies": {
         "@vitest/ui": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juicebox.js",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "type": "module",
   "main": "./dist/juicebox.esm.js",
   "module": "./dist/juicebox.esm.js",


### PR DESCRIPTION
Minor. The change since v4.0.0 is #518 / ADR-0011, and it is additive twice over: `decodeSessionString` accepts one more spelling (`data:application/gzip;base64,…`) where it used to throw, and the `exports` map gains `./test/data/wireFormatCorpus.js`. Nothing was removed, narrowed or renamed on the public surface — `NAMESPACE_SURFACE` is untouched — so no consumer can break on this.

Cut despite ADR-0011 decision 3's "no juicebox release is required for any of this". That is right about semver and wrong about mechanics: both consumers pin by tag (`github:aidenlab/juicebox.js#v4.0.0`), and the Spacewalk half of #518 (aidenlab/spacewalk#86) imports `juicebox.js/test/data/wireFormatCorpus.js` — a file that, at v4.0.0, has neither the `payload` field nor the `exports` entry that makes it importable. Without a tag there is nothing for it to import.

The ADR is left as written rather than amended: it recorded what was known when it was accepted, which is the point of the record.

`npm run build` and `npx vitest run` (1047 passed) both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)