### PR TITLE
Ship the wire-format corpus, and bump to 4.1.1

### DIFF
--- a/docs/adr/0011-session-string-is-the-cross-host-contract.md
+++ b/docs/adr/0011-session-string-is-the-cross-host-contract.md
@@ -171,3 +171,24 @@ ADR-0006 decision 7 deliberately put it inside the JSON.
   asked, and this ADR answers one it did not know it had left open — that "one
   decoder" meant one *per repo*. Rewriting an accepted ADR to look prescient
   loses the record of when we learned this.
+
+## Amendment, recorded during implementation (2026-08-24)
+
+**Decision 3's premise about distribution is false, and one line of
+`package.json` was needed to make the export real.** The decision reads "a
+github-installed dependency already ships the whole tree, so nothing about
+distribution changes". It does not. npm installs a git dependency by *packing*
+it, which honours `files` — at v4.1.0 `files` was `dist/**` and `dev-proxy/**`,
+so `exports` resolved `./test/data/wireFormatCorpus.js` to a path that did not
+exist in `node_modules`. Measured from Spacewalk's own tree after the bump
+rather than reasoned about: the import failed with `Cannot find module`.
+
+`files` therefore gains `test/data/wireFormatCorpus.js` — the one file, not the
+directory, because shipping a fixture corpus is the deliberate act decision 3
+describes and shipping a test tree is not. v4.1.1 carries it.
+
+The consequence the decision drew from the false premise — that the entry "makes
+the corpus a deliberate export rather than a file someone reached into
+`node_modules` for" — survives intact, and is truer than it was: the file is now
+reachable in both install modes and reachable *only* through the export. Nothing
+else in the ADR rested on the tree being shipped whole.

--- a/js/version.js
+++ b/js/version.js
@@ -1,2 +1,2 @@
-const version = "4.1.0"
+const version = "4.1.1"
 export {version}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juicebox.js",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juicebox.js",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "devDependencies": {
         "@vitest/ui": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juicebox.js",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "type": "module",
   "main": "./dist/juicebox.esm.js",
   "module": "./dist/juicebox.esm.js",
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist/**",
-    "dev-proxy/**"
+    "dev-proxy/**",
+    "test/data/wireFormatCorpus.js"
   ],
   "author": {
     "name": "Jim Robinson"


### PR DESCRIPTION
v4.1.0's `exports` entry for `./test/data/wireFormatCorpus.js` resolves to a file that is not in the package.

npm installs a git dependency by **packing** it, so `files` applies to a github install exactly as it does to an npm one. ADR-0011 decision 3's "a github-installed dependency already ships the whole tree, so nothing about distribution changes" is false. Measured from Spacewalk's own tree after re-pinning it to v4.1.0, not reasoned about:

```
IMPORT FAILED Cannot find module
  /Users/…/spacewalk/node_modules/juicebox.js/test/data/wireFormatCorpus.js
```

`node_modules/juicebox.js/` held `dist`, `dev-proxy`, `LICENSE`, `package.json`, `README.md` — and nothing else.

## The fix

`files` gains **`test/data/wireFormatCorpus.js`** — the one file, not `test/**`. Shipping a fixture corpus is the deliberate act ADR-0011 decision 3 describes; shipping a test tree is not. `npm pack --dry-run` now lists it at 55.0kB, 16 files total.

ADR-0011 gains an **amendment section** rather than an edit to decision 3, matching ADR-0010's convention: the premise was wrong when it was written, and the record should say so rather than look prescient.

## Version

**Patch.** Nothing about the API or the wire format moved. The only thing that changes for a consumer is that an export shipped in v4.1.0 now resolves.

Both consumers get re-pinned to v4.1.1 — juicebox-web's v4.1.0 bump landed before this was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)