### PR TITLE
Seed the host's colour scale under the resolved normalization (#575)

### DIFF
--- a/docs/adr/0003-public-api-contract.md
+++ b/docs/adr/0003-public-api-contract.md
@@ -313,3 +313,61 @@ rather than re-reasoned.
 candidates and 160 commits, including two that deleted a module (`StateManager`)
 and one that removed a wire format (`?juiceboxURL=`). The half of the contract
 that drifted is the half nothing executes.
+
+---
+
+## Appended — 2026-08-25: `config.colorScale`'s threshold is a directive
+
+Appended, not revised, per the rule above. This adds a clause to the contract
+rather than re-measuring it: the surface did not change, but something a host may
+rely on was true only by accident and is now stated.
+
+**A `colorScale` on a config names the contrast the map opens at. The first
+render draws at that threshold; it does not compute one and overwrite it.**
+
+This was never written down, and until #575 it was not reliably true. The
+mechanism is a cache seed: `contactMatrixView.setColorScale` files the threshold
+in `imageTileSource.thresholdCache` under `colorScaleKey(state, displayMode)`,
+and the first render pass reads the same key back. Where the key matches, the
+host's value stands. Where it does not, `#ensureColorScale` refetches contact
+records and replaces the threshold with the 95th percentile of the data.
+
+Before #575, `init` seeded that cache *above* the normalization enforcer, so the
+key carried the **requested** normalization while the render looked up the
+**resolved** one. The two agree only when nothing was substituted. So the
+directive was honoured when the request happened to be valid and silently
+discarded when it was not — which is not a contract, it is a coin flip.
+
+### Why this is a contract rather than a hint
+
+`toJSON` writes `colorScale` into every saved session (`hicBrowser.js:1365`), and
+session restore comes back through `init`'s config. So the population relying on
+this is not a hypothetical embedder reading an options table — it is **every
+published juicebox link**. A link reopening at a different contrast than the one
+it was saved at is the same class of harm ADR-0009 decision 2 argues against for
+`pixelSize` and origin: a link that no longer shows what it was made to show.
+
+The measurement tables above cannot see this. They record which *members* a
+consumer calls, and this is a claim about what a member *does* with a field.
+`browser.config` and `restoreSession` are both in the tables; the behaviour that
+makes them worth calling was not.
+
+### What follows
+
+- **The ordering in `init` is load-bearing and commented as such.** The
+  `config.colorScale` branch sits below the normalization write. Moving it back
+  up reintroduces the defect silently — nothing throws, a threshold is just
+  different. `test/testRestoreNormalization.js` pins which normalization the seed
+  lands under; `test/testImageTileSource.js` pins that a matching seed suppresses
+  the automatic threshold and a mismatched one does not.
+- **The threshold is still per-normalization.** Nothing here says it should be.
+  A host's "open at this contrast" is arguably not a statement about
+  normalization at all, and keying it that way is what made the ordering matter
+  in the first place. #575 fixed the ordering rather than the keying, deliberately
+  — decoupling the seed from `colorScaleKey` touches the render path's cache
+  protocol and belongs on its own card, argued on its own merits.
+- **The comparison modes are excluded, and were already.** `#ensureColorScale`
+  returns early for `AOB`, `BOA` and `AMB`: a signed scale's threshold is
+  user-driven and never derived from the data, so there is no automatic value for
+  a host directive to be overwritten by. CONTEXT.md's *Color scale* entry states
+  this distinction.

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -262,14 +262,6 @@ class HICBrowser {
                 this.coordinator.onDisplayMode(config.displayMode);
             }
 
-            if (config.colorScale) {
-                if (config.normalization) {
-                    this.state.normalization = config.normalization;
-                }
-                this.contactMatrixView.setColorScale(config.colorScale);
-                this.coordinator.onColorScale(this.contactMatrixView.getColorScale());
-            }
-
             const promises = [];
 
             if (config.tracks) {
@@ -301,6 +293,34 @@ class HICBrowser {
             if (config.normalization) {
                 this.state.normalization = await this.#resolveNormalization(config.normalization);
                 await this.#announceSubstitution(config.normalization, this.state.normalization);
+            }
+
+            // Below the normalization write, and pinned there (#575). A host's
+            // `colorScale` carries a threshold it means to be drawn at, and the
+            // only thing that makes that threshold survive the first render is
+            // the cache entry `setColorScale` seeds -- keyed, through
+            // `colorScaleKey`, on `state.normalization`. `#ensureColorScale`
+            // reads that key back on the first pass with the *resolved*
+            // normalization in force, so a seed written any earlier is filed
+            // under a value that is not the one looked up: the lookup misses,
+            // `autoThreshold` runs, and the host's threshold is overwritten by
+            // one computed from the data.
+            //
+            // Above the seam this branch used to sit above, it also wrote
+            // `state.normalization` from `config.normalization` unvalidated --
+            // a second enforcer for the invariant ADR-0009 decision 5 says has
+            // one or none. Moving the branch is what removes it; the write is
+            // not deleted, it is the one below.
+            //
+            // The reordering costs a repaint of the colour-scale widget, which
+            // is all `onColorScale` does (`browserCoordinator.js:281`). It now
+            // lands after the track and normalization-vector loads rather than
+            // before them -- behind the spinner and the interaction shield
+            // raised at the top of this method, and read by nothing on either
+            // load path.
+            if (config.colorScale) {
+                this.contactMatrixView.setColorScale(config.colorScale);
+                this.coordinator.onColorScale(this.contactMatrixView.getColorScale());
             }
 
             if (config.cycle) {

--- a/test/testImageTileSource.js
+++ b/test/testImageTileSource.js
@@ -465,6 +465,54 @@ describe('ImageTileSource automatic color scale', () => {
         await collect(makeSource({observer}).tilesFor(request()))
         expect(observer.seen.scales).toEqual([])
     })
+
+    /**
+     * The read side of #575. A host that passes `config.colorScale` is naming
+     * the contrast it wants drawn -- `toJSON` writes one into every saved
+     * session, so this is what a published link reopens at, not a niche
+     * embedder option. See ADR-0003's 2026-08-25 appendix.
+     *
+     * `setColorScale` is the only thing that makes that threshold survive: it
+     * seeds the threshold cache, and the seed is keyed on the normalization in
+     * the state it is handed. So the directive is honoured exactly when the
+     * seed key and the key the first pass looks up are the same value -- which
+     * is what pins `hicBrowser.init`'s ordering. The write side, which
+     * normalization `init` actually seeds under, is in
+     * `testRestoreNormalization.js`.
+     */
+    it("honours a host's threshold when the seed key matches the normalization in force", async () => {
+        const observer = recordingObserver()
+        const ds = dataset({records: manyRecords})
+        const source = makeSource({observer})
+        const inForce = state({normalization: 'KR'})
+
+        source.setColorScale({...scale(), threshold: 1234}, 'A', inForce)
+
+        await collect(source.tilesFor(request({dataset: ds, state: inForce})))
+
+        // No scale-only probe: the seed answered the question, so nothing was
+        // refetched and `autoThreshold` never ran.
+        expect(scaleFetches(ds)).toBe(0)
+        expect(source.getColorScale('A').threshold).toBe(1234)
+    })
+
+    it("discards a host's threshold when the seed was keyed on a different normalization", async () => {
+        // The defect #575 fixes, stated as behaviour rather than as ordering:
+        // seed under one normalization, render under another, and the host's
+        // 1234 is silently replaced by the 95th percentile of the data. This is
+        // what `init` did to every config carrying a `colorScale` alongside a
+        // `normalization` that got substituted.
+        const observer = recordingObserver()
+        const ds = dataset({records: manyRecords})
+        const source = makeSource({observer})
+
+        source.setColorScale({...scale(), threshold: 1234}, 'A', state({normalization: 'KR'}))
+
+        await collect(source.tilesFor(request({dataset: ds, state: state({normalization: 'NONE'})})))
+
+        expect(scaleFetches(ds)).toBe(1)
+        expect(source.getColorScale('A').threshold).toBe(96)
+    })
 })
 
 describe('ImageTileSource loading signal', () => {

--- a/test/testRestoreNormalization.js
+++ b/test/testRestoreNormalization.js
@@ -310,6 +310,93 @@ describe('normalization is validated against the loaded dataset at restore (#561
         expect(announcement(browser)).not.toMatch(/control map/i)
     })
 
+    /**
+     * A host's `colorScale` threshold is seeded into the tile source's cache
+     * under the normalization in force at the moment `setColorScale` runs
+     * (`imageTileSource.js:129`, through `colorScaleKey`). #575 moved that
+     * branch below the enforcer so the value it is filed under is the resolved
+     * one -- which is the only thing that makes the threshold survive the first
+     * render, since `#ensureColorScale` reads the same key back and recomputes
+     * on a miss.
+     *
+     * Asserted on the key rather than on the render: `ContactMatrixView.update`
+     * is stubbed in this fixture, so the read side is driven in
+     * `testImageTileSource.js`. What is claimed here is the half only a real
+     * `init` can show -- which normalization the seed ends up under.
+     */
+    const seededKeys = browser => Object.keys(browser.contactMatrixView.imageTileSource.thresholdCache)
+
+    const hostScale = threshold => ({
+        threshold, r: 255, g: 0, b: 0,
+        setThreshold(t) { this.threshold = t }
+    })
+
+    test('a host colorScale is seeded under the resolved normalization, not the requested one', async () => {
+
+        // `KR` is not offered, so the enforcer answers `VC`. A seed written
+        // before the enforcer ran would be filed under `KR` -- a key the first
+        // render never looks up.
+        offered = ['VC']
+
+        const browser = embed()
+
+        await browser.init({
+            url: HIC_URL,
+            state: savedWith('NONE'),
+            normalization: 'KR',
+            colorScale: hostScale(1234)
+        })
+
+        expect(browser.state.normalization).toBe('VC')
+
+        const keys = seededKeys(browser)
+        expect(keys.length).toBe(1)
+        expect(keys[0]).toContain('_VC_')
+        expect(keys[0]).not.toContain('_KR_')
+        expect(browser.contactMatrixView.imageTileSource.thresholdCache[keys[0]]).toBe(1234)
+    })
+
+    test('a host colorScale is seeded under the requested normalization when nothing is substituted', async () => {
+
+        // The case that worked before #575 and has to keep working: no
+        // substitution, so requested and resolved are the same value and the
+        // seed lands under it either way.
+        offered = ['NONE', 'VC', 'KR']
+
+        const browser = embed()
+
+        await browser.init({
+            url: HIC_URL,
+            state: savedWith('NONE'),
+            normalization: 'KR',
+            colorScale: hostScale(1234)
+        })
+
+        expect(browser.state.normalization).toBe('KR')
+        expect(seededKeys(browser)[0]).toContain('_KR_')
+    })
+
+    test('the moved colorScale branch still announces the substitution', async () => {
+
+        // The branch now runs after `#announceSubstitution` rather than before
+        // it. Nothing on the colour-scale path calls `clearSubstitution`, and
+        // this is what says so -- an announcement raised and then walked over
+        // by the reorder would put #372 back with a marker in it.
+        offered = ['VC']
+
+        const browser = embed()
+
+        await browser.init({
+            url: HIC_URL,
+            state: savedWith('NONE'),
+            normalization: 'KR',
+            colorScale: hostScale(1234)
+        })
+
+        expect(announcement(browser)).toContain('KR')
+        expect(announcement(browser)).toContain('VC')
+    })
+
     test('a coerced top-level config.normalization announces it too', async () => {
 
         // The second of `#resolveNormalization`'s two doors. It is the same


### PR DESCRIPTION
Closes #575.

`init`'s `config.colorScale` branch wrote `state.normalization` unvalidated — a second enforcer for the invariant ADR-0009 decision 5 says has one or none.

**The grilling session inverted the ticket's plan.** The original body said "most likely just delete the inner `if`." That write is load-bearing: `setColorScale` seeds the threshold cache keyed through `colorScaleKey` on `state.normalization`, and `#ensureColorScale` reads the same key back on the first render — a miss refetches contact records and overwrites the host's threshold with an automatic one.

It was also already wrong. The seed is filed under the *requested* normalization and looked up under the *resolved* one, so any config carrying a `colorScale` alongside a substituted `normalization` silently lost its contrast. `toJSON` writes a `colorScale` into every saved session, so that reaches every published link.

Moving the whole branch below the validated write fixes both at once. The enforcer cannot move up to meet it: `loadNormalizationFile` adds to the set `#resolveNormalization` reads (`dataLoader.js:518-523`), pinning it below `Promise.all`.

**Cost, measured.** `onColorScale` only repaints the colour-scale widget (`browserCoordinator.js:281-285`); nothing on the track or norm-vector load path reads the colour scale. The repaint now lands after those loads — behind the spinner and the interaction shield raised at the top of `init`.

## The search the triage comment asked for

Two readers of `state.normalization` exist between the two writes.

1. **`colorScaleKey`** — load-bearing, and the subject of this PR.
2. **`normalizationWidget.updateOptions`** — split out as #603. It runs from *inside* the norm-vector load, so it necessarily precedes any possible resolution; no ordering fixes it, and it moves output on its own account. Separate ticket per ADR-0009 decision 3 and #536, so each movement has one explanation.

## Tests

- `testRestoreNormalization.js` — the seed lands under the resolved normalization (fails on the old ordering), still lands under the requested one when nothing is substituted, and the substitution announcement survives the reorder.
- `testImageTileSource.js` — a matching seed suppresses `autoThreshold`; a mismatched one lets it overwrite the host's 1234 with the data's 96.

Full suite green, 1075 tests. No golden moves — the three goldens characterise config, decoded session and restored state, and a threshold cache is none of those.

## Docs

ADR-0003 gains an appended clause: a `colorScale` on a config names the contrast the map opens at, and the first render honours it rather than computing one. The tables are untouched; the ADR is append-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)