### PR TITLE
Bump version to 4.2.0

### DIFF
--- a/js/version.js
+++ b/js/version.js
@@ -1,2 +1,2 @@
-const version = "4.1.1"
+const version = "4.2.0"
 export {version}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juicebox.js",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juicebox.js",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "MIT",
       "devDependencies": {
         "@vitest/ui": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juicebox.js",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "type": "module",
   "main": "./dist/juicebox.esm.js",
   "module": "./dist/juicebox.esm.js",


### PR DESCRIPTION
Minor bump for the v4.2.0 release.

**Minor, not patch:** #372 adds a user-visible surface that did not exist before. A normalization substitution now announces itself as a clickable marker on the normalization widget, with the reason readable as text on the page. The restore-time coercion (#561) was silent; the mid-render miss raised a modal. Both land on the widget now, and the last modal in the library is gone.

**Minor, not major:** `js/publicApi.js` is byte-identical to v4.1.1. The renamed `onNormalizationExternalChange` and the deleted `canBeSynched` are both internal.

`config.synchState` is the one host-visible removal, and it is not a behaviour change — #566 established the rung was unreachable, so the key is now ignored silently like every other unrecognised config key.

Verified: `npm run build` clean, `npx vitest run` 56 files / 1068 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)