### PR TITLE
Mirror the resolution lock across a sync group, and make it hold (ADR-0014)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -124,6 +124,27 @@ is the thing `initRegistry(container, config)` returns, and the unit of
 isolation that lets two embeds coexist on a page — see `docs/adr/0004`.
 _Avoid_: browser session, browser context, embed.
 
+**Sync group** — the set of browsers a browser publishes its canonical state to.
+Membership is a rule rather than a container: a browser joins when it has not
+opted out and its dataset is compatible with the other's. What travels the group
+is canonical state and, by deliberate exception, view preferences — never dataset
+choices. See `docs/adr/0014`.
+_Avoid_: sync set, linked browsers.
+
+**View preference** — a setting the user makes on one browser that changes how
+that browser interprets a gesture, without being part of what the view *is*.
+Three properties define the category: the user sets it, it is scoped to a single
+browser, and it is absent from canonical state. The **resolution lock** is the
+first one named. This is the distinction that decides what crosses a sync group,
+and it is the reason normalization and the colour scale do not — `docs/adr/0014`.
+
+**Resolution lock** — the padlock beside the resolution selector, and the view
+preference it holds: while it is closed, a zoom gesture changes pixel size rather
+than moving to a different resolution rung.
+_Avoid_: **scale lock**, which collides with both *colour scale* and *pixel
+size*. The lock is honoured on local gesture paths only; sync is not one of them
+— issue #608.
+
 **Alert dialog** — the modal a load failure or an unavailable option is reported
 in, one per registry, built in that registry's container on first use
 (`registry.presentAlert`). Distinct from igv-ui's `Alert` singleton, which is

--- a/docs/adr/0014-view-preferences-mirror-canonical-state-syncs.md
+++ b/docs/adr/0014-view-preferences-mirror-canonical-state-syncs.md
@@ -115,6 +115,27 @@ change does not alter that. It is a real gap, and deliberately a separate one:
 adding a field to the wire format engages ADR-0006 and ADR-0011 and has nothing
 to do with mirroring.
 
+**8. The lock holds against a peer exactly as it holds against a local gesture.**
+`State.sync` consults the receiver's `resolutionLocked` and, when set, holds the
+rung and solves `pixelSize` for the publisher's `bpPerPixel` — the same branch,
+in the same shape, that `updateWithLoci` has always had.
+
+This was originally filed away as #608 and deferred, on the reasoning that it was
+a product decision (a locked browser *stops following its peers' resolution*)
+rather than a repair, and that mirroring would incidentally mitigate it because a
+locked peer's own gestures honour its lock. **That reasoning was wrong, and
+testing found it.** A peer receiving a sync is not gesturing, and sync was the
+one path that never asked about the lock. The observed behaviour: lock two
+synced browsers, wheel-zoom one, and the receiver re-derives a rung from the
+publisher's scale, moves off the rung it was pinned to, auto-clears its lock for
+having moved — and the mirror sends that clear back, so **both** padlocks open.
+
+Mirroring made it worse rather than better, which is what makes this
+inseparable from the mirroring work rather than a follow-up to it: decisions 1–7
+describe a feature that does not survive its first gesture without this.
+
+Unlocked, `sync` is unchanged.
+
 ## Considered and rejected
 
 - **Mirror everything a widget holds.** Rejected on the colour scale, which is
@@ -123,19 +144,18 @@ to do with mirroring.
   mirroring it would silently rewrite what a user saved. A rule that damages the
   clearest case is the wrong rule.
 - **A group-level property.** See decision 2.
-- **Fix the lock instead of mirroring it.** `State.sync` ignores the receiver's
-  `resolutionLocked`, so a locked browser follows a peer's resolution change
-  anyway, and the coordinator then clears the lock it just defeated. That is a
-  genuine defect and it is filed as #608 — but fixing it means a locked browser
-  *stops following its peers' resolution*, which is a product decision about what
-  "synced" means, not a repair. It is deliberately not bundled here.
+- **Fix the lock instead of mirroring it.** This was originally deferred to #608
+  as a product decision rather than a repair. Testing showed it is not separable:
+  see decision 8.
 
 ## Consequences
 
-- Mirroring the lock **incidentally mitigates** #608 on gesture paths: once the
-  peer is locked too, its own wheel and drag honour the lock, so no resolution
-  change propagates back. The dropdown and locus-goto paths are unaffected, and
-  neither defect is fixed.
+- A locked group holds its rungs and stays visually aligned. Two locked browsers
+  may sit on *different* rungs — each holds its own and matches the other's
+  `bpPerPixel` — which is the intended reading of the lock, not a defect.
+- A locked receiver that cannot reach the published scale within
+  `MAX_PIXEL_SIZE` clamps, and the two views diverge visually until the lock
+  comes off. Same ceiling a locked sweep zoom already hits.
 - Padlocks agree in every case reachable through the UI. The rung-mismatch
   divergence that decision 3 originally accepted is closed by mirroring the
   auto-clears.

--- a/docs/adr/0014-view-preferences-mirror-canonical-state-syncs.md
+++ b/docs/adr/0014-view-preferences-mirror-canonical-state-syncs.md
@@ -1,0 +1,112 @@
+# ADR-0014 — View preferences mirror across a sync group; canonical state syncs; dataset choices do neither
+
+**Status:** Accepted
+**Date:** 2026-08-31
+**Related:** #608 (the two lock/sync defects this does *not* fix), ADR-0004
+(browser registry, decision 6 — the sync-group membership rule), ADR-0006
+(session wire format), ADR-0013 (test tier), `CONTEXT.md` (*Sync group*, *View
+preference*, *Resolution lock*), `js/syncGroup.js`, `js/hicState.js`
+(`getSyncState`)
+
+## Context
+
+A collaborator asked that toggling the resolution lock in one of N synced
+browsers close the padlock in the others too, and made the same request for
+crosshairs. Neither is unreasonable, and neither is what sync does today:
+`State.getSyncState` publishes exactly six fields — `chr1Name`, `chr2Name`,
+`binSize`, `binX`, `binY`, `pixelSize` — all of them view geometry. No widget
+state has ever crossed the sync boundary.
+
+Answering the request one widget at a time is the trap. The same argument applies
+verbatim to normalization, the colour-scale threshold, background colour, display
+mode and track loading, and each new request would re-open an argument nobody had
+written down. What was needed first was the rule.
+
+The grilling session that produced this ADR also settled the *scope*: the
+resolution lock ships, crosshairs are deferred whole. Crosshairs turned out not
+to be a widget at all — they are a Shift-held transient driven by mousemove, and
+mirroring them raises questions the lock does not (wire unit, and whether a
+mirrored crosshair should fire a host's `customCrosshairsHandler`, which in
+Spacewalk drives 3D highlighting under a single shared key). Those are real
+decisions, and bundling them would have held the small change hostage to the
+large one.
+
+## Decision
+
+**1. Three categories, not two.** Every browser-scoped thing a user can change
+falls into exactly one:
+
+| Category | Travels the sync group as | Examples |
+| --- | --- | --- |
+| **Canonical state** | the sync payload, on every update | the seven `State` fields |
+| **View preference** | a mirror, on the user's action only | resolution lock; crosshairs, when they land |
+| **Dataset choice** | nothing | normalization, colour scale, background colour, display mode, tracks, control map |
+
+A **view preference** is defined by three properties together: the user sets it,
+it is scoped to one browser, and it is not part of what the view *is*. The test
+that separates it from a dataset choice is whether it changes **how a gesture is
+interpreted** or **what data is shown**.
+
+**2. A view preference is mirrored, not shared.** Each browser keeps its own
+copy; the user's action writes the same value into its peers. The sync group does
+**not** own the property. A peer may therefore diverge — and does, whenever its
+own resolution changes clear its lock — and that divergence is accepted rather
+than designed out. The alternative, a group-level property, would have removed
+per-browser control and introduced a second thing that owns state.
+
+**3. Only the user's action mirrors — never the system's bookkeeping.** The
+resolution lock is auto-cleared by the coordinator on every resolution change,
+which is the sync hot path. Those clears stay local. They already land on each
+browser independently, so fanning them out would broadcast during a drag to
+redo work that has happened anyway.
+
+**4. Mirroring does not ride in the sync payload.** It is a separate fan-out over
+the same `synchedBrowsers` set. Two reasons: the sync payload is sent on every
+`update()` and a preference changes on a click, so riding along would ship it
+thousands of times per drag to say nothing changed; and the payload *is*
+canonical state, which a view preference by definition is not. Keeping them
+separate keeps the vocabulary and the code agreeing.
+
+**5. The sync group is the only membership rule.** Mirroring reuses
+`synchedBrowsers` rather than defining its own set, even though some preferences
+(the lock among them) are genome-independent and could sensibly reach further. A
+second membership rule is a second thing to reason about, and "synced" is already
+the word the user's mental model uses for these panels. Per ADR-0004 decision 6,
+the rule stays a pure function over a list of browsers, so a cross-registry group
+remains one call over a concatenated array.
+
+**6. No public surface.** No coordinator callback, no bus event. No host uses the
+resolution lock; `js/publicApi.js` is a pinned contract and is not widened
+speculatively.
+
+**7. Nothing serialized.** A view preference does not enter the session wire
+format. `resolutionLocked` does not survive a session round trip today, and this
+change does not alter that. It is a real gap, and deliberately a separate one:
+adding a field to the wire format engages ADR-0006 and ADR-0011 and has nothing
+to do with mirroring.
+
+## Considered and rejected
+
+- **Mirror everything a widget holds.** Rejected on the colour scale, which is
+  the instructive case: two maps are often held at *deliberately* different
+  thresholds, and unlike the lock the threshold is persisted in the session, so
+  mirroring it would silently rewrite what a user saved. A rule that damages the
+  clearest case is the wrong rule.
+- **A group-level property.** See decision 2.
+- **Fix the lock instead of mirroring it.** `State.sync` ignores the receiver's
+  `resolutionLocked`, so a locked browser follows a peer's resolution change
+  anyway, and the coordinator then clears the lock it just defeated. That is a
+  genuine defect and it is filed as #608 — but fixing it means a locked browser
+  *stops following its peers' resolution*, which is a product decision about what
+  "synced" means, not a repair. It is deliberately not bundled here.
+
+## Consequences
+
+- Mirroring the lock **incidentally mitigates** #608 on gesture paths: once the
+  peer is locked too, its own wheel and drag honour the lock, so no resolution
+  change propagates back. The dropdown and locus-goto paths are unaffected, and
+  neither defect is fixed.
+- Padlocks can still disagree, but only when a peer's dataset lacks the matching
+  resolution rung. Named, not defended against.
+- The next "why doesn't X sync?" request has a written answer, and re-opening it
+  means superseding this ADR rather than re-arguing from scratch.

--- a/docs/adr/0014-view-preferences-mirror-canonical-state-syncs.md
+++ b/docs/adr/0014-view-preferences-mirror-canonical-state-syncs.md
@@ -39,7 +39,7 @@ falls into exactly one:
 | Category | Travels the sync group as | Examples |
 | --- | --- | --- |
 | **Canonical state** | the sync payload, on every update | the seven `State` fields |
-| **View preference** | a mirror, on the user's action only | resolution lock; crosshairs, when they land |
+| **View preference** | a mirror, on every transition | resolution lock; crosshairs, when they land |
 | **Dataset choice** | nothing | normalization, colour scale, background colour, display mode, tracks, control map |
 
 A **view preference** is defined by three properties together: the user sets it,
@@ -54,11 +54,41 @@ own resolution changes clear its lock — and that divergence is accepted rather
 than designed out. The alternative, a group-level property, would have removed
 per-browser control and introduced a second thing that owns state.
 
-**3. Only the user's action mirrors — never the system's bookkeeping.** The
-resolution lock is auto-cleared by the coordinator on every resolution change,
-which is the sync hot path. Those clears stay local. They already land on each
-browser independently, so fanning them out would broadcast during a drag to
-redo work that has happened anyway.
+**3. Every transition mirrors, not only the user's click.** The lock is a claim
+about the group, so whatever voids it on one browser voids it on all of them: the
+padlock clicked open, the coordinator's auto-clear on a resolution change, and
+the auto-clear on a map load.
+
+This was decided the other way first — mirror the click, keep the auto-clears
+local, on the argument that a resolution change already reaches each browser
+independently. That argument is true in the common case and false in the one that
+matters: a peer whose dataset lacks the matching rung reports `zoomChanged:
+false`, keeps its lock, and shows an icon the rest of the group has stopped
+agreeing with. Since parity is the whole point of the feature (see Context),
+tolerating a parity break was incoherent — it optimized a cost while leaving the
+goal unmet.
+
+The cost is genuinely small. Pan and drag report `resolutionChanged: false`, so
+the fan-out fires per *rung crossing*, not per frame, and each hop is a boolean
+and two class toggles. What makes it small is decision 3a.
+
+**3a. A write that changes nothing does nothing.** `setResolutionLocked` returns
+early when the value already holds. Without that, every resolution change in a
+never-locked session would fan out to announce that nothing happened, and a
+mirrored clear would do O(N²) hops as each peer's own auto-clear re-broadcast.
+With it, the hot path is one comparison, fan-out happens only on a real
+transition, and the recursion question does not arise: a peer set to a value it
+already holds stops there. No other guard is written, and none is needed.
+
+**3b. The map-load clear is included, on the collaborator's call.** A new map in
+one panel unlocks the group. The narrower reading — that only a *resolution*
+change should void the lock, since a map load is a panel reset rather than a
+resolution move — was considered and set aside as more subtlety than the feature
+warrants. Mechanically it works because `clearDataset()` removes the loading
+browser from its peers' sets but deliberately leaves its own standing (#492), so
+the browser can still reach the group on its way past. **Consequence:** a map
+load that changes genome unlocks the peers and *then* drops out of their group,
+which is the intended reading of "a new map voids the lock" but is worth knowing.
 
 **4. Mirroring does not ride in the sync payload.** It is a separate fan-out over
 the same `synchedBrowsers` set. Two reasons: the sync payload is sent on every
@@ -106,7 +136,8 @@ to do with mirroring.
   peer is locked too, its own wheel and drag honour the lock, so no resolution
   change propagates back. The dropdown and locus-goto paths are unaffected, and
   neither defect is fixed.
-- Padlocks can still disagree, but only when a peer's dataset lacks the matching
-  resolution rung. Named, not defended against.
+- Padlocks agree in every case reachable through the UI. The rung-mismatch
+  divergence that decision 3 originally accepted is closed by mirroring the
+  auto-clears.
 - The next "why doesn't X sync?" request has a written answer, and re-opening it
   means superseding this ADR rather than re-arguing from scratch.

--- a/js/browserCoordinator.js
+++ b/js/browserCoordinator.js
@@ -135,8 +135,8 @@ class BrowserCoordinator {
 
         // 5. Update resolution selector
         if (this.widgets.resolutionSelector) {
-            this.browser.resolutionLocked = false;
-            this.widgets.resolutionSelector.setResolutionLock(false);
+            // Bookkeeping, not the user asking: never mirrored. ADR-0014 decision 3.
+            this.browser.setResolutionLocked(false);
             this.widgets.resolutionSelector.updateResolutions(this.browser.state.zoom);
         }
 
@@ -216,8 +216,9 @@ class BrowserCoordinator {
         // 3. Update resolution selector
         if (this.widgets.resolutionSelector) {
             if (resolutionChanged) {
-                this.browser.resolutionLocked = false;
-                this.widgets.resolutionSelector.setResolutionLock(false);
+                // Reached on the sync hot path. Local, never mirrored -- a peer
+                // whose own resolution moved clears its own lock. ADR-0014.
+                this.browser.setResolutionLocked(false);
             }
             if (chrChanged !== false) {
                 const isWholeGenome = this.browser.dataset.isWholeGenome(state.chr1);

--- a/js/browserCoordinator.js
+++ b/js/browserCoordinator.js
@@ -135,8 +135,10 @@ class BrowserCoordinator {
 
         // 5. Update resolution selector
         if (this.widgets.resolutionSelector) {
-            // Bookkeeping, not the user asking: never mirrored. ADR-0014 decision 3.
-            this.browser.setResolutionLocked(false);
+            // A new map voids the group's lock, not just this browser's.
+            // Reaches the peers because `clearDataset()` leaves this browser's
+            // own `synchedBrowsers` standing (#492). ADR-0014 decision 3.
+            this.browser.setResolutionLocked(false, {mirror: true});
             this.widgets.resolutionSelector.updateResolutions(this.browser.state.zoom);
         }
 
@@ -216,9 +218,10 @@ class BrowserCoordinator {
         // 3. Update resolution selector
         if (this.widgets.resolutionSelector) {
             if (resolutionChanged) {
-                // Reached on the sync hot path. Local, never mirrored -- a peer
-                // whose own resolution moved clears its own lock. ADR-0014.
-                this.browser.setResolutionLocked(false);
+                // The resolution moved, so the lock is void everywhere. Safe on
+                // the sync hot path because a peer already unlocked is a
+                // no-op that stops there. ADR-0014 decision 3.
+                this.browser.setResolutionLocked(false, {mirror: true});
             }
             if (chrChanged !== false) {
                 const isWholeGenome = this.browser.dataset.isWholeGenome(state.chr1);

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -1301,8 +1301,8 @@ class HICBrowser {
     }
 
     /**
-     * Set the resolution lock: the field, the padlock, and -- when the user is
-     * the one asking -- the peers.
+     * Set the resolution lock: the field, the padlock, and -- on a real
+     * transition -- the peers.
      *
      * The one writer for a **view preference** (`CONTEXT.md`), and the first of
      * the category to mirror across a sync group (ADR-0014). Three callers used
@@ -1313,15 +1313,28 @@ class HICBrowser {
      * left alone: it declares the field, and it runs before either the widget or
      * `synchedBrowsers` exists.
      *
-     * `mirror` is opt-in rather than opt-out, and only the widget's click passes
-     * it. The coordinator's two auto-clears sit on the sync hot path and stay
-     * local -- they already land on each browser independently, so fanning them
-     * out would broadcast during a drag to redo work that has happened anyway
-     * (ADR-0014 decision 3).
+     * **Every transition mirrors, not just the user's click.** The lock is a
+     * claim about the group, so whatever voids it on one browser voids it on all
+     * of them -- a resolution change, a map load, or the padlock being clicked
+     * open. The alternative, mirroring only the click, left the padlocks free to
+     * disagree in exactly the case that had already been flagged: a peer whose
+     * dataset lacks the matching rung reports `zoomChanged: false`, keeps its
+     * lock, and shows an icon the group has stopped agreeing with. Parity was
+     * the point of the feature, so tolerating a parity break was incoherent.
      *
-     * No recursion guard is needed and none is written: `pairSynchable` pairs
-     * every compatible combination, so one hop reaches the whole group, and the
-     * hop below does not pass `mirror`.
+     * `changed` is what makes that affordable. Without it every resolution
+     * change in a never-locked session would fan out to announce that nothing
+     * happened, and a mirrored clear would do O(N^2) hops as each peer's own
+     * auto-clear re-broadcast. With it the hot path is one comparison, fan-out
+     * happens only on a real transition, and the recursion question does not
+     * arise: a peer set to a value it already holds stops there.
+     *
+     * The map-load clear reaches the peers through a set `clearDataset()` has
+     * half torn down -- it removes this browser from *their* sets but leaves
+     * this browser's own, deliberately, because it is still on the page and
+     * `registry.sync()` re-pairs it (`hicBrowser.js:676`, #492). That asymmetry
+     * is documented intent, and it is what lets a map load say "the group's lock
+     * is void" on its way past.
      *
      * @param {boolean} locked
      * @param {Object} [options]
@@ -1329,7 +1342,13 @@ class HICBrowser {
      */
     setResolutionLocked(locked, {mirror = false} = {}) {
 
+        const changed = this.resolutionLocked !== locked;
         this.resolutionLocked = locked;
+
+        if (!changed) {
+            return;
+        }
+
         this.coordinator?.widgets?.resolutionSelector?.setResolutionLock(locked);
 
         if (mirror) {

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -1301,6 +1301,45 @@ class HICBrowser {
     }
 
     /**
+     * Set the resolution lock: the field, the padlock, and -- when the user is
+     * the one asking -- the peers.
+     *
+     * The one writer for a **view preference** (`CONTEXT.md`), and the first of
+     * the category to mirror across a sync group (ADR-0014). Three callers used
+     * to write `resolutionLocked` and separately remember to call
+     * `setResolutionLock` on the widget; forgetting the second half is a padlock
+     * that lies about the browser it sits on, so the pairing lives here instead
+     * of in each of them. The constructor's `this.resolutionLocked = false` is
+     * left alone: it declares the field, and it runs before either the widget or
+     * `synchedBrowsers` exists.
+     *
+     * `mirror` is opt-in rather than opt-out, and only the widget's click passes
+     * it. The coordinator's two auto-clears sit on the sync hot path and stay
+     * local -- they already land on each browser independently, so fanning them
+     * out would broadcast during a drag to redo work that has happened anyway
+     * (ADR-0014 decision 3).
+     *
+     * No recursion guard is needed and none is written: `pairSynchable` pairs
+     * every compatible combination, so one hop reaches the whole group, and the
+     * hop below does not pass `mirror`.
+     *
+     * @param {boolean} locked
+     * @param {Object} [options]
+     * @param {boolean} [options.mirror=false] - fan out to the sync group
+     */
+    setResolutionLocked(locked, {mirror = false} = {}) {
+
+        this.resolutionLocked = locked;
+        this.coordinator?.widgets?.resolutionSelector?.setResolutionLock(locked);
+
+        if (mirror) {
+            for (const browser of [...this.synchedBrowsers]) {
+                browser.setResolutionLocked(locked);
+            }
+        }
+    }
+
+    /**
      * Synchronize this browser's state to other synched browsers.
      * Called separately from rendering to keep concerns separated.
      */

--- a/js/hicResolutionSelector.js
+++ b/js/hicResolutionSelector.js
@@ -55,9 +55,11 @@ class ResolutionSelector {
         this.resolutionLockElement.className = 'fa fa-unlock';
         this.resolutionLockElement.setAttribute('aria-hidden', 'true');
         this.labelContainerElement.appendChild(this.resolutionLockElement);
+        // The only writer that mirrors. `setResolutionLocked` repaints this
+        // padlock on the way through, so there is no `setResolutionLock` call
+        // here -- and the peers get theirs the same way. ADR-0014.
         this.labelContainerElement.addEventListener('click', () => {
-            this.browser.resolutionLocked = !this.browser.resolutionLocked;
-            this.setResolutionLock(this.browser.resolutionLocked);
+            this.browser.setResolutionLocked(!this.browser.resolutionLocked, {mirror: true});
         });
 
         this.resolutionSelectorElement = document.createElement('select');

--- a/js/hicState.js
+++ b/js/hicState.js
@@ -490,11 +490,26 @@ class State {
         const chr2 = genome.getChromosome(targetState.chr2Name)
 
         const bpPerPixelTarget = targetState.binSize / targetState.pixelSize
-        // Matched against `browser.getResolutions()` rather than the raw
-        // `bpResolutions` array so a peer sitting at the sentinel rung is a rung
-        // this browser can follow it to. Same reason as everywhere else: array
-        // position and zoom index are not the same number.
-        const zoomNew = browser.findMatchingZoomIndex(bpPerPixelTarget, browser.getResolutions())
+
+        // The lock holds against a peer exactly as it holds against a local
+        // gesture -- same branch, same shape as `updateWithLoci`. Sync was the
+        // one path that never asked, which made the lock defeatable by touching
+        // a *different* browser: a locked peer re-derived a rung from the
+        // publisher's bpPerPixel, moved off the rung it was pinned to, and then
+        // had its lock auto-cleared for having moved. #608.
+        //
+        // What a locked receiver follows is the *scale*, not the rung: the
+        // pixelSize below solves for the publisher's bpPerPixel against the rung
+        // being held, so the two views stay aligned while their resolutions
+        // deliberately differ. That divergence is the point of the lock.
+        //
+        // Unlocked, matched against `browser.getResolutions()` rather than the
+        // raw `bpResolutions` array so a peer sitting at the sentinel rung is a
+        // rung this browser can follow it to. Same reason as everywhere else:
+        // array position and zoom index are not the same number.
+        const zoomNew = (true === browser.resolutionLocked)
+            ? this.zoom
+            : browser.findMatchingZoomIndex(bpPerPixelTarget, browser.getResolutions())
         const binSizeNew = dataset.binSizeForZoom(zoomNew)
 
         const xBinNew = targetState.binX * (targetState.binSize / binSizeNew)

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
-      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
       "dev": true,
       "funding": [
         {
@@ -184,9 +184,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
-      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
       "dev": true,
       "funding": [
         {
@@ -247,16 +247,16 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.146.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
-      "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
+      "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -577,9 +577,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm-eabi": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
-      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.6.tgz",
+      "integrity": "sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==",
       "cpu": [
         "arm"
       ],
@@ -594,9 +594,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
-      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.6.tgz",
+      "integrity": "sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==",
       "cpu": [
         "arm64"
       ],
@@ -611,9 +611,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
-      "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.6.tgz",
+      "integrity": "sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==",
       "cpu": [
         "arm64"
       ],
@@ -628,9 +628,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
-      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.6.tgz",
+      "integrity": "sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==",
       "cpu": [
         "x64"
       ],
@@ -645,9 +645,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
-      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.6.tgz",
+      "integrity": "sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==",
       "cpu": [
         "x64"
       ],
@@ -662,9 +662,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
-      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.6.tgz",
+      "integrity": "sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==",
       "cpu": [
         "arm"
       ],
@@ -679,9 +679,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
-      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.6.tgz",
+      "integrity": "sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==",
       "cpu": [
         "arm64"
       ],
@@ -699,9 +699,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
-      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.6.tgz",
+      "integrity": "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==",
       "cpu": [
         "arm64"
       ],
@@ -719,9 +719,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
-      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.6.tgz",
+      "integrity": "sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==",
       "cpu": [
         "ppc64"
       ],
@@ -739,9 +739,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
-      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.6.tgz",
+      "integrity": "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==",
       "cpu": [
         "s390x"
       ],
@@ -759,9 +759,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
-      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.6.tgz",
+      "integrity": "sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==",
       "cpu": [
         "x64"
       ],
@@ -779,9 +779,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
-      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.6.tgz",
+      "integrity": "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==",
       "cpu": [
         "x64"
       ],
@@ -799,9 +799,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
-      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.6.tgz",
+      "integrity": "sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==",
       "cpu": [
         "arm64"
       ],
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
-      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.6.tgz",
+      "integrity": "sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==",
       "cpu": [
         "arm64"
       ],
@@ -833,9 +833,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
-      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.6.tgz",
+      "integrity": "sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==",
       "cpu": [
         "x64"
       ],
@@ -1917,9 +1917,9 @@
       }
     },
     "node_modules/p-map": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
-      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.7.tgz",
+      "integrity": "sha512-VaWRu2i4FJNRtiRWCuuQRgfQ1B7a6+gMSrO+3j0EQi/k0ULfS9kosRxGoiqwzIjZTDI02tGfk5mXXltLg6QtfQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2033,13 +2033,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
-      "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.6.tgz",
+      "integrity": "sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.146.0",
+        "@oxc-project/types": "=0.147.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -2049,21 +2049,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm-eabi": "1.2.5",
-        "@rolldown/binding-android-arm64": "1.2.5",
-        "@rolldown/binding-darwin-arm64": "1.2.5",
-        "@rolldown/binding-darwin-x64": "1.2.5",
-        "@rolldown/binding-freebsd-x64": "1.2.5",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
-        "@rolldown/binding-linux-arm64-musl": "1.2.5",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
-        "@rolldown/binding-linux-x64-gnu": "1.2.5",
-        "@rolldown/binding-linux-x64-musl": "1.2.5",
-        "@rolldown/binding-openharmony-arm64": "1.2.5",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
-        "@rolldown/binding-win32-x64-msvc": "1.2.5"
+        "@rolldown/binding-android-arm-eabi": "1.2.6",
+        "@rolldown/binding-android-arm64": "1.2.6",
+        "@rolldown/binding-darwin-arm64": "1.2.6",
+        "@rolldown/binding-darwin-x64": "1.2.6",
+        "@rolldown/binding-freebsd-x64": "1.2.6",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.6",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.6",
+        "@rolldown/binding-linux-arm64-musl": "1.2.6",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.6",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-musl": "1.2.6",
+        "@rolldown/binding-openharmony-arm64": "1.2.6",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.6",
+        "@rolldown/binding-win32-x64-msvc": "1.2.6"
       }
     },
     "node_modules/sass": {

--- a/test/testResolutionLockMirror.js
+++ b/test/testResolutionLockMirror.js
@@ -4,19 +4,24 @@ import {withContainers} from './utils/browserFixture.js'
 import {withStubbedLoads} from './utils/stubbedLoads.js'
 
 /**
- * The resolution lock mirrors across a sync group; its auto-clears do not.
+ * The resolution lock mirrors across a sync group, on every transition.
  *
  * ADR-0014 draws the line between what *syncs* (canonical state, on every
- * update) and what *mirrors* (a view preference, on the user's action only),
- * and the resolution lock is the first preference on the mirror side. Both
- * halves need pinning, and the second is the one that would rot silently: a
- * later refactor routing the coordinator's auto-clears through the same call
- * with `mirror: true` would put a fan-out on the sync hot path, and nothing
- * about the feature would look broken.
+ * update) and what *mirrors* (a view preference, on any transition), and the
+ * resolution lock is the first preference on the mirror side. Whatever voids the
+ * lock on one browser voids it on all of them -- the padlock clicked open, a
+ * resolution change, a map load -- because parity is the point of the feature
+ * and a lock that survived on one panel would be a padlock the group has stopped
+ * agreeing with.
+ *
+ * What makes that affordable is the no-op guard, and that is the claim here most
+ * likely to rot: drop it and the suite still passes on behaviour while every
+ * resolution change in a never-locked session broadcasts to say nothing
+ * happened. It gets its own test for that reason.
  *
  * Two embeds throughout, per the house rule in `testDeleteAllUnsync.js` -- a
- * mirror that reached the whole page rather than the sync group would pass
- * every single-embed assertion.
+ * mirror that reached the whole page rather than the sync group would pass every
+ * single-embed assertion.
  */
 
 const session = (...urls) => ({browsers: urls.map(url => ({url}))})
@@ -96,9 +101,9 @@ describe('mirroring the resolution lock across a sync group', () => {
         expect([a.resolutionLocked, b.resolutionLocked]).toEqual([true, false])
     })
 
-    it('leaves peers alone when the coordinator auto-clears the lock', async () => {
-        // The claim that would rot silently. Both browsers are locked; only the
-        // one whose resolution actually changed comes back unlocked.
+    it('unlocks the peers too when a resolution change voids the lock', async () => {
+        // The auto-clear on the sync hot path. A peer that kept its lock here is
+        // the rung-mismatch divergence ADR-0014 decision 3 exists to close.
         const mine = registryForContainer(dom.container)
         await mine.restoreSession(session('https://example.com/a.hic', 'https://example.com/b.hic'))
         const [a, b] = mine.browsers
@@ -106,6 +111,56 @@ describe('mirroring the resolution lock across a sync group', () => {
 
         a.coordinator.onLocusChange({state: a.state, resolutionChanged: true, chrChanged: false})
 
-        expect([a.resolutionLocked, b.resolutionLocked]).toEqual([false, true])
+        expect([a.resolutionLocked, b.resolutionLocked]).toEqual([false, false])
+    })
+
+    it('unlocks the peers when a map is loaded into one panel', async () => {
+        // Decision 3b. Driven through the coordinator rather than through
+        // `loadHicFile`, which the fixture stubs wholesale -- the stub stands in
+        // for the network read and so never reaches `onMapLoaded` at all.
+        const mine = registryForContainer(dom.container)
+        await mine.restoreSession(session('https://example.com/a.hic', 'https://example.com/b.hic'))
+        const [a, b] = mine.browsers
+        a.setResolutionLocked(true, {mirror: true})
+        expect(b.resolutionLocked).toBe(true)
+
+        a.coordinator.onMapLoaded(a.dataset, a.state, a.dataset.datasetType)
+
+        expect([a.resolutionLocked, b.resolutionLocked]).toEqual([false, false])
+    })
+
+    it('still holds its peers after clearDataset, which is what lets a map load reach them', async () => {
+        // The mechanical precondition the test above rests on, and the one that
+        // could be taken away by a change that looks like tidying. Every map
+        // load opens with `clearDataset()`, which strips this browser from its
+        // peers' sets but deliberately leaves its own standing (#492) -- so the
+        // load can still address the group on its way past. Make that symmetric
+        // and decision 3b stops working, silently.
+        const mine = registryForContainer(dom.container)
+        await mine.restoreSession(session('https://example.com/a.hic', 'https://example.com/b.hic'))
+        const [a, b] = mine.browsers
+
+        a.clearDataset()
+
+        expect([...a.synchedBrowsers]).toEqual([b])
+        expect([...b.synchedBrowsers]).toEqual([])
+    })
+
+    it('does not fan out when the value already holds', async () => {
+        // The guard, asserted on the fan-out rather than on the field -- the
+        // field would read `false` either way. A never-locked session takes this
+        // path on every resolution change, which is why it must cost nothing.
+        const mine = registryForContainer(dom.container)
+        await mine.restoreSession(session('https://example.com/a.hic', 'https://example.com/b.hic'))
+        const [a, b] = mine.browsers
+        expect([a.resolutionLocked, b.resolutionLocked]).toEqual([false, false])
+
+        let reached = 0
+        const spied = b.setResolutionLocked.bind(b)
+        b.setResolutionLocked = (...args) => { reached += 1; return spied(...args) }
+
+        a.setResolutionLocked(false, {mirror: true})
+
+        expect(reached).toBe(0)
     })
 })

--- a/test/testResolutionLockMirror.js
+++ b/test/testResolutionLockMirror.js
@@ -2,6 +2,8 @@ import {describe, it, expect} from 'vitest'
 import {registryForContainer} from '../js/browserRegistry.js'
 import {withContainers} from './utils/browserFixture.js'
 import {withStubbedLoads} from './utils/stubbedLoads.js'
+import Genome from '../js/genome.js'
+import State from '../js/hicState.js'
 
 /**
  * The resolution lock mirrors across a sync group, on every transition.
@@ -144,6 +146,53 @@ describe('mirroring the resolution lock across a sync group', () => {
 
         expect([...a.synchedBrowsers]).toEqual([b])
         expect([...b.synchedBrowsers]).toEqual([])
+    })
+
+    it('holds its rung against a locked peer, and keeps both locks', async () => {
+        // #608, and the case that made the whole feature look broken: a locked
+        // zoom in one panel unlocked both. `State.sync` re-derived a rung from
+        // the publisher's bpPerPixel without consulting the receiver's lock, the
+        // receiver moved off the rung it was pinned to, its lock auto-cleared
+        // for having moved, and the mirror sent that clear back to the origin.
+        //
+        // Locked, the receiver follows the *scale* and holds the rung: same
+        // zoom, same pixelSize, no `zoomChanged`, no clear, nothing to mirror.
+        const mine = registryForContainer(dom.container)
+        await mine.restoreSession(session('https://example.com/a.hic', 'https://example.com/b.hic'))
+        const [a, b] = mine.browsers
+        for (const browser of [a, b]) {
+            browser.genome = new Genome(browser.dataset.genomeId, browser.dataset.chromosomes)
+            await browser.setState(new State(1, 1, 4, 0, 0, 1.5, 'NONE'))
+        }
+        a.setResolutionLocked(true, {mirror: true})
+
+        // The locked wheel zoom: rung frozen, pixelSize past the rung ratio, so
+        // an unlocked receiver would drop to the 50kb rung and take both locks
+        // down with it.
+        a.state.pixelSize = 2.6
+        await b.syncState(a.getSyncState())
+
+        expect(b.state.zoom).toBe(4)
+        expect(b.state.pixelSize).toBeCloseTo(2.6, 6)
+        expect([a.resolutionLocked, b.resolutionLocked]).toEqual([true, true])
+    })
+
+    it('still re-derives the peer\'s rung when nothing is locked', async () => {
+        // The other side of the same branch: unlocked, sync keeps its old
+        // behaviour and follows the publisher onto whatever rung its scale
+        // implies. The fix above is a branch, not a replacement.
+        const mine = registryForContainer(dom.container)
+        await mine.restoreSession(session('https://example.com/a.hic', 'https://example.com/b.hic'))
+        const [a, b] = mine.browsers
+        for (const browser of [a, b]) {
+            browser.genome = new Genome(browser.dataset.genomeId, browser.dataset.chromosomes)
+            await browser.setState(new State(1, 1, 4, 0, 0, 1.5, 'NONE'))
+        }
+
+        a.state.pixelSize = 2.6
+        await b.syncState(a.getSyncState())
+
+        expect(b.state.zoom).toBe(5)
     })
 
     it('does not fan out when the value already holds', async () => {

--- a/test/testResolutionLockMirror.js
+++ b/test/testResolutionLockMirror.js
@@ -1,0 +1,111 @@
+import {describe, it, expect} from 'vitest'
+import {registryForContainer} from '../js/browserRegistry.js'
+import {withContainers} from './utils/browserFixture.js'
+import {withStubbedLoads} from './utils/stubbedLoads.js'
+
+/**
+ * The resolution lock mirrors across a sync group; its auto-clears do not.
+ *
+ * ADR-0014 draws the line between what *syncs* (canonical state, on every
+ * update) and what *mirrors* (a view preference, on the user's action only),
+ * and the resolution lock is the first preference on the mirror side. Both
+ * halves need pinning, and the second is the one that would rot silently: a
+ * later refactor routing the coordinator's auto-clears through the same call
+ * with `mirror: true` would put a fan-out on the sync hot path, and nothing
+ * about the feature would look broken.
+ *
+ * Two embeds throughout, per the house rule in `testDeleteAllUnsync.js` -- a
+ * mirror that reached the whole page rather than the sync group would pass
+ * every single-embed assertion.
+ */
+
+const session = (...urls) => ({browsers: urls.map(url => ({url}))})
+
+describe('mirroring the resolution lock across a sync group', () => {
+
+    const dom = withContainers()
+    withStubbedLoads()
+
+    it('closes the padlock on every peer when the user closes one', async () => {
+        const mine = registryForContainer(dom.container)
+        await mine.restoreSession(session(
+            'https://example.com/a.hic',
+            'https://example.com/b.hic',
+            'https://example.com/c.hic',
+        ))
+        const [a, b, c] = mine.browsers
+        expect([...a.synchedBrowsers]).toEqual(expect.arrayContaining([b, c]))
+
+        a.setResolutionLocked(true, {mirror: true})
+
+        expect([a, b, c].map(browser => browser.resolutionLocked)).toEqual([true, true, true])
+    })
+
+    it('repaints each peer\'s padlock, not just its field', async () => {
+        // The half that used to be a separate call every writer had to
+        // remember. A mirrored browser whose field moved but whose icon did not
+        // is exactly the lying padlock the setter exists to prevent.
+        const mine = registryForContainer(dom.container)
+        await mine.restoreSession(session('https://example.com/a.hic', 'https://example.com/b.hic'))
+        const [a, b] = mine.browsers
+
+        a.setResolutionLocked(true, {mirror: true})
+
+        const icon = browser => browser.coordinator.widgets.resolutionSelector.resolutionLockElement
+        for (const browser of [a, b]) {
+            expect(icon(browser).classList.contains('fa-lock')).toBe(true)
+            expect(icon(browser).classList.contains('fa-unlock')).toBe(false)
+        }
+    })
+
+    it('opens every peer again when the user re-opens one', async () => {
+        const mine = registryForContainer(dom.container)
+        await mine.restoreSession(session('https://example.com/a.hic', 'https://example.com/b.hic'))
+        const [a, b] = mine.browsers
+
+        a.setResolutionLocked(true, {mirror: true})
+        b.setResolutionLocked(false, {mirror: true})
+
+        expect([a.resolutionLocked, b.resolutionLocked]).toEqual([false, false])
+    })
+
+    it('does not reach the other embed', async () => {
+        // Membership is the sync group, not the page. ADR-0014 decision 5.
+        const mine = registryForContainer(dom.container)
+        const theirs = registryForContainer(dom.another())
+        await mine.restoreSession(session('https://example.com/a.hic'))
+        await theirs.restoreSession(session('https://example.com/c.hic'))
+        const [a] = mine.browsers
+        const [c] = theirs.browsers
+
+        a.setResolutionLocked(true, {mirror: true})
+
+        expect(a.resolutionLocked).toBe(true)
+        expect(c.resolutionLocked).toBe(false)
+    })
+
+    it('does not mirror without being asked', async () => {
+        // The default. Every caller but the widget's click takes this path, so
+        // the default being `false` is what keeps the auto-clears local.
+        const mine = registryForContainer(dom.container)
+        await mine.restoreSession(session('https://example.com/a.hic', 'https://example.com/b.hic'))
+        const [a, b] = mine.browsers
+
+        a.setResolutionLocked(true)
+
+        expect([a.resolutionLocked, b.resolutionLocked]).toEqual([true, false])
+    })
+
+    it('leaves peers alone when the coordinator auto-clears the lock', async () => {
+        // The claim that would rot silently. Both browsers are locked; only the
+        // one whose resolution actually changed comes back unlocked.
+        const mine = registryForContainer(dom.container)
+        await mine.restoreSession(session('https://example.com/a.hic', 'https://example.com/b.hic'))
+        const [a, b] = mine.browsers
+        a.setResolutionLocked(true, {mirror: true})
+
+        a.coordinator.onLocusChange({state: a.state, resolutionChanged: true, chrChanged: false})
+
+        expect([a.resolutionLocked, b.resolutionLocked]).toEqual([false, true])
+    })
+})


### PR DESCRIPTION
Closes #608.

Toggling the padlock in one of N synced browsers now closes it in its peers, anything that voids the lock voids it everywhere, and — the part testing forced — a locked browser actually holds its rung against a peer.

## The rule came first

The same request applies verbatim to normalization, the colour scale, display mode and tracks, so answering it one widget at a time would have re-opened the argument on every future ask. **ADR-0014** writes the split down:

| Category | Travels the sync group as | Examples |
| --- | --- | --- |
| Canonical state | the sync payload, every update | the seven `State` fields |
| **View preference** | a mirror, on every transition | resolution lock |
| Dataset choice | nothing | normalization, colour scale, display mode, tracks |

`CONTEXT.md` gains **sync group**, **view preference**, and **resolution lock** — the last retiring "scale lock", which collided with both *colour scale* and *pixel size*.

## The change

**Mirroring.** `HICBrowser.setResolutionLocked(locked, {mirror})` is now the one writer. Three callers previously set `resolutionLocked` and separately remembered to repaint the padlock; forgetting the second half leaves an icon lying about the browser it sits on, so the pairing lives in the setter.

- **Every transition mirrors** — the click, the auto-clear on a resolution change, and the auto-clear on a map load. The lock is a claim about the group.
- **A write that changes nothing does nothing.** The early return is what makes that affordable: without it every resolution change in a never-locked session fans out to announce that nothing happened, and a mirrored clear does O(N²) hops. It also retires the recursion question.
- **Separate fan-out**, not a seventh field in `getSyncState` — that payload ships on every `update()`, and it *is* canonical state, which a view preference by definition is not.
- Nothing serialized, no public surface added.

**And the lock now holds against a peer** (`State.sync`, ADR-0014 decision 8). This was filed as #608 and deferred as a product decision rather than a repair. Testing showed it is not separable — see below.

## What testing found

Lock two synced browsers, wheel-zoom one:

```
BEFORE a: { zoom: 4, px: 1.5 }   BEFORE b: { zoom: 4, px: 1.5 }   both locked
a publishes: { binSize: 100000, pixelSize: 2.6 }   ← locked zoom, rung correctly held
AFTER  b: { zoom: 5, px: 1.3, locked: false }
AFTER  a: { zoom: 4, locked: false }
```

Both padlocks open, from one gesture. Three things compounding: `State.sync` re-derived a rung from the published `bpPerPixel` without consulting the receiver's lock; that reported `zoomChanged: true` so the receiver's lock auto-cleared; and the new mirror sent that clear back to the origin.

My earlier claim that mirroring would "incidentally mitigate #608 on gesture paths, since a locked peer's own wheel and drag honour the lock" was **wrong** — a peer receiving a sync is not gesturing, and sync was the one path that never asked about the lock. Mirroring made the defect worse, not better, which is why the fix lands here: decisions 1–7 describe a feature that does not survive its first gesture without it.

The fix is the branch `updateWithLoci` has always had. Locked, the receiver follows the **scale**, not the rung. Unlocked, `sync` is unchanged, and that is asserted rather than assumed.

## Consequences worth a reviewer's eye

- **Two locked browsers may sit on different rungs**, each holding its own and matching the other's `bpPerPixel`. Visually aligned, resolutions deliberately different. That is the lock working, not a defect.
- **A locked receiver that cannot reach the published scale within `MAX_PIXEL_SIZE` clamps** and diverges visually until the lock comes off — the same ceiling a locked sweep zoom already hits.
- **The map-load clear is included on the collaborator's call**, over the narrower reading that a map load is a panel reset rather than a resolution move. It works because `clearDataset()` strips the loading browser from its peers' sets but deliberately leaves its own standing (`hicBrowser.js:676`, #492). A map load that changes genome therefore unlocks the peers and *then* drops out of their group.

## Deferred

**Crosshairs** were the other half of the original request and are deferred whole. They turned out not to be a widget — they're a Shift-held transient driven by mousemove — and mirroring them raises a wire-unit question plus a real hazard: a mirrored crosshair routed through `updateCrosshairs` would fire each peer's `customCrosshairsHandler`, and Spacewalk's drives 3D bead highlighting under one shared key.

## Tests

Node-only per ADR-0013, two embeds throughout. Eleven cases. Three carry the weight:

- the **locked-peer sync**, which is the reproduction above as a permanent test;
- the **no-op guard**, asserted on the fan-out rather than the field — the field reads `false` either way, so behaviour alone would not catch its removal;
- the **`clearDataset` asymmetry** the map-load mirror rests on, which a plausible tidying would remove silently.

Full suite: 57 files, 1079 tests, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rv5xZB54jteXewVgKKukNA