### PR TITLE
The straw substitution is sticky, like the other two (#600)

### DIFF
--- a/docs/adr/0012-substitution-is-announced-in-the-widget.md
+++ b/docs/adr/0012-substitution-is-announced-in-the-widget.md
@@ -2,6 +2,9 @@
 
 **Status:** Accepted
 **Date:** 2026-08-25
+**Amended:** 2026-09-03 — decision 4 answers the question it deferred; see
+*Restated, and answered* below and the last of the explicit no-s. No decision is
+reversed: the amendment closes #600 in the direction decision 3 already required.
 **Related:** #372 (the 2022 report this settles), ADR-0009 decision 5 (which
 deferred the error UX to here), ADR-0003 (public API contract), #425 (the missing
 `Alert` import that made the original failure silent), #561, #600 (case 3's
@@ -103,4 +106,8 @@ that cannot work, which is worse than the silence this ADR is replacing.
   documented exception at `docs/state-manipulation.md:237`. Routing either through
   `browser.setNormalization` would trigger a repaint from inside a render pass —
   case 3's hook fires from inside a tile fetch — which is a re-entrancy hazard,
-  not a cleanup.
+  not a cleanup. They share one implementation, `HICBrowser.substituteNormalization`,
+  so "sticky, written direct, no repaint" is one rule in one place rather than a
+  convention each mid-render caller re-implements. Case 1 does not join them: its
+  state write belongs to `#resolveNormalization`'s caller, and its reason is one of
+  the other two.

--- a/docs/adr/0012-substitution-is-announced-in-the-widget.md
+++ b/docs/adr/0012-substitution-is-announced-in-the-widget.md
@@ -4,8 +4,8 @@
 **Date:** 2026-08-25
 **Related:** #372 (the 2022 report this settles), ADR-0009 decision 5 (which
 deferred the error UX to here), ADR-0003 (public API contract), #425 (the missing
-`Alert` import that made the original failure silent), #561, `CONTEXT.md`
-(*Substitution*)
+`Alert` import that made the original failure silent), #561, #600 (case 3's
+missing state write, restated under decision 4), `CONTEXT.md` (*Substitution*)
 
 ## Context
 
@@ -70,6 +70,13 @@ This also undermines **#600**, which was filed against the same mistaken premise
 The path is a substitution, not a failure, so the question that issue asks needs
 restating before it can be answered.
 
+Restated, and answered: #600 observed a real divergence — the widget said `NONE`
+while state still said `KR` — and, believing the path to be a failure, proposed
+deleting the widget update. Under this decision the remedy is the other one.
+Case 3 keeps its announcement and gains the state write decision 3 requires of
+every substitution, so it is sticky like the other two and the next render pass
+stops re-asking for a vector the file has already refused.
+
 **5. Which of the first two reasons applies is asked of the primary file.** With a
 control map loaded the offered set is an intersection, and a normalization missing
 from an intersection is missing for one of two causes with different remedies: the
@@ -92,7 +99,8 @@ that cannot work, which is worse than the silence this ADR is replacing.
   `await` is what makes decision 1 observable at all; the unit fixture missed it
   because its dataset double was synchronous where the real one is not.
 
-- **Case 2's direct `state.normalization` write stays outside the chokepoint.** It
-  is the documented exception at `docs/state-manipulation.md:237`. Routing it
-  through `browser.setNormalization` would trigger a repaint from inside a render
-  pass, which is a re-entrancy hazard, not a cleanup.
+- **Cases 2 and 3 write `state.normalization` outside the chokepoint.** It is the
+  documented exception at `docs/state-manipulation.md:237`. Routing either through
+  `browser.setNormalization` would trigger a repaint from inside a render pass —
+  case 3's hook fires from inside a tile fetch — which is a re-entrancy hazard,
+  not a cleanup.

--- a/docs/state-manipulation.md
+++ b/docs/state-manipulation.md
@@ -234,7 +234,7 @@ The replacement is followed by a render and the application continues normally �
 
 **The state field has exactly one writer.** `browser.state` and its `activeState` alias are getters over a private field; the setters that used to stand beside them are gone (#563, ADR-0009 decision 7). Reading canonical state is unrestricted, here as everywhere; *replacing* it is `setState`.
 
-That is the field, not the object. The getter hands back the live `State`, so a `browser.state.<field> = x` from outside is still reachable — and for `normalization`, three production sites do it (see the next section). For the canonical six, the discipline that stops it is the same one it always was: they are written through translators, by convention, and `setView` is where the invariants are enforced.
+That is the field, not the object. The getter hands back the live `State`, so a `browser.state.<field> = x` from outside is still reachable — and for `normalization` three production sites do it: `HICBrowser.init`, and the two mid-render callers that both go through `HICBrowser.substituteNormalization` — `imageTileSource` (via the observer in `createWidgets`) and hic-straw's `alert` hook (via `dataLoader`), which write directly because they run inside a render pass and `setNormalization` repaints (#600, ADR-0012 decision 3). For the canonical six, the discipline that stops it is the same one it always was: they are written through translators, by convention, and `setView` is where the invariants are enforced.
 
 ## What is NOT a state mutation
 

--- a/docs/state-manipulation.md
+++ b/docs/state-manipulation.md
@@ -234,7 +234,7 @@ The replacement is followed by a render and the application continues normally �
 
 **The state field has exactly one writer.** `browser.state` and its `activeState` alias are getters over a private field; the setters that used to stand beside them are gone (#563, ADR-0009 decision 7). Reading canonical state is unrestricted, here as everywhere; *replacing* it is `setState`.
 
-That is the field, not the object. The getter hands back the live `State`, so a `browser.state.<field> = x` from outside is still reachable — and for `normalization`, two production sites do it (see the next section). For the canonical six, the discipline that stops it is the same one it always was: they are written through translators, by convention, and `setView` is where the invariants are enforced.
+That is the field, not the object. The getter hands back the live `State`, so a `browser.state.<field> = x` from outside is still reachable — and for `normalization`, three production sites do it (see the next section). For the canonical six, the discipline that stops it is the same one it always was: they are written through translators, by convention, and `setView` is where the invariants are enforced.
 
 ## What is NOT a state mutation
 

--- a/js/createWidgets.js
+++ b/js/createWidgets.js
@@ -25,7 +25,7 @@ import LocusGoto from "./hicLocusGoto.js"
 import ResolutionSelector from "./hicResolutionSelector.js"
 import ColorScaleWidget from "./hicColorScaleWidget.js"
 import ControlMapWidget from "./controlMapWidget.js"
-import NormalizationWidget, {substitutionReason} from "./normalizationWidget.js"
+import NormalizationWidget from "./normalizationWidget.js"
 import {getNavbarContainer} from "./layoutController.js"
 import SweepZoom from "./sweepZoom.js"
 import ScrollbarWidget from "./scrollbarWidget.js"
@@ -101,20 +101,12 @@ function createWidgets(browser) {
             // failure and the widget is the surface. Same notification path as
             // the restore-time coercion, different reason -- here the remedy is
             // to pan or zoom.
-            normalizationSubstituted: (requested, effective) => {
-                // The source never writes canonical state, so the correction
-                // lands here. Still outside the setView chokepoint, as it was
-                // before -- routing it through `browser.setNormalization` would
-                // repaint from inside a render pass. See the known
-                // inconsistency noted in docs/state-manipulation.md.
-                if (browser.state) {
-                    browser.state.normalization = effective;
-                }
-                coordinator.onNormalizationSubstituted(
-                    effective,
-                    substitutionReason.notAtThisView(requested, effective)
-                );
-            },
+            // The source never writes canonical state, so the correction lands
+            // on the browser -- which holds the whole rule, shared with the
+            // other mid-render caller in `dataLoader`: sticky, written direct,
+            // no repaint from inside a render pass.
+            normalizationSubstituted: (requested, effective) =>
+                browser.substituteNormalization(requested, effective),
 
             // Resolved lazily: the browser does not hold its contact matrix view
             // until this function has returned.

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -36,7 +36,6 @@ import Track2D from './track2D.js'
 
 import {decodeState} from "./sessionCodec.js"
 import {mapTrackConfig} from "./urlMapper.js"
-import {substitutionReason} from "./normalizationWidget.js"
 
 /**
  * How this module reports a `config.state` that is neither a state token nor a
@@ -82,32 +81,19 @@ class DataLoader {
      * reason is rebuilt from what the browser already knows: `state.normalization`
      * is what was asked for at the moment the vector was refused.
      *
-     * And the substitution is made sticky, which is #600 restated. The issue was
-     * filed while this hook was still believed to be a read-failure channel, and
-     * asked for the widget update to be deleted; decision 4 retired that premise,
-     * leaving the opposite defect. Decision 3 says state is rewritten to name what
-     * is drawn -- the two sibling paths, `#resolveNormalization` and
-     * `createWidgets`' `normalizationSubstituted`, both do it -- and this one did
-     * not, so the widget read `NONE` while canonical state still read `KR` and the
-     * next render pass re-asked for a vector the file had already refused.
-     *
-     * The write is direct rather than through `browser.setNormalization`, for the
-     * same reason `createWidgets` writes directly: the hook fires from inside a
-     * tile fetch, so repainting from it is a re-entrancy hazard. It is the
-     * exception documented at `docs/state-manipulation.md`.
+     * And it is sticky, which is #600 restated. The issue was filed while this
+     * hook was still believed to be a read-failure channel, and asked for the
+     * widget update to be deleted; decision 4 retired that premise, leaving the
+     * opposite defect -- the widget read `NONE` while canonical state still read
+     * `KR`, so the next render pass re-asked for a vector the file had already
+     * refused. `browser.substituteNormalization` is where the rest of that rule
+     * lives, shared with the mid-render caller in `createWidgets`; the guard on
+     * an absent or already-`NONE` request is its, not this hook's.
      *
      * @returns {(str: string) => void} the callback, closed over this browser
      */
     #announceStrawSubstitution() {
-        return () => {
-            const requested = this.browser.state?.normalization;
-            if (!requested || 'NONE' === requested) return;
-            this.browser.state.normalization = 'NONE';
-            this.browser.coordinator.onNormalizationSubstituted(
-                'NONE',
-                substitutionReason.notAtThisView(requested, 'NONE')
-            );
-        };
+        return () => this.browser.substituteNormalization(this.browser.state?.normalization, 'NONE');
     }
 
     /**

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -82,12 +82,27 @@ class DataLoader {
      * reason is rebuilt from what the browser already knows: `state.normalization`
      * is what was asked for at the moment the vector was refused.
      *
+     * And the substitution is made sticky, which is #600 restated. The issue was
+     * filed while this hook was still believed to be a read-failure channel, and
+     * asked for the widget update to be deleted; decision 4 retired that premise,
+     * leaving the opposite defect. Decision 3 says state is rewritten to name what
+     * is drawn -- the two sibling paths, `#resolveNormalization` and
+     * `createWidgets`' `normalizationSubstituted`, both do it -- and this one did
+     * not, so the widget read `NONE` while canonical state still read `KR` and the
+     * next render pass re-asked for a vector the file had already refused.
+     *
+     * The write is direct rather than through `browser.setNormalization`, for the
+     * same reason `createWidgets` writes directly: the hook fires from inside a
+     * tile fetch, so repainting from it is a re-entrancy hazard. It is the
+     * exception documented at `docs/state-manipulation.md`.
+     *
      * @returns {(str: string) => void} the callback, closed over this browser
      */
     #announceStrawSubstitution() {
         return () => {
             const requested = this.browser.state?.normalization;
             if (!requested || 'NONE' === requested) return;
+            this.browser.state.normalization = 'NONE';
             this.browser.coordinator.onNormalizationSubstituted(
                 'NONE',
                 substitutionReason.notAtThisView(requested, 'NONE')

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -84,10 +84,11 @@ class HICBrowser {
      *
      * The field, not the object. The getter hands back the live `State`, so
      * `browser.state.normalization = x` still writes canonical state from
-     * outside -- and two production sites do exactly that, `createWidgets`'
-     * `normalizationSubstituted` and `init`. `normalization` is not one of the
-     * canonical six and `setView` does not take it; what it has instead is one
-     * enforcer, `#resolveNormalization`. See `docs/state-manipulation.md`.
+     * outside -- and three production sites do exactly that, `createWidgets`'
+     * `normalizationSubstituted`, `dataLoader.#announceStrawSubstitution` (#600)
+     * and `init`. `normalization` is not one of the canonical six and `setView`
+     * does not take it; what it has instead is one enforcer,
+     * `#resolveNormalization`. See `docs/state-manipulation.md`.
      */
     #state
 

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -84,10 +84,10 @@ class HICBrowser {
      *
      * The field, not the object. The getter hands back the live `State`, so
      * `browser.state.normalization = x` still writes canonical state from
-     * outside -- and three production sites do exactly that, `createWidgets`'
-     * `normalizationSubstituted`, `dataLoader.#announceStrawSubstitution` (#600)
-     * and `init`. `normalization` is not one of the canonical six and `setView`
-     * does not take it; what it has instead is one enforcer,
+     * outside -- and three production sites do exactly that: `init`, and the two
+     * mid-render callers that both reach it through `substituteNormalization`
+     * below (#600). `normalization` is not one of the canonical six and
+     * `setView` does not take it; what it has instead is one enforcer,
      * `#resolveNormalization`. See `docs/state-manipulation.md`.
      */
     #state
@@ -1270,6 +1270,45 @@ class HICBrowser {
             this.#state.normalization = normalization;
         }
         this.coordinator.onNormalizationChange(this.#state?.normalization);
+    }
+
+    /**
+     * Record a substitution: the view is being drawn with something other than
+     * what was asked for, because what was asked for is not on offer here.
+     *
+     * The sibling of `setNormalization` above, and deliberately not a call to
+     * it. `setNormalization` is the user answering the question and repaints on
+     * the way out; a substitution is discovered *during* a render pass -- by
+     * `imageTileSource`, or by hic-straw's `alert` hook from inside a tile
+     * fetch -- and repainting from there is a re-entrancy hazard, not a
+     * cleanup. So the write is direct, which is the exception documented at
+     * `docs/state-manipulation.md`.
+     *
+     * Sticky, per ADR-0012 decision 3: state is rewritten to name what is
+     * drawn, so a zoom back out to a resolution that does carry the vector
+     * stays on the substitute until the user asks again. Keeping the request in
+     * state and re-attempting each pass is the lie ADR-0009 removed.
+     *
+     * Both mid-render callers land here rather than each writing the triple out
+     * themselves, so "sticky, direct, no repaint" is one rule in one place.
+     * `#announceSubstitution` does not: it is the restore-time coercion, whose
+     * state write belongs to `#resolveNormalization`'s caller and whose reason
+     * is one of the other two.
+     *
+     * @param {string|undefined} requested - what the render pass asked for
+     * @param {string} effective - what it can actually draw with
+     */
+    substituteNormalization(requested, effective) {
+
+        if (!this.#state || !requested || requested === effective) {
+            return;
+        }
+
+        this.#state.normalization = effective;
+        this.coordinator.onNormalizationSubstituted(
+            effective,
+            substitutionReason.notAtThisView(requested, effective)
+        );
     }
 
     async shiftPixels(dx, dy) {

--- a/test/testStrawSubstitution.js
+++ b/test/testStrawSubstitution.js
@@ -1,0 +1,129 @@
+/**
+ * hic-straw's `alert` hook is a substitution channel, and a substitution is
+ * sticky. #600, restated by ADR-0012 decision 4.
+ *
+ * The issue was filed against the premise that this hook is a read-failure
+ * channel, and asked for the widget update to be deleted. Decision 4 retired
+ * that premise: the hook has exactly one caller in the library, and it fires
+ * when a vector is absent at this chromosome and resolution -- the same event
+ * `imageTileSource` reports one layer up. So the announcement stays.
+ *
+ * What was left behind is the other half of it. Decision 3 says a substitution
+ * is sticky: state is rewritten to name what is drawn, because a state that
+ * still names the request is the lie ADR-0009 removed, and the next render pass
+ * re-asks for a vector the file has already refused. The two sibling paths --
+ * `#resolveNormalization` and `createWidgets`' `normalizationSubstituted` --
+ * both write it. This one did not, so the widget read NONE while canonical
+ * state still read KR.
+ *
+ * The write is a direct field assignment rather than `setNormalization`, for
+ * the same reason `createWidgets` makes it directly: the hook fires from inside
+ * a tile fetch, and repainting from there is a re-entrancy hazard. It is the
+ * exception documented at `docs/state-manipulation.md`.
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+const loadDataset = vi.fn();
+
+vi.mock('../js/hicDataset.js', () => ({
+    default: { loadDataset: (...args) => loadDataset(...args) },
+    HiCDataset: class {}
+}));
+
+const { default: DataLoader } = await import("../js/dataLoader.js");
+
+function stubBrowser(normalization) {
+    return {
+        state: { normalization },
+        substituted: [],
+        clearDataset: () => undefined,
+        stopSpinner: () => undefined,
+        contactMatrixView: { startSpinner: () => undefined },
+        contactMapLabel: { textContent: "", title: "" },
+        userInteractionShield: { style: {} },
+        controlDataset: undefined,
+        controlUrl: undefined,
+        registry: { presentAlert: () => undefined },
+        get coordinator() {
+            return {
+                onNormalizationSubstituted: (normalization, reason) =>
+                    this.substituted.push({ normalization, reason })
+            };
+        }
+    };
+}
+
+/**
+ * Run a load far enough to capture the `alert` hook it hands to hic-straw, and
+ * hand back the hook itself. The load is failed deliberately: what is under
+ * test is the callback that was passed in, and nothing past the call needs to
+ * run for it to exist.
+ */
+async function captureStrawAlert(browser, load) {
+    loadDataset.mockRejectedValue(Error("stop here"));
+    await load(new DataLoader(browser)).catch(() => undefined);
+    return loadDataset.mock.calls[0][0].alert;
+}
+
+describe("the hic-straw alert hook is a sticky substitution (#600)", () => {
+
+    beforeEach(() => {
+        loadDataset.mockReset();
+    });
+
+    test("it announces the substitution in the widget", async () => {
+        const browser = stubBrowser('KR');
+        const alert = await captureStrawAlert(browser, loader =>
+            loader.loadHicFile({ url: "https://example.com/x.hic" }));
+
+        alert("Normalization option KR not available at resolution 10000. Will use NONE.");
+
+        expect(browser.substituted).toHaveLength(1);
+        expect(browser.substituted[0].normalization).toBe('NONE');
+        expect(browser.substituted[0].reason).toContain('KR');
+    });
+
+    test("it writes canonical state, so the widget and the state agree", async () => {
+        const browser = stubBrowser('KR');
+        const alert = await captureStrawAlert(browser, loader =>
+            loader.loadHicFile({ url: "https://example.com/x.hic" }));
+
+        alert("Normalization option KR not available at resolution 10000. Will use NONE.");
+
+        expect(browser.state.normalization).toBe('NONE');
+    });
+
+    test("the control map's loader is the same hook, and is sticky too", async () => {
+        const browser = stubBrowser('SCALE');
+        const alert = await captureStrawAlert(browser, loader =>
+            loader.loadHicControlFile({ url: "https://example.com/control.hic" }));
+
+        alert("Normalization option SCALE not available at resolution 10000. Will use NONE.");
+
+        expect(browser.state.normalization).toBe('NONE');
+        expect(browser.substituted).toHaveLength(1);
+    });
+
+    test("a request already on NONE was not substituted, so nothing is said", async () => {
+        const browser = stubBrowser('NONE');
+        const alert = await captureStrawAlert(browser, loader =>
+            loader.loadHicFile({ url: "https://example.com/x.hic" }));
+
+        alert("Normalization option NONE not available at resolution 10000. Will use NONE.");
+
+        expect(browser.substituted).toHaveLength(0);
+        expect(browser.state.normalization).toBe('NONE');
+    });
+
+    test("a browser with no state yet is left alone rather than grown one", async () => {
+        const browser = stubBrowser(undefined);
+        browser.state = undefined;
+        const alert = await captureStrawAlert(browser, loader =>
+            loader.loadHicFile({ url: "https://example.com/x.hic" }));
+
+        alert("Normalization option KR not available at resolution 10000. Will use NONE.");
+
+        expect(browser.state).toBeUndefined();
+        expect(browser.substituted).toHaveLength(0);
+    });
+});

--- a/test/testStrawSubstitution.js
+++ b/test/testStrawSubstitution.js
@@ -1,25 +1,20 @@
 /**
- * hic-straw's `alert` hook is a substitution channel, and a substitution is
- * sticky. #600, restated by ADR-0012 decision 4.
+ * hic-straw's `alert` hook is a substitution channel, and it hands the
+ * substitution to the browser. #600, restated by ADR-0012 decision 4.
  *
  * The issue was filed against the premise that this hook is a read-failure
  * channel, and asked for the widget update to be deleted. Decision 4 retired
  * that premise: the hook has exactly one caller in the library, and it fires
  * when a vector is absent at this chromosome and resolution -- the same event
- * `imageTileSource` reports one layer up. So the announcement stays.
+ * `imageTileSource` reports one layer up. So the announcement stays, and what
+ * was missing is the other half of it, decision 3's sticky state write.
  *
- * What was left behind is the other half of it. Decision 3 says a substitution
- * is sticky: state is rewritten to name what is drawn, because a state that
- * still names the request is the lie ADR-0009 removed, and the next render pass
- * re-asks for a vector the file has already refused. The two sibling paths --
- * `#resolveNormalization` and `createWidgets`' `normalizationSubstituted` --
- * both write it. This one did not, so the widget read NONE while canonical
- * state still read KR.
- *
- * The write is a direct field assignment rather than `setNormalization`, for
- * the same reason `createWidgets` makes it directly: the hook fires from inside
- * a tile fetch, and repainting from there is a re-entrancy hazard. It is the
- * exception documented at `docs/state-manipulation.md`.
+ * That rule is not written out here. It lives on `browser.substituteNormalization`,
+ * shared with the mid-render caller in `createWidgets`, and is driven at its own
+ * seam by `testSubstitutionIsSticky.js` against a real browser. What this file
+ * claims is narrower and is the loader's own: both `.hic` loads install the
+ * hook, and the hook reports the request that was refused rather than inventing
+ * one.
  */
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 
@@ -34,7 +29,7 @@ const { default: DataLoader } = await import("../js/dataLoader.js");
 
 function stubBrowser(normalization) {
     return {
-        state: { normalization },
+        state: undefined === normalization ? undefined : { normalization },
         substituted: [],
         clearDataset: () => undefined,
         stopSpinner: () => undefined,
@@ -44,11 +39,8 @@ function stubBrowser(normalization) {
         controlDataset: undefined,
         controlUrl: undefined,
         registry: { presentAlert: () => undefined },
-        get coordinator() {
-            return {
-                onNormalizationSubstituted: (normalization, reason) =>
-                    this.substituted.push({ normalization, reason })
-            };
+        substituteNormalization(requested, effective) {
+            this.substituted.push({ requested, effective });
         }
     };
 }
@@ -65,65 +57,55 @@ async function captureStrawAlert(browser, load) {
     return loadDataset.mock.calls[0][0].alert;
 }
 
-describe("the hic-straw alert hook is a sticky substitution (#600)", () => {
+const REFUSAL = "Normalization option KR not available at resolution 10000. Will use NONE.";
+
+describe("the hic-straw alert hook reports a substitution (#600)", () => {
 
     beforeEach(() => {
         loadDataset.mockReset();
     });
 
-    test("it announces the substitution in the widget", async () => {
+    test("it names the refused request and NONE as what will be drawn", async () => {
         const browser = stubBrowser('KR');
         const alert = await captureStrawAlert(browser, loader =>
             loader.loadHicFile({ url: "https://example.com/x.hic" }));
 
-        alert("Normalization option KR not available at resolution 10000. Will use NONE.");
+        alert(REFUSAL);
 
-        expect(browser.substituted).toHaveLength(1);
-        expect(browser.substituted[0].normalization).toBe('NONE');
-        expect(browser.substituted[0].reason).toContain('KR');
+        expect(browser.substituted).toEqual([{ requested: 'KR', effective: 'NONE' }]);
     });
 
-    test("it writes canonical state, so the widget and the state agree", async () => {
-        const browser = stubBrowser('KR');
-        const alert = await captureStrawAlert(browser, loader =>
-            loader.loadHicFile({ url: "https://example.com/x.hic" }));
-
-        alert("Normalization option KR not available at resolution 10000. Will use NONE.");
-
-        expect(browser.state.normalization).toBe('NONE');
-    });
-
-    test("the control map's loader is the same hook, and is sticky too", async () => {
+    test("the control map's loader installs the same hook", async () => {
         const browser = stubBrowser('SCALE');
         const alert = await captureStrawAlert(browser, loader =>
             loader.loadHicControlFile({ url: "https://example.com/control.hic" }));
 
-        alert("Normalization option SCALE not available at resolution 10000. Will use NONE.");
+        alert(REFUSAL);
 
-        expect(browser.state.normalization).toBe('NONE');
-        expect(browser.substituted).toHaveLength(1);
+        expect(browser.substituted).toEqual([{ requested: 'SCALE', effective: 'NONE' }]);
     });
 
-    test("a request already on NONE was not substituted, so nothing is said", async () => {
-        const browser = stubBrowser('NONE');
+    test("the request is read from state, not from hic-straw's sentence", async () => {
+
+        // hic-straw hands over a formatted sentence rather than the pieces. The
+        // sentence here names VC and state names KR; the browser is told what
+        // was actually asked for, which is the thing the widget must explain.
+        const browser = stubBrowser('KR');
         const alert = await captureStrawAlert(browser, loader =>
             loader.loadHicFile({ url: "https://example.com/x.hic" }));
 
-        alert("Normalization option NONE not available at resolution 10000. Will use NONE.");
+        alert("Normalization option VC not available at resolution 10000. Will use NONE.");
 
-        expect(browser.substituted).toHaveLength(0);
-        expect(browser.state.normalization).toBe('NONE');
+        expect(browser.substituted[0].requested).toBe('KR');
     });
 
-    test("a browser with no state yet is left alone rather than grown one", async () => {
+    test("a browser with no state yet asks for nothing, so nothing is reported", async () => {
         const browser = stubBrowser(undefined);
-        browser.state = undefined;
         const alert = await captureStrawAlert(browser, loader =>
             loader.loadHicFile({ url: "https://example.com/x.hic" }));
 
-        alert("Normalization option KR not available at resolution 10000. Will use NONE.");
+        alert(REFUSAL);
 
-        expect(browser.state).toBeUndefined();
-        expect(browser.substituted).toHaveLength(0);
+        expect(browser.substituted).toEqual([{ requested: undefined, effective: 'NONE' }]);
     });
 });

--- a/test/testSubstitutionIsSticky.js
+++ b/test/testSubstitutionIsSticky.js
@@ -1,0 +1,133 @@
+/**
+ * A substitution is sticky: state is rewritten to name what is drawn.
+ * ADR-0012 decision 3, #600.
+ *
+ * `browser.substituteNormalization` is where that rule lives, and it has two
+ * mid-render callers -- `imageTileSource`, via the observer wired in
+ * `createWidgets`, and hic-straw's `alert` hook, via `dataLoader`. Both used to
+ * write the triple out themselves and only one of them wrote the state half, so
+ * the widget read `NONE` while canonical state still read `KR` and the next
+ * render pass re-asked for a vector the file had already refused. That is #600,
+ * restated by decision 4.
+ *
+ * Driven against a real browser rather than a stub, because the claim is about
+ * canonical state and about the announcement reaching the coordinator -- a stub
+ * that implemented either would be asserting its own behaviour. The loaders'
+ * own seam, "both loads install the hook and report the right request", is in
+ * `testStrawSubstitution.js`.
+ *
+ * The write is direct rather than through `setNormalization`, and that is not
+ * an oversight to be tidied later: both callers are inside a render pass, and
+ * `setNormalization` repaints. It is the exception documented at
+ * `docs/state-manipulation.md`. The last test here is what would notice if
+ * someone routed it through the chokepoint.
+ */
+import {describe, expect, test, vi} from 'vitest'
+import State from '../js/hicState.js'
+import {restoreFixture} from './utils/restoreFixture.js'
+
+vi.mock('../js/hicDataset.js', async () => {
+    const {restoreDataset, datasetModule} = await import('./utils/restoreDataset.js')
+    return datasetModule(config => {
+        const dataset = restoreDataset(config)
+        dataset.getNormalizationOptions = async () => ['NONE', 'VC', 'KR']
+        return dataset
+    })
+})
+
+const {default: HICBrowser} = await import('../js/hicBrowser.js')
+
+const HIC_URL = 'https://example.org/sticky-substitution.hic'
+
+/** chr1 x chr1 at 250kb bins, at an origin well inside the chromosome. */
+const savedWith = normalization => new State(1, 1, 3, 10, 10, 2, normalization)
+
+describe('a substitution is sticky (#600, ADR-0012 decision 3)', () => {
+
+    const {restore} = restoreFixture(HICBrowser, {suite: 'sticky substitution', url: HIC_URL})
+
+    /** A browser drawing KR, and a record of everything its coordinator is told. */
+    async function drawingKR() {
+        const browser = await restore(savedWith('KR'))
+        const announced = []
+        vi.spyOn(browser.coordinator, 'onNormalizationSubstituted')
+            .mockImplementation((normalization, reason) => announced.push({normalization, reason}))
+        return {browser, announced}
+    }
+
+    test('state is rewritten to name what is drawn', async () => {
+
+        const {browser} = await drawingKR()
+
+        browser.substituteNormalization('KR', 'NONE')
+
+        expect(browser.state.normalization).toBe('NONE')
+    })
+
+    test('the widget is told, with the reason that names this view', async () => {
+
+        const {browser, announced} = await drawingKR()
+
+        browser.substituteNormalization('KR', 'NONE')
+
+        expect(announced).toHaveLength(1)
+        expect(announced[0].normalization).toBe('NONE')
+        // The remedy for this reason, and the one that separates it from the
+        // other two: the vector exists, just not here.
+        expect(announced[0].reason).toContain('KR')
+        expect(announced[0].reason).toMatch(/zoom/i)
+    })
+
+    test('it stays substituted -- a second pass has nothing left to substitute', async () => {
+
+        // Stickiness is the point. Once state names NONE the next render pass
+        // asks for NONE, gets it, and says nothing; the alternative is keeping
+        // the request in state and re-attempting every pass, which is the lie
+        // ADR-0009 removed.
+        const {browser, announced} = await drawingKR()
+
+        browser.substituteNormalization('KR', 'NONE')
+        browser.substituteNormalization(browser.state.normalization, 'NONE')
+
+        expect(browser.state.normalization).toBe('NONE')
+        expect(announced).toHaveLength(1)
+    })
+
+    test('nothing was substituted when the request is what is drawn', async () => {
+
+        const {browser, announced} = await drawingKR()
+
+        browser.substituteNormalization('KR', 'KR')
+
+        expect(browser.state.normalization).toBe('KR')
+        expect(announced).toHaveLength(0)
+    })
+
+    test('a caller that asked for nothing is not a substitution', async () => {
+
+        // The hic-straw hook reports whatever state held at the moment the
+        // vector was refused, and that can be nothing at all -- a refusal
+        // arriving before a state exists. Guarded here, once, rather than at
+        // each caller.
+        const {browser, announced} = await drawingKR()
+
+        browser.substituteNormalization(undefined, 'NONE')
+
+        expect(browser.state.normalization).toBe('KR')
+        expect(announced).toHaveLength(0)
+    })
+
+    test('it does not repaint, because both callers are inside a render pass', async () => {
+
+        // `setNormalization` is the user answering the question and repaints on
+        // the way out. Routing a substitution through it would repaint from
+        // inside the render pass that discovered the substitution.
+        const {browser} = await drawingKR()
+        const changed = vi.spyOn(browser.coordinator, 'onNormalizationChange')
+            .mockImplementation(() => undefined)
+
+        browser.substituteNormalization('KR', 'NONE')
+
+        expect(changed).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
Closes #600.

## Read the issue with care — it is stale

#600 asks for a two-line deletion at `dataLoader.js:101` and `:327`. Neither line
exists any more: #372's PR rewrote both sites, and the call it names
(`onNormalizationExternalChange`) has since been renamed. More to the point, the
issue was filed against a premise that [ADR-0012](https://github.com/aidenlab/juicebox.js/blob/master/docs/adr/0012-substitution-is-announced-in-the-widget.md)
decision 4 has already retired — that hic-straw's `alert` hook is a read-failure
channel — and that decision says so by name:

> This also undermines **#600** ... The path is a substitution, not a failure, so
> the question that issue asks needs restating before it can be answered.

## Restated, and answered

The divergence #600 observed is real: the widget read `NONE` while canonical
state still read `KR`. But the hook is a *substitution* channel, so deleting the
widget update would restore the silence ADR-0012 removed. The remedy is the other
one — decision 3 requires a substitution to be **sticky**, and this path never
wrote state, so the next render pass re-asked for a vector the file had already
refused.

The two sibling paths both wrote it; this one did not.

## The change

`HICBrowser.substituteNormalization` now holds the whole rule — sticky, written
direct, no repaint — and the two mid-render callers delegate to it:

- `imageTileSource`, via the observer wired in `createWidgets`
- hic-straw's `alert` hook, via `dataLoader`

It sits beside `setNormalization` and is deliberately **not** a call to it. That
sibling is the user answering the question and repaints on the way out; a
substitution is discovered *during* a render pass — case 3's hook fires from
inside a tile fetch — so repainting from there is a re-entrancy hazard. The direct
write is the exception documented at `docs/state-manipulation.md`.

Case 1 does not join them: its state write belongs to `#resolveNormalization`'s
caller, and its reason is one of the other two.

## Tests

- `testStrawSubstitution.js` — the loader's own claim: both loads install the
  hook, and it reports the request that was refused rather than parsing
  hic-straw's sentence.
- `testSubstitutionIsSticky.js` — the rule, against a **real** browser through the
  restore fixture rather than a stub that would be asserting its own behaviour.
  Sabotaging the state write turns two of its six red.

1091 tests pass across 60 files; build clean.

## Docs

ADR-0012 gains a dated amendment note (it now answers a question it had deferred;
no decision is reversed) and records the shared implementation. The "production
sites that write `state.normalization` directly" count in
`docs/state-manipulation.md` and the `hicBrowser` class doc now names the sites
rather than pointing at a section that never enumerated them.

## Review

Both `/code-review` axes ran. Spec passed and confirmed the restatement is a
reading of the governing ADR rather than a substitution of my own judgement.
Standards flagged the guard-write-notify duplication that the first commit
introduced — that is what the second commit extracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdVeYVDHunaWcZrK7gxNXT