### PR TITLE
init's normalization dropdown catches up with the resolved value (#603)

### DIFF
--- a/js/browserCoordinator.js
+++ b/js/browserCoordinator.js
@@ -319,6 +319,25 @@ class BrowserCoordinator {
     }
 
     /**
+     * Orchestrate the selector catching up with a normalization that has just
+     * been resolved.
+     *
+     * Distinct from `onNormalizationSubstituted`, which is the case where the
+     * answer differs from the request: that one also carries a reason and
+     * raises the marker. This is the quiet half -- the request survived, but the
+     * selector was built before the answer existed -- so it moves the selection
+     * and says nothing. Why the selector can be behind at all is written down
+     * once, at `NormalizationWidget.reselect` (#603).
+     *
+     * @param {string} normalization - the resolved normalization, as the state holds it
+     */
+    async onNormalizationResolved(normalization) {
+        if (this.widgets.normalizationWidget) {
+            await this.widgets.normalizationWidget.reselect(normalization);
+        }
+    }
+
+    /**
      * Orchestrate component updates for normalization file load status.
      * 
      * @param {string} status - Load status ("start" or "stop")

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -294,6 +294,20 @@ class HICBrowser {
             if (config.normalization) {
                 this.state.normalization = await this.#resolveNormalization(config.normalization);
                 await this.#announceSubstitution(config.normalization, this.state.normalization);
+
+                // And the selector catches up, because it cannot have been
+                // right before this line (#603). The mechanism is written down
+                // at `NormalizationWidget.reselect`; what is this call site's
+                // own is where it sits. It cannot move up, for the same reason
+                // the resolution above it cannot: `loadNormalizationFile`
+                // pushes types into `dataset.normalizationTypes`, and the
+                // enforcer reads exactly that set, so asking above the
+                // `Promise.all` would substitute away a normalization one of
+                // those files is about to supply. And it is after
+                // `#announceSubstitution` on purpose -- nothing on this path
+                // calls `clearSubstitution`, so a marker just raised survives
+                // it.
+                await this.coordinator.onNormalizationResolved(this.state.normalization);
             }
 
             // Below the normalization write, and pinned there (#575). A host's

--- a/js/normalizationWidget.js
+++ b/js/normalizationWidget.js
@@ -225,7 +225,73 @@ class NormalizationWidget {
         }
     }
 
+    /**
+     * Re-select the entry naming `normalization`, leaving the list alone.
+     *
+     * `updateOptions` decides what is selected by reading
+     * `browser.state.normalization` at the moment it runs, and on the `init`
+     * path it runs from inside the norm-vector-file load -- above the validated
+     * write of `config.normalization` (#603). Nothing else re-reads the state
+     * afterwards, so the selector can sit on a normalization that was never
+     * resolved. This is the re-selection that closes that gap, and it is a
+     * re-selection rather than a second `updateOptions` because the list itself
+     * is already right: only which entry is marked selected is stale, and
+     * asking for the list again means another `getNormalizationOptions()`,
+     * which on a `.hic` file reads the normalization vector index off the wire.
+     * The one case that does rebuild is the one where re-selecting cannot work
+     * -- a value with no entry to select.
+     *
+     * Waits on the list build first. `onNormVectorIndexLoad` calls
+     * `updateOptions` without awaiting it, so a rebuild can still be in flight
+     * here -- and a rebuild landing after this re-selection would overwrite it
+     * with the same stale reading again.
+     *
+     * Does **not** touch the substitution announcement, deliberately: only the
+     * change handler and `onNormalizationChange` clear it, because only a user
+     * answering the question makes it false (#372, ADR-0012).
+     *
+     * @param {string} normalization - the resolved normalization, as the state holds it
+     */
+    async reselect(normalization) {
+
+        await this._optionsUpdate;
+
+        if (this.normalizationSelector.value === normalization) {
+            return;
+        }
+
+        const offered = Array.from(this.normalizationSelector.options)
+            .some(option => option.value === normalization);
+
+        // A value with no entry to select means the list was built against a
+        // different set than the one the resolution read -- so rebuild rather
+        // than deselect everything, which is what a bare programmatic set would
+        // leave behind.
+        if (offered) {
+            this.setNormalizationProgrammatically(normalization);
+        } else {
+            await this.updateOptions();
+        }
+    }
+
+    /**
+     * Rebuild the `<option>` list from the dataset's offered normalizations.
+     *
+     * The in-flight build is kept so `reselect` can wait for it. What is kept
+     * is a *settled* copy: `onNormVectorIndexLoad` calls this without awaiting
+     * it, so a failed option read used to be nobody's rejection, and handing it
+     * to `reselect` bare would route it into `init` and turn a failed list
+     * build into a failed load -- the opposite of the load path's coerce-never-
+     * reject rule (ADR-0009 decision 2). Callers that do await get the real
+     * promise, rejection and all.
+     */
     async updateOptions() {
+        const update = this.#buildOptions();
+        this._optionsUpdate = update.catch(() => undefined);
+        return update;
+    }
+
+    async #buildOptions() {
         const labels = {
             NONE: 'None',
             VC: 'Coverage',

--- a/test/testInitNormalizationSelector.js
+++ b/test/testInitNormalizationSelector.js
@@ -1,0 +1,307 @@
+/**
+ * The normalization dropdown shows the *resolved* normalization after `init`.
+ * #603.
+ *
+ * `updateOptions` reads `browser.state.normalization` to decide which `<option>`
+ * is selected, and on the `init` path it is called from *inside* the
+ * norm-vector-file load:
+ *
+ *     config.normVectorFiles
+ *       -> dataLoader.loadNormalizationFile
+ *       -> coordinator.onNormVectorIndexLoad
+ *       -> normalizationWidget.updateOptions()
+ *
+ * That happens in `init`'s `Promise.all`, above the validated write of
+ * `config.normalization`. So the list is built against whatever `loadHicFile`
+ * left behind -- `config.state`'s normalization, or `NONE` -- and never against
+ * the resolved answer.
+ *
+ * No ordering fixes it. `loadNormalizationFile` pushes new types into
+ * `dataset.normalizationTypes`, and the enforcer reads exactly that set through
+ * `getNormalizationOptions`, so resolving any earlier would substitute away a
+ * normalization one of these files is about to supply. The fix is a re-sync
+ * after the validated write, which is what this file drives.
+ *
+ * Not #372. That ticket and ADR-0012 own *announcing* a substitution; the
+ * announcement is only borrowed here, to pin the fact the fix depends on --
+ * `updateOptions` does not call `clearSubstitution`, so a re-sync placed after
+ * `#announceSubstitution` does not silence the marker.
+ *
+ * The harness is `restoreFixture`, as in `testRestoreNormalization.js`, plus
+ * the one thing the norm-vector path asks of a dataset that the shared fixture
+ * does not carry: a `hicFile` that can answer `readNormalizationVectorFile`.
+ * The viewport is stated, not measured, for the reason ADR-0009 fact 5 gives.
+ */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+import State from '../js/hicState.js'
+import {restoreFixture} from './utils/restoreFixture.js'
+import {withDOM} from './utils/browserFixture.js'
+import NormalizationWidget, {substitutionReason} from '../js/normalizationWidget.js'
+
+/** What the loaded dataset offers. Set per test, read by the mock below. */
+let offered
+
+/** The types the `normVectorFiles` entry supplies when it is read. */
+let supplied
+
+vi.mock('../js/hicDataset.js', async () => {
+    const {restoreDataset, datasetModule} = await import('./utils/restoreDataset.js')
+    return datasetModule(config => {
+        const dataset = restoreDataset(config)
+        dataset.getNormalizationOptions = async () => offered
+        // The one field `loadNormalizationFile` guards on, plus the read it
+        // makes through it. Its `types` are what get pushed into
+        // `dataset.normalizationTypes` -- the set the enforcer would be asked
+        // about too early, if the resolution were hoisted.
+        dataset.hicFile = {
+            readNormalizationVectorFile: async () => ({types: supplied})
+        }
+        return dataset
+    })
+})
+
+const {default: HICBrowser} = await import('../js/hicBrowser.js')
+
+const HIC_URL = 'https://example.org/init-normalization-selector.hic'
+const NORM_VECTOR_FILE = 'https://example.org/init-normalization-selector.norm'
+
+/** chr1 x chr1 at 250kb bins. Only the normalization varies between tests. */
+const savedWith = normalization => new State(1, 1, 3, 10, 10, 2, normalization)
+
+describe("init's normalization dropdown shows the resolved normalization (#603)", () => {
+
+    const {embed} = restoreFixture(HICBrowser, {suite: 'init normalization selector', url: HIC_URL})
+
+    beforeEach(() => {
+        offered = ['NONE']
+        supplied = []
+    })
+
+    /** What the selector is actually showing. */
+    const selected = browser => browser.coordinator.widgets.normalizationWidget.normalizationSelector.value
+
+    /** The standing announcement, if any. */
+    const announcement = browser => {
+        const widget = browser.coordinator.widgets.normalizationWidget
+        return 'none' === widget.substitutionMarker.style.display ? undefined : widget.container.title
+    }
+
+    /** One embed, one `init` carrying a norm-vector file. Returns the live browser. */
+    const init = async config => {
+        const browser = embed()
+        await browser.init({
+            url: HIC_URL,
+            state: savedWith('NONE'),
+            normalizationFiles: undefined,
+            normVectorFiles: [NORM_VECTOR_FILE],
+            ...config
+        })
+        return browser
+    }
+
+    test('a config.normalization the dataset offers ends up selected', async () => {
+
+        // The defect in one line: the list is built while `state.normalization`
+        // is still `NONE`, so `NONE` is the entry marked selected, and nothing
+        // re-reads the state after the enforcer writes `KR` into it.
+        offered = ['NONE', 'VC', 'KR']
+        supplied = ['VC', 'KR']
+
+        const browser = await init({normalization: 'KR'})
+
+        expect(browser.state.normalization).toBe('KR')
+        expect(selected(browser)).toBe('KR')
+    })
+
+    test('a normalization supplied by the norm-vector file itself ends up selected', async () => {
+
+        // Why the resolution cannot simply be hoisted above the `Promise.all`:
+        // `KR` is on offer only because the file that was just read pushed it
+        // there. Asked any earlier, the enforcer would substitute it away.
+        offered = ['NONE', 'KR']
+        supplied = ['KR']
+
+        const browser = await init({normalization: 'KR'})
+
+        expect(browser.state.normalization).toBe('KR')
+        expect(selected(browser)).toBe('KR')
+    })
+
+    test('a substituted normalization ends up selected, not the one asked for', async () => {
+
+        offered = ['NONE', 'VC']
+        supplied = ['VC']
+
+        const browser = await init({normalization: 'KR'})
+
+        expect(browser.state.normalization).toBe('NONE')
+        expect(selected(browser)).toBe('NONE')
+    })
+
+    test('a coerced init still announces, with the re-selection in the path', async () => {
+
+        // The announcement reaching the widget through a real `init` that also
+        // re-selects. What it cannot claim is that the re-selection *moved*
+        // anything: `#announceSubstitution` puts the effective value on the
+        // selector itself, so by the time the re-selection runs the selector is
+        // already where it belongs and it returns early. The fact the fix leans
+        // on -- that a re-selection which does move the entry leaves the marker
+        // standing -- is driven at the widget's own seam below, where the
+        // moment can be staged.
+        offered = ['NONE', 'VC']
+        supplied = ['VC']
+
+        const browser = await init({normalization: 'KR'})
+
+        expect(announcement(browser)).toContain('KR')
+        expect(announcement(browser)).toContain('NONE')
+    })
+
+    test('an init with no config.normalization leaves the selector where the load left it', async () => {
+
+        offered = ['NONE', 'VC']
+        supplied = ['VC']
+
+        const browser = await init({state: savedWith('VC')})
+
+        expect(browser.state.normalization).toBe('VC')
+        expect(selected(browser)).toBe('VC')
+    })
+})
+
+/**
+ * The re-selection's own seam.
+ *
+ * Two of the three claims the fix rests on cannot be staged through `init`:
+ * a re-selection that *moves* the entry while an announcement is standing
+ * (through `init`, the announcement has already moved it), and the price the
+ * settle-point in #603 is about -- that a re-selection does not go back to
+ * `getNormalizationOptions()`, which on a real `.hic` file is a read of the
+ * normalization vector index off the wire.
+ *
+ * A widget and a browser stub, as in `testNormalizationSubstitution.js`: what
+ * is being asked here is what the widget does with a value, not how the value
+ * was arrived at.
+ */
+describe('a re-selection moves the entry and costs nothing else (#603)', () => {
+
+    const VIEW = {chr1: 1, chr2: 1, zoom: 3, x: 10, y: 10}
+
+    let fixture
+    let widget
+    let asked
+
+    /** Build a widget over a browser stub offering `options`, sitting on `normalization`. */
+    const build = async (options, normalization) => {
+        fixture = withDOM()
+        const {document} = fixture.window
+
+        const navbar = document.createElement('div')
+        const lower = document.createElement('div')
+        lower.id = 'reselect-lower-hic-nav-bar-widget-container'
+        navbar.appendChild(lower)
+        document.body.appendChild(navbar)
+
+        asked = 0
+        widget = new NormalizationWidget({
+            state: {...VIEW, normalization},
+            setNormalization: () => undefined,
+            getNormalizationOptions: async () => {
+                asked++
+                return options
+            }
+        }, navbar)
+
+        await widget.updateOptions()
+        return widget
+    }
+
+    const markerShowing = () => 'none' !== widget.substitutionMarker.style.display
+
+    afterEach(() => {
+        fixture.restore()
+    })
+
+    test('the selection moves without asking for the list again', async () => {
+
+        // The whole reason this is a re-selection rather than a second
+        // `updateOptions`. `asked` counts the list build; the re-selection must
+        // not add to it.
+        await build(['NONE', 'VC', 'KR'], 'NONE')
+        expect(widget.normalizationSelector.value).toBe('NONE')
+        const built = asked
+
+        await widget.reselect('KR')
+
+        expect(widget.normalizationSelector.value).toBe('KR')
+        expect(asked).toBe(built)
+    })
+
+    test('a standing announcement survives a re-selection that moves the entry', async () => {
+
+        // The fact the placement depends on: the re-selection runs *after*
+        // `#announceSubstitution`, and neither it nor `updateOptions` calls
+        // `clearSubstitution` -- only the change handler and
+        // `onNormalizationChange` do, because only a user answering the
+        // question makes the reason false (#372, ADR-0012).
+        await build(['NONE', 'VC', 'KR'], 'VC')
+        widget.announceSubstitution(substitutionReason.notInFile('KR', 'NONE'), VIEW)
+
+        await widget.reselect('NONE')
+
+        expect(widget.normalizationSelector.value).toBe('NONE')
+        expect(markerShowing()).toBe(true)
+        expect(widget.container.title).toContain('KR')
+    })
+
+    test('a value with no entry rebuilds the list rather than deselecting everything', async () => {
+
+        // The one case a re-selection cannot serve. Reached here by moving the
+        // offered set out from under a list already built -- a shape
+        // `#resolveNormalization` should not produce, since it picks out of the
+        // same set the list is built from, which is exactly why the branch
+        // needs staging to be driven at all. A bare programmatic set would
+        // leave the selector on nothing.
+        await build(['NONE', 'VC'], 'NONE')
+        widget.browser.getNormalizationOptions = async () => {
+            asked++
+            return ['NONE', 'VC', 'KR']
+        }
+        widget.browser.state.normalization = 'KR'
+
+        await widget.reselect('KR')
+
+        expect(widget.normalizationSelector.value).toBe('KR')
+    })
+
+    test('the rebuilding branch leaves a standing announcement alone too', async () => {
+
+        await build(['NONE', 'VC'], 'NONE')
+        widget.announceSubstitution(substitutionReason.notInFile('KR', 'NONE'), VIEW)
+
+        widget.browser.getNormalizationOptions = async () => ['NONE', 'VC', 'KR']
+        widget.browser.state.normalization = 'KR'
+
+        await widget.reselect('KR')
+
+        expect(markerShowing()).toBe(true)
+        expect(widget.container.title).toContain('KR')
+    })
+
+    test('a failed list build does not reach the re-selection', async () => {
+
+        // `onNormVectorIndexLoad` calls `updateOptions` without awaiting it, so
+        // a failed option read was nobody's rejection. The re-selection waits
+        // on that same build -- and must not turn it into a failed `init`,
+        // which is the opposite of the load path's coerce-never-reject rule
+        // (ADR-0009 decision 2).
+        await build(['NONE', 'VC'], 'NONE')
+
+        widget.browser.getNormalizationOptions = async () => {
+            throw new Error('normalization vector index unreadable')
+        }
+        widget.updateOptions().catch(() => undefined)
+
+        await expect(widget.reselect('VC')).resolves.toBeUndefined()
+    })
+})


### PR DESCRIPTION
Closes #603.

## What was wrong

`normalizationWidget.updateOptions()` decides which `<option>` is selected by reading `browser.state.normalization` at the moment it runs. On the `init` path it runs from *inside* the norm-vector-file load — `config.normVectorFiles` → `loadNormalizationFile` → `onNormVectorIndexLoad` → `updateOptions()` — which is in the `Promise.all` **above** the validated write of `config.normalization`. So the entry it marks selected is `config.state`'s normalization, or `NONE`, and never the resolved answer.

## Why it isn't an ordering fix

`loadNormalizationFile` pushes types into `dataset.normalizationTypes`, and `#resolveNormalization` reads exactly that set through `getNormalizationOptions`. Resolving above the `Promise.all` would substitute away a normalization one of those files is about to supply. The fix is a re-selection after the write, not a move.

## The change

- **`js/normalizationWidget.js`** — `reselect(normalization)`. Returns early when the selector already shows the value; waits on any in-flight list build (`onNormVectorIndexLoad` calls `updateOptions` un-awaited, so a late rebuild would otherwise land on top of the re-selection); re-selects rather than rebuilding, so the second `getNormalizationOptions()` — a read of the normalization vector index, off the wire on a real `.hic` file — does not happen; rebuilds only when the value has no entry to select. `updateOptions` keeps a *settled* copy of its build, so a failed option read cannot be routed into `init` and turn a failed list build into a failed load (ADR-0009 decision 2).
- **`js/browserCoordinator.js`** — `onNormalizationResolved`, the quiet counterpart to `onNormalizationSubstituted`: it moves the selection and says nothing. Internal, absent from `js/publicApi.js` (ADR-0012).
- **`js/hicBrowser.js`** — the call, immediately after the validated write and after `#announceSubstitution`.

## Not #372

The announcement — marker, reason, what clears it — is untouched. It is only *pinned* here: nothing on this path calls `clearSubstitution`, and the fix's placement depends on that.

## Tests

`test/testInitNormalizationSelector.js`, 10 tests. Two were red before the fix: a `config.normalization` the dataset offers, and one supplied by the `normVectorFiles` entry itself.

The announcement claim is driven at the widget's own seam rather than through `init`: through a real `init`, `#announceSubstitution` moves the selector itself first, so the re-selection early-returns and a test there would pass without exercising anything. The seam tests also pin the two settle-points the issue named — that a re-selection costs no second `getNormalizationOptions()`, and that a standing announcement survives one that actually moves the entry (and survives the rebuilding branch too).

Full suite: 61 files, 1101 tests, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4y75HMaTaQyT1aAovXXKx