### PR TITLE
Shift-click to target several browsers, so a track load reaches all of them (#615)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -151,8 +151,9 @@ and it lasts until the user re-aims rather than standing. The browsers in one
 are **targeted browsers**.
 _Avoid_: **selection**, **selected browsers** — `registry.select()`, the
 `BrowserSelect` event and `hic-root-selected` already spend that word on the
-current browser. Also avoid *target group*: `js/targetGroup.js` is named for its
-neighbour `js/syncGroup.js`, but what it holds is a set, not a group.
+current browser. Do not call the thing a *target group* in prose either:
+`js/targetGroup.js` is named for its neighbour `js/syncGroup.js` so the pair is
+visible in the tree, and that filename is the one place the word is allowed.
 
 **View preference** — a setting the user makes on one browser that changes how
 that browser interprets a gesture, without being part of what the view *is*.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -128,7 +128,8 @@ _Avoid_: browser session, browser context, embed.
 Membership is a rule rather than a container: a browser joins when it has not
 opted out and its dataset is compatible with the other's. What travels the group
 is canonical state and, by deliberate exception, view preferences — never dataset
-choices. See `docs/adr/0014`.
+choices. See `docs/adr/0014`. Dataset choices reach several browsers by the other
+mechanism, the **target set** — `docs/adr/0015`.
 _Avoid_: sync set, linked browsers.
 
 **Sync state** — canonical state as a *peer* reads it: chromosomes by name and a
@@ -139,6 +140,19 @@ Membership decides who is handed one; whether a particular one can be acted on
 is a separate question, because a receiver's genome need not know every name a
 peer can publish — `canResolveSyncState` in `js/syncGroup.js`, issue #605.
 _Avoid_: sync payload, target state.
+
+**Target set** — the browsers a *load* reaches: the ones the user has
+explicitly aimed at by shift-clicking their navbars, plus the current browser,
+which is always in it. Per registry, and read as `registry.targetedBrowsers`.
+A target set is **not** a sync group, and confusing the two is the mistake
+`docs/adr/0015` exists to prevent: membership here is an explicit gesture rather
+than a computed rule, the cargo is dataset choices rather than canonical state,
+and it lasts until the user re-aims rather than standing. The browsers in one
+are **targeted browsers**.
+_Avoid_: **selection**, **selected browsers** — `registry.select()`, the
+`BrowserSelect` event and `hic-root-selected` already spend that word on the
+current browser. Also avoid *target group*: `js/targetGroup.js` is named for its
+neighbour `js/syncGroup.js`, but what it holds is a set, not a group.
 
 **View preference** — a setting the user makes on one browser that changes how
 that browser interprets a gesture, without being part of what the view *is*.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -143,7 +143,9 @@ _Avoid_: sync payload, target state.
 
 **Target set** — the browsers a *load* reaches: the ones the user has
 explicitly aimed at by shift-clicking their navbars, plus the current browser,
-which is always in it. Per registry, and read as `registry.targetedBrowsers`.
+which is always in it. The first shift-click of a new aim also makes that browser
+current, because the load is issued from the current browser and it is that
+browser's genome the aim is measured against — see `docs/adr/0015` decision 4a. Per registry, and read as `registry.targetedBrowsers`.
 A target set is **not** a sync group, and confusing the two is the mistake
 `docs/adr/0015` exists to prevent: membership here is an explicit gesture rather
 than a computed rule, the cargo is dataset choices rather than canonical state,

--- a/css/juicebox.css
+++ b/css/juicebox.css
@@ -1300,6 +1300,14 @@ div[id$=content-container] div[id$=x-scrollbar-container] div[id$=x-axis-scrollb
   border-color: #5f5f5f;
 }
 
+/* The target set (#615): a load reaches these panels. Deliberately a second
+   class and a second visual, not the selected border -- a user still needs to
+   see at a glance which panel the widgets are reading. */
+.hic-root-targeted {
+  outline: 2px dashed #3a8ab4;
+  outline-offset: -2px;
+}
+
 .unselect {
   -webkit-touch-callout: none;
   -webkit-user-select: none;

--- a/css/juicebox.scss
+++ b/css/juicebox.scss
@@ -1173,6 +1173,14 @@ div[id$="content-container"] {
 .hic-root-selected {
   border-color: #5f5f5f;
 }
+
+/* The target set (#615): a load reaches these panels. Deliberately a second
+   class and a second visual, not the selected border -- a user still needs to
+   see at a glance which panel the widgets are reading. */
+.hic-root-targeted {
+  outline: 2px dashed #3a8ab4;
+  outline-offset: -2px;
+}
 .unselect {
   -webkit-touch-callout: none;
   -webkit-user-select: none;

--- a/dashboard.html
+++ b/dashboard.html
@@ -161,6 +161,7 @@
             { name: 'jQuery Cleanse', path: 'dev/jquery-cleanse.html' },
             { name: 'Juicebox Normalization Warning', path: 'dev/juicebox-normalization-warning.html' },
             { name: 'Load and Reset', path: 'dev/load-and-reset.html' },
+            { name: 'Issue 615: Multi-Browser Targeting', path: 'dev/multi-browser-targeting.html' },
             { name: 'Non Synched Maps', path: 'dev/non_synched_maps.html' },
             { name: 'Olga Assembly', path: 'dev/olga-assembly.html' }
         ];

--- a/dev/multi-browser-targeting.html
+++ b/dev/multi-browser-targeting.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Multi-browser targeting — one load, several panels</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
+    <link rel="stylesheet" type="text/css" href="../css/juicebox.css">
+
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+            margin: 16px;
+        }
+
+        .controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            align-items: center;
+            margin-bottom: 12px;
+        }
+
+        .summary {
+            font-family: Menlo, Consolas, monospace;
+            font-size: 12px;
+            white-space: pre-wrap;
+            background: #f4f4f4;
+            border: 1px solid #ddd;
+            padding: 8px;
+            min-height: 3em;
+        }
+
+        .aim {
+            font-family: Menlo, Consolas, monospace;
+            font-size: 12px;
+            margin: 8px 0;
+        }
+
+        /* The badge the registry drives, exaggerated here so the three states --
+           current (which is also targeted), targeted, neither -- are obvious at a
+           glance. The library's own rule is in css/juicebox.scss. */
+        .hic-root-targeted {
+            outline: 3px dashed #3a8ab4;
+            outline-offset: -3px;
+        }
+
+        #panels {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+        }
+
+        .note {
+            max-width: 62em;
+            font-size: 13px;
+            color: #333;
+        }
+    </style>
+</head>
+
+<body>
+
+<h2>Multi-browser targeting (#615)</h2>
+
+<p class="note">
+    <b>Shift-click a panel's navbar</b> to put it in the target set; <b>plain-click</b>
+    a navbar to clear the set and make that panel current. The current panel is always
+    targeted, so with nothing shift-clicked a load behaves exactly as it does today.
+    Dashed outline = targeted; solid border = current.
+</p>
+
+<p class="note">
+    Two of the panels are here to exercise the <b>skip</b> paths, which are the parts
+    most likely to be silently wrong: one panel has <b>no map</b> at all, and one is on
+    <b>mm10</b> while the loads below are hg38. Aim at them and the summary must report
+    them as skipped — not as loaded, and not as an error.
+</p>
+
+<div class="controls">
+    <button id="add-browser">Add browser (hg38)</button>
+    <button id="load-1d">Load 1D track into targets</button>
+    <button id="load-2d">Load 2D annotation into targets</button>
+    <button id="load-both">Load both into targets</button>
+</div>
+
+<div class="aim" id="aim">aim: —</div>
+
+<div class="summary" id="summary">No load yet.</div>
+
+<div id="panels"></div>
+
+<script type="module">
+
+    import hic from '../js/index.js'
+    import EventBus from '../js/eventBus.js'
+    import {devMapUrl} from '../dev-proxy/map-url.js'
+
+    // Dev-only: routes .hic reads on hosts that answer localhost with a bot challenge
+    // (encodeproject.org today) through the dev server's proxy. The mm10 panel below is
+    // the one that needs it. See the README, "Loading maps from hosts that serve a bot
+    // challenge".
+    hic.setUrlMapper(devMapUrl)
+
+    // Verified reachable from a browser. Do NOT repoint these at
+    // hicfiles.s3.amazonaws.com or dnazoo -- those hosts gate on User-Agent and serve
+    // 403 to any browser. See the note in dev/big_viewport.html.
+    const hg38Maps = [
+        {
+            url: 'https://s3.us-east-1.wasabisys.com/aiden-suhas/hic_files/FINAL_GRCh38_processing/LCL/GM12878/diploid/r.hic',
+            name: 'GM12878 diploid (r) — hg38',
+            nvi: '43762184328,25419'
+        },
+        {
+            url: 'https://s3.us-east-1.wasabisys.com/aiden-suhas/hic_files/FINAL_GRCh38_processing/LCL/GM12878/diploid/a.hic',
+            name: 'GM12878 diploid (a) — hg38',
+            nvi: '43835341324,25419'
+        },
+        {
+            url: 'https://s3.us-east-1.wasabisys.com/aiden-suhas/hic_files/FINAL_GRCh38_processing/LCL/LCL_combined/9_12_23/inter_30.hic',
+            name: 'LCL combined inter_30 — hg38',
+            nvi: '2113712247631,126136'
+        }
+    ]
+
+    // The different-genome panel. mm10, reached through the dev proxy.
+    const mm10Map = {
+        url: 'https://www.encodeproject.org/files/ENCFF602BZP/@@download/ENCFF602BZP.hic',
+        name: 'ENCFF602BZP — mm10'
+    }
+
+    // hg38, and `format` is set deliberately: a format-less URL ending in .txt.gz is
+    // routed to the 2D loader, so an annotation that says nothing about itself would
+    // arrive as a broken 2D track rather than as genes. See js/dataLoader.js.
+    const track1D = {
+        url: 'https://s3.amazonaws.com/igv.org.genomes/hg38/refGene.sorted.txt.gz',
+        type: 'annotation',
+        format: 'refgene',
+        name: 'RefSeq Genes (hg38)',
+        color: '#1f77b4'
+    }
+
+    const track2D = {
+        url: 'https://www.dropbox.com/scl/fi/mweycro8eyhubrjrhv6oo/fosl1_loops_with_snps_nothresh.bedpe?rlkey=1dv8wbc7c57m9muob7tlxvm89&e=1&st=2c4adj56&dl=0',
+        name: 'fosl1 loops (hg38)',
+        color: '#00fdff',
+        displayMode: 'COLLAPSED'
+    }
+
+    const panels = document.getElementById('panels')
+    const summaryElement = document.getElementById('summary')
+    const aimElement = document.getElementById('aim')
+
+    const label = browser => browser.dataset ? (browser.config?.name || browser.id) : `${browser.id} (no map)`
+
+    // One container, and therefore **one registry**: a target set never spans two
+    // embeds -- it falls out of the per-container isolation of ADR-0004, and a fan-out
+    // is issued *through* a registry, so a set spanning two would have no caller. Every
+    // panel here is a browser in the same registry, which is the shape juicebox-web has
+    // when a user adds a second map.
+    let registry
+
+    async function addPanel(config) {
+        return undefined === registry
+            ? hic.init(panels, config ?? {})
+            : hic.createBrowser(panels, config ?? {})
+    }
+
+    function renderAim() {
+        // The event fires while the first panel is still being built, before
+        // there is a registry to ask.
+        if (undefined === registry) {
+            return
+        }
+        aimElement.textContent = `aim: ${registry.targetedBrowsers.map(label).join(', ') || '—'}`
+    }
+
+    function renderSummary(summary) {
+        const line = what => what.length ? what.join(', ') : '—'
+        summaryElement.textContent = [
+            `loaded:  ${line(summary.loaded.map(label))}`,
+            `skipped: ${line(summary.skipped.map(({browser, reason}) => `${label(browser)} [${reason}]`))}`,
+            `failed:  ${line(summary.failed.map(({browser, error}) => `${label(browser)}: ${error.message}`))}`
+        ].join('\n')
+    }
+
+    // juicebox.js raises no alert for a fan-out: it returns the summary and the caller
+    // reports. One report per gesture, not one modal per browser -- and where it appears
+    // is the host's decision. This page's decision is the line above the panels.
+    async function fanOut(configs) {
+        summaryElement.textContent = 'loading…'
+        renderSummary(await registry.loadTracksIntoTargets(configs))
+    }
+
+    // The event a host subscribes to instead of re-deriving the implicit-current rule.
+    EventBus.globalBus.subscribe('BrowserTargetChange', () => renderAim())
+
+    ;(async function () {
+
+        // Panel 1: hg38, and the one everything is aimed from to begin with.
+        const first = await addPanel(hg38Maps[0])
+        registry = first.registry
+
+        // Sequential rather than Promise.all: panel order is registry order, and this
+        // page is about which panel is which.
+
+        // Panels 2 and 3: hg38 peers, the happy path.
+        await addPanel(hg38Maps[1])
+        await addPanel(hg38Maps[2])
+
+        // Panel 4: no map. An empty browser is a normal transient state, and aiming at
+        // one must skip rather than fail.
+        await addPanel()
+
+        // Panel 5: mm10. The skip that prevents the nasty failure -- a track drawn at
+        // meaningless coordinates in a panel nobody was watching.
+        await addPanel(mm10Map)
+
+        renderAim()
+
+        document.getElementById('add-browser')
+            .addEventListener('click', () => addPanel(hg38Maps[0]).then(renderAim))
+
+        document.getElementById('load-1d').addEventListener('click', () => fanOut([track1D]))
+        document.getElementById('load-2d').addEventListener('click', () => fanOut([track2D]))
+        document.getElementById('load-both').addEventListener('click', () => fanOut([track1D, track2D]))
+
+    })()
+
+</script>
+
+</body>
+</html>

--- a/dev/multi-browser-targeting.html
+++ b/dev/multi-browser-targeting.html
@@ -72,6 +72,13 @@
 </p>
 
 <p class="note">
+    The <b>first</b> shift-click of a new aim also makes that panel current. The load is
+    issued from the current panel, and it is that panel's genome the skips below are
+    measured against — so the aim line names its origin. Aim from the mm10 panel and the
+    hg38 panels are the ones skipped.
+</p>
+
+<p class="note">
     Two of the panels are here to exercise the <b>skip</b> paths, which are the parts
     most likely to be silently wrong: one panel has <b>no map</b> at all, and one is on
     <b>mm10</b> while the loads below are hg38. Aim at them and the summary must report
@@ -194,7 +201,12 @@
         if (undefined === registry) {
             return
         }
+        // The origin is named, not just the members: it is the current browser,
+        // and it is the genome every skip is measured against. An aim whose
+        // origin you cannot see is one whose skips look inexplicable.
+        const origin = registry.currentBrowser
         aimElement.textContent = `aim: ${registry.targetedBrowsers.map(label).join(', ') || '—'}`
+            + `   (from ${origin ? label(origin) : '—'}, genome ${origin?.genome?.id ?? 'none'})`
     }
 
     function renderSummary(summary) {
@@ -237,6 +249,12 @@
         // Panel 5: mm10. The skip that prevents the nasty failure -- a track drawn at
         // meaningless coordinates in a panel nobody was watching.
         await addPanel(mm10Map, 'mm10')
+
+        // Panel 1 is made current before anything else happens. `add()` selects,
+        // so the last panel built -- the mm10 one -- would otherwise be the
+        // browser every default load is issued from and measured against, and
+        // this page would open in the one state it exists to explain.
+        registry.select(first)
 
         renderAim()
         renderRoster()

--- a/dev/multi-browser-targeting.html
+++ b/dev/multi-browser-targeting.html
@@ -87,6 +87,8 @@
 
 <div class="aim" id="aim">aim: —</div>
 
+<div class="aim" id="roster">panels: —</div>
+
 <div class="summary" id="summary">No load yet.</div>
 
 <div id="panels"></div>
@@ -151,6 +153,13 @@
     const panels = document.getElementById('panels')
     const summaryElement = document.getElementById('summary')
     const aimElement = document.getElementById('aim')
+    const rosterElement = document.getElementById('roster')
+
+    // What each panel was built to be, so a map that fails to load is *visible*
+    // rather than quietly degrading into the no-dataset skip. That degradation is
+    // the failure mode this page is least able to afford: it would collapse the two
+    // skip paths into one and leave the genome rule untested while looking fine.
+    const built = []
 
     const label = browser => browser.dataset ? (browser.config?.name || browser.id) : `${browser.id} (no map)`
 
@@ -161,10 +170,22 @@
     // when a user adds a second map.
     let registry
 
-    async function addPanel(config) {
-        return undefined === registry
-            ? hic.init(panels, config ?? {})
-            : hic.createBrowser(panels, config ?? {})
+    async function addPanel(config, expectedGenome) {
+        const browser = undefined === registry
+            ? await hic.init(panels, config ?? {})
+            : await hic.createBrowser(panels, config ?? {})
+        built.push({browser, expectedGenome})
+        return browser
+    }
+
+    function renderRoster() {
+        rosterElement.textContent = 'panels: ' + built
+            .map(({browser, expectedGenome}) => {
+                const actual = browser.genome?.id ?? 'no map'
+                const wrong = (expectedGenome ?? 'no map') !== actual
+                return `${label(browser)} = ${actual}${wrong ? ` ⚠ expected ${expectedGenome ?? 'no map'}` : ''}`
+            })
+            .join(' | ')
     }
 
     function renderAim() {
@@ -199,28 +220,32 @@
     ;(async function () {
 
         // Panel 1: hg38, and the one everything is aimed from to begin with.
-        const first = await addPanel(hg38Maps[0])
+        const first = await addPanel(hg38Maps[0], 'hg38')
         registry = first.registry
 
         // Sequential rather than Promise.all: panel order is registry order, and this
         // page is about which panel is which.
 
         // Panels 2 and 3: hg38 peers, the happy path.
-        await addPanel(hg38Maps[1])
-        await addPanel(hg38Maps[2])
+        await addPanel(hg38Maps[1], 'hg38')
+        await addPanel(hg38Maps[2], 'hg38')
 
         // Panel 4: no map. An empty browser is a normal transient state, and aiming at
         // one must skip rather than fail.
-        await addPanel()
+        await addPanel(undefined, undefined)
 
         // Panel 5: mm10. The skip that prevents the nasty failure -- a track drawn at
         // meaningless coordinates in a panel nobody was watching.
-        await addPanel(mm10Map)
+        await addPanel(mm10Map, 'mm10')
 
         renderAim()
+        renderRoster()
 
         document.getElementById('add-browser')
-            .addEventListener('click', () => addPanel(hg38Maps[0]).then(renderAim))
+            .addEventListener('click', () => addPanel(hg38Maps[0], 'hg38').then(() => {
+                renderAim()
+                renderRoster()
+            }))
 
         document.getElementById('load-1d').addEventListener('click', () => fanOut([track1D]))
         document.getElementById('load-2d').addEventListener('click', () => fanOut([track2D]))

--- a/dev/multi-browser-targeting.html
+++ b/dev/multi-browser-targeting.html
@@ -72,6 +72,13 @@
 </p>
 
 <p class="note">
+    <b>Go to annotations</b> navigates to where the loaded 2D features actually are,
+    computed from <code>browser.tracks2D</code> — repeated clicks cycle the chromosome
+    pairs. The fixture's loops are motif-resolution anchors, tens of bp wide, so they
+    draw at the one-pixel floor: small marks on the diagonal, not blocks.
+</p>
+
+<p class="note">
     The <b>first</b> shift-click of a new aim also makes that panel current. The load is
     issued from the current panel, and it is that panel's genome the skips below are
     measured against — so the aim line names its origin. Aim from the mm10 panel and the
@@ -90,6 +97,7 @@
     <button id="load-1d">Load 1D track into targets</button>
     <button id="load-2d">Load 2D annotation into targets</button>
     <button id="load-both">Load both into targets</button>
+    <button id="goto-2d">Go to annotations</button>
 </div>
 
 <div class="aim" id="aim">aim: —</div>
@@ -226,6 +234,93 @@
         renderSummary(await registry.loadTracksIntoTargets(configs))
     }
 
+    /**
+     * Where a browser's 2D annotations actually are, one entry per chromosome pair.
+     *
+     * `track.featureMap` is keyed `"chr1_chr2"` and each feature carries
+     * `chr1/x1/x2` and `chr2/y1/y2`, so the extent is a min/max over the map --
+     * no need to know anything about the file that was loaded. That matters for a
+     * harness: a 2D fan-out that lands off-screen is indistinguishable from one
+     * that did not happen.
+     */
+    function annotationRegions(browser) {
+
+        const regions = []
+
+        for (const track of browser.tracks2D ?? []) {
+            for (const features of Object.values(track.featureMap ?? {})) {
+
+                if (0 === features.length) {
+                    continue
+                }
+
+                const extent = features.reduce((acc, f) => ({
+                    x1: Math.min(acc.x1, f.x1), x2: Math.max(acc.x2, f.x2),
+                    y1: Math.min(acc.y1, f.y1), y2: Math.max(acc.y2, f.y2)
+                }), {x1: Infinity, x2: -Infinity, y1: Infinity, y2: -Infinity})
+
+                const {chr1, chr2} = features[0]
+                regions.push({...extent, chr1, chr2, count: features.length, name: track.name})
+            }
+        }
+
+        return regions
+    }
+
+    // Padded, with a floor: these fixtures are motif-resolution anchors tens of bp
+    // wide, and an unpadded window on one would be a view no map has a rung for.
+    function locusString({chr1, chr2, x1, x2, y1, y2}) {
+
+        // On the diagonal, both axes get the union. A cluster of intrachromosomal
+        // loops shares one anchor, so its x extent is a few tens of bp against a
+        // y extent of hundreds of kb -- and axes that far apart put the diagonal,
+        // which is where the features sit, off screen.
+        if (chr1 === chr2) {
+            const [lo, hi] = [Math.min(x1, y1), Math.max(x2, y2)]
+            ;[x1, x2, y1, y2] = [lo, hi, lo, hi]
+        }
+
+        const pad = ([start, end]) => {
+            const padding = Math.max((end - start) * 0.2, 25000)
+            return [Math.max(0, Math.round(start - padding)), Math.round(end + padding)]
+        }
+        const [xStart, xEnd] = pad([x1, x2])
+        const [yStart, yEnd] = pad([y1, y2])
+        return `${chr1}:${xStart}-${xEnd} ${chr2}:${yStart}-${yEnd}`
+    }
+
+    // Repeated clicks cycle the chromosome pairs, since a 2D file routinely covers
+    // several and only one can be on screen at a time.
+    let nextRegion = 0
+
+    async function goToAnnotations() {
+
+        const regions = annotationRegions(registry.currentBrowser)
+
+        if (0 === regions.length) {
+            summaryElement.textContent = `no 2D annotations loaded in ${label(registry.currentBrowser)} — load some first`
+            return
+        }
+
+        const region = regions[nextRegion++ % regions.length]
+        const locus = locusString(region)
+
+        // Every targeted panel that carries this same chromosome pair, so the
+        // panels the fan-out reached all land in the same place. A panel without
+        // the annotation is left where it is rather than sent to coordinates that
+        // mean nothing to it -- the same rule the fan-out itself follows.
+        const going = registry.targetedBrowsers.filter(browser => annotationRegions(browser)
+            .some(({chr1, chr2}) => chr1 === region.chr1 && chr2 === region.chr2))
+
+        await Promise.all(going.map(browser => browser.parseGotoInput(locus)))
+
+        summaryElement.textContent = [
+            `went to: ${locus}`,
+            `region:  ${region.chr1}/${region.chr2}, ${region.count} feature(s) from "${region.name}"`,
+            `panels:  ${going.map(label).join(', ') || '—'}`
+        ].join('\n')
+    }
+
     // The event a host subscribes to instead of re-deriving the implicit-current rule.
     EventBus.globalBus.subscribe('BrowserTargetChange', () => renderAim())
 
@@ -268,6 +363,7 @@
         document.getElementById('load-1d').addEventListener('click', () => fanOut([track1D]))
         document.getElementById('load-2d').addEventListener('click', () => fanOut([track2D]))
         document.getElementById('load-both').addEventListener('click', () => fanOut([track1D, track2D]))
+        document.getElementById('goto-2d').addEventListener('click', () => goToAnnotations())
 
     })()
 

--- a/docs/adr/0015-targeting-is-not-a-sync-group.md
+++ b/docs/adr/0015-targeting-is-not-a-sync-group.md
@@ -1,0 +1,150 @@
+# ADR-0015 — Targeting is not a sync group: dataset choices fan out by an explicit aim
+
+**Status:** Accepted
+**Date:** 2026-09-05
+**Related:** #615 (the feature), #588 (unbounded, serial track loads — whose
+blast radius this multiplies), ADR-0014 (what crosses a sync group, and the
+sentence this is the other half of), ADR-0004 (browser registry per container,
+decision 6 — a membership rule kept out of the registry), ADR-0013 (test tier),
+`CONTEXT.md` (*Target set*, *Sync group*), `js/targetGroup.js`,
+`js/syncGroup.js`
+
+## Context
+
+A collaborator loads the same track into three or four panels by hand, one panel
+at a time, and asked for one gesture that does it once.
+
+juicebox.js already has a mechanism for "one action reaching several browsers":
+the sync group. It would have been the obvious place to put this, and putting it
+there would have been wrong. ADR-0014 settled what crosses a sync group —
+canonical state always, view preferences by deliberate exception, **dataset
+choices never** — and tracks are squarely a dataset choice. Widening the sync
+payload to carry them would have re-opened, one widget at a time, exactly the
+argument ADR-0014 exists to close.
+
+So this is the other half of ADR-0014's sentence. Dataset choices *do* propagate;
+they propagate by a different mechanism, with different membership, and the risk
+worth recording is that a future reader finds two mechanisms for the same-sounding
+thing and no note saying why there are two.
+
+## Decision
+
+**1. A target set is a second, distinct mechanism, and the distinction is the
+design.**
+
+| | sync group | target set |
+| --- | --- | --- |
+| membership | a computed rule (compatible dataset, not opted out) | an explicit user gesture |
+| cargo | canonical state, plus view preferences | dataset choices (tracks) |
+| lifetime | standing | until re-aimed |
+
+A sync group answers *whose view follows mine*. A target set answers *where does
+this load land*. Neither implies the other: two panels can sync without being
+aimed at together, and two panels can be aimed at together while one of them has
+opted out of syncing.
+
+**2. One file per mechanism.** `js/targetGroup.js` sits beside `js/syncGroup.js`,
+holding the skip predicate and the fan-out as pure functions over browsers — no
+registry, no DOM, unit-testable exactly as `pairSynchable` and
+`canResolveSyncState` are. The distinction is then visible in the file tree and
+not only in this document.
+
+**3. The current browser is targeted implicitly.** `registry.targetedBrowsers` is
+a getter computing `{currentBrowser} ∪ explicit` over the registry's `browsers`,
+so it cannot drift out of sync with them and a deleted browser cannot linger in
+it. With nothing explicitly aimed at, the set is `[currentBrowser]` and every
+load behaves exactly as it does today. That is what makes the feature opt-in at
+the *gesture* rather than at the call site.
+
+**4. Shift-click aims; plain click re-aims.** Shift-click on a panel's **navbar**
+toggles that browser in or out; a plain click clears the set and makes that panel
+current, which is the only way back from a large aim. The navbar and not the whole
+panel, because a shift over the contact map already means crosshairs.
+
+The clear lives in the gesture (`registry.retarget`) and deliberately not inside
+`select()`, even though every plain click ends there: `select` is also how a new
+browser becomes current, how a deleted browser's selection falls through to a
+survivor, and how a restore settles — and none of those is the user re-aiming.
+Folding the clear into `select` would mean that adding a panel silently destroys
+the aim, which decision 6 says it must not.
+
+**5. Skip, do not throw.** A target with no dataset, or on a genome other than the
+**originating** browser's, is skipped and reported as skipped. Tracks carry no
+genome of their own, so the browser the load was issued from is the track's genome
+declaration — the menu it came from was built for that browser's genome. This is
+the skip that prevents the nasty failure: not an error, just a track drawn at
+meaningless coordinates in a panel nobody was watching. The precedent is #605's
+`canResolveSyncState`, which declines a state it cannot place rather than failing
+the publication.
+
+**6. Lifecycle.**
+
+| event | target set |
+| --- | --- |
+| browser deleted | dropped, in `releaseSlot` — a disposed browser is fatal on use, not merely stale |
+| browser added | does **not** join — a panel just created was not part of the aim the user set up |
+| `browser.reset()` | **survives** |
+| session restore | cleared; never serialized |
+
+The reset row is the one that diverges from the sync group, and on purpose: sync
+membership is a *rule* that gets recomputed, so losing it costs nothing; targeting
+is a user's act, and a reset should not silently undo it. `HICBrowser.reset`
+therefore captures explicit membership before the teardown and hands it back to
+`reclaimSlot`, next to the slot and the selection it already restores.
+
+A target set is per registry and never spans two embeds. That falls out of
+ADR-0004's isolation, and there is no caller for the alternative: a fan-out is
+issued *through* a registry.
+
+**7. juicebox.js raises no alert.** `loadTracksIntoTargets` returns
+`{loaded, failed, skipped}` and the caller reports — one report per gesture, not
+one modal per browser. *Where* it appears is a host's decision, and juicebox-web
+and Spacewalk have different notification surfaces.
+
+This is what forced the loader split. `DataLoader.loadTracks` catches, alerts and
+resolves, so a fan-out over it could not tell failure from success. Its body is now
+`loadTracksOrThrow`, and the public method is a try/catch wrapper around it that
+is byte-identical in behaviour — because that behaviour is contract:
+`HICBrowser.loadTracks` is published surface and two hosts call it.
+
+**8. Nothing existing becomes plural.** `currentBrowser`, `BrowserSelect`,
+`HICBrowser.loadTracks` and `layoutController.removeTrackXYPair` mean exactly what
+they meant before. A host opts in by calling the new method. The new event is
+`BrowserTargetChange` — plural name because the subject is a set, unlike
+`BrowserSelect`, whose payload is one browser — and it carries the resolved array,
+so a host need not re-derive decision 3's implicit-current rule, plus the registry,
+because the bus is page-wide while a target set is per embed.
+
+**9. Concurrency is not capped here.** The fan-out is `Promise.allSettled`,
+unbounded. #588 is the unbounded, serial track-load problem, and it deserves one
+global answer wherever it lands rather than a second, local, wrong-place one in
+this file. What this feature does is multiply that blast radius — one click now
+issues N times the track loads — which is worth knowing when #588 is picked up.
+
+## Consequences
+
+**Undoing a fan-out is asymmetric, and shipped that way.** One click creates
+tracks in four panels; removing them costs four per-panel deletes through the gear
+popup or the annotation trash. Loading lives in the host's nav bar and fans out
+easily; deletion is buried in per-track widgets and has no satisfying design yet.
+Recorded here rather than discovered later, on the argument that shipping the
+asymmetry produces better information about what deletion should look like than
+guessing now would.
+
+**Contact maps are out of scope.** The collaborator asked for maps as well as
+tracks; this pass narrows to 1D tracks and 2D annotations. So are 2D annotation
+attributes — colour, display mode, ordering, visibility — which are closer to view
+preferences, and which ADR-0014 already puts outside what travels between
+browsers.
+
+**No user sees this until juicebox-web ships against it.** The track menu that
+would call `loadTracksIntoTargets` lives in juicebox-web, so the feature is
+reachable here only through `dev/multi-browser-targeting.html` until that host is
+repointed at a release carrying it.
+
+**The gesture and the badge have no automated test**, per ADR-0013. The rules and
+the registry's half — membership, the implicit member, both skip paths, the
+lifecycle table, the event — are covered from node in `test/testTargetGroup.js` and
+`test/testBrowserTargeting.js`. The dev harness carries a map-less panel and a
+different-genome panel deliberately: those are the two skip paths, and a harness
+that only showed the happy path is the one that would let the skip rule rot.

--- a/docs/adr/0015-targeting-is-not-a-sync-group.md
+++ b/docs/adr/0015-targeting-is-not-a-sync-group.md
@@ -56,11 +56,10 @@ it. With nothing explicitly aimed at, the set is `[currentBrowser]` and every
 load behaves exactly as it does today. That is what makes the feature opt-in at
 the *gesture* rather than at the call site.
 
-The invariant underneath it is that the current browser is **never also in the
-explicit set**: `select` drops the browser it makes current. Without that, a
-browser aimed at and then selected — which a host does through `select`, not only
-through a plain click — would be stuck: shift-clicking it is a no-op while it is
-current, and it would silently stay targeted once the selection moved on.
+The current browser **is** also recorded in the explicit set while an aim is in
+progress, even though it would be resolved into the set anyway. That redundancy is
+load-bearing: an empty explicit set is how the gesture knows the next shift-click
+starts a *new* aim rather than adding to one — see decision 4a.
 
 **4. Shift-click aims; plain click re-aims.** Shift-click on a panel's **navbar**
 toggles that browser in or out; a plain click clears the set and makes that panel
@@ -74,7 +73,27 @@ survivor, and how a restore settles — and none of those is the user re-aiming.
 Folding the clear into `select` would mean that adding a panel silently destroys
 the aim, which decision 6 says it must not.
 
-**4a. The badge ships in the library, not in the harness.** `hic-root-targeted`
+**4a. The first shift-click of a new aim also selects.** This was decided the
+other way first — targeting and selection are different questions, so a gesture
+named for one should not move the other — and testing the harness showed why that
+is wrong.
+
+The fan-out is issued from the current browser, and decision 5 makes the current
+browser the *track's genome declaration*. So an aim inherits its genome from
+whichever panel happened to be current, which is the last one built. Shift-click
+two hg38 panels while an mm10 panel is current and the two panels the user chose
+are reported `genome-mismatch` while the track lands in the one panel they never
+touched. Every symptom points at targeting being broken; nothing is, except the
+question of where the aim is measured from.
+
+Selecting on the first click makes the browser an aim *starts from* the browser it
+is *measured against*, which is the only pair a user can see. Later clicks in the
+same aim do not move the selection, so the origin stays where the user put it.
+
+Shift-clicking the current browser remains a no-op in everything observable — the
+resolved set and the event are unchanged — and internally it starts the aim.
+
+**4b. The badge ships in the library, not in the harness.** `hic-root-targeted`
 is applied by the registry, beside `hic-root-selected`, and styled in
 `css/juicebox.scss`. The gesture that sets a target set is library-side —
 shift-click is bound in `layoutController` — so its feedback has to be, or every

--- a/docs/adr/0015-targeting-is-not-a-sync-group.md
+++ b/docs/adr/0015-targeting-is-not-a-sync-group.md
@@ -56,6 +56,12 @@ it. With nothing explicitly aimed at, the set is `[currentBrowser]` and every
 load behaves exactly as it does today. That is what makes the feature opt-in at
 the *gesture* rather than at the call site.
 
+The invariant underneath it is that the current browser is **never also in the
+explicit set**: `select` drops the browser it makes current. Without that, a
+browser aimed at and then selected — which a host does through `select`, not only
+through a plain click — would be stuck: shift-clicking it is a no-op while it is
+current, and it would silently stay targeted once the selection moved on.
+
 **4. Shift-click aims; plain click re-aims.** Shift-click on a panel's **navbar**
 toggles that browser in or out; a plain click clears the set and makes that panel
 current, which is the only way back from a large aim. The navbar and not the whole
@@ -67,6 +73,17 @@ browser becomes current, how a deleted browser's selection falls through to a
 survivor, and how a restore settles — and none of those is the user re-aiming.
 Folding the clear into `select` would mean that adding a panel silently destroys
 the aim, which decision 6 says it must not.
+
+**4a. The badge ships in the library, not in the harness.** `hic-root-targeted`
+is applied by the registry, beside `hic-root-selected`, and styled in
+`css/juicebox.scss`. The gesture that sets a target set is library-side —
+shift-click is bound in `layoutController` — so its feedback has to be, or every
+host would have to reimplement the same outline to stop the gesture from looking
+broken. It is a *second* class and a second visual deliberately: the selected
+border keeps meaning what it means, because a user still needs to see at a glance
+which panel the widgets are reading. The three states are current (which is also
+targeted), targeted, and neither. `dev/multi-browser-targeting.html` overrides the
+rule with a louder one; that is a harness decision, not the library's.
 
 **5. Skip, do not throw.** A target with no dataset, or on a genome other than the
 **originating** browser's, is skipped and reported as skipped. Tracks carry no
@@ -102,10 +119,14 @@ one modal per browser. *Where* it appears is a host's decision, and juicebox-web
 and Spacewalk have different notification surfaces.
 
 This is what forced the loader split. `DataLoader.loadTracks` catches, alerts and
-resolves, so a fan-out over it could not tell failure from success. Its body is now
-`loadTracksOrThrow`, and the public method is a try/catch wrapper around it that
-is byte-identical in behaviour — because that behaviour is contract:
-`HICBrowser.loadTracks` is published surface and two hosts call it.
+resolves, so a fan-out over it could not tell failure from success. The work is now
+a private `#loadTracks`, with two wrappers over it: the public `loadTracks`, which
+reports, and `loadTracksOrThrow`, which the fan-out calls. The spinner is started
+in the body and stopped by each wrapper rather than wrapped around the body,
+because that is what keeps the public method **byte-identical in behaviour** —
+including the order in which it reports and then puts the spinner away. That
+behaviour is contract: `HICBrowser.loadTracks` is published surface and two hosts
+call it.
 
 **8. Nothing existing becomes plural.** `currentBrowser`, `BrowserSelect`,
 `HICBrowser.loadTracks` and `layoutController.removeTrackXYPair` mean exactly what

--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -2,7 +2,7 @@ import {AlertDialog} from 'igv-ui'
 import EventBus from './eventBus.js'
 import HICEvent from './hicEvent.js'
 import {pairSynchable} from './syncGroup.js'
-import {loadTracksIntoTargets} from './targetGroup.js'
+import {fanOutTracks} from './targetGroup.js'
 import {normalizeSession} from './normalizeSession.js'
 // A cycle, deliberately: `createBrowser.js` resolves its registry from a
 // container, and `restoreSession` below needs browsers built. Neither module
@@ -125,6 +125,11 @@ class BrowserRegistry {
      */
     clear() {
         this.browsers = []
+        // The aim goes with them. `targetedBrowsers` filters over `browsers`, so
+        // leaving these behind would be invisible -- and invisible is exactly
+        // the wrong thing to be holding references to browsers that are on
+        // their way to being disposed.
+        this.#targeted.clear()
     }
 
     /**
@@ -150,6 +155,14 @@ class BrowserRegistry {
         // Outside the transition check below: a browser already current in its
         // own registry is not necessarily the last one selected page-wide.
         mostRecentlySelectedBrowser = browser
+
+        // The invariant that keeps `toggleTarget`'s early return honest: the
+        // current browser is targeted *implicitly*, so it is never also in the
+        // explicit set. Without this, a browser aimed at and then selected --
+        // which a host does through `select`, not only through a plain click --
+        // would be un-removable while current (the toggle is a no-op there) and
+        // would silently stay targeted once the selection moved on.
+        this.#targeted.delete(browser)
 
         if (browser !== this.currentBrowser) {
             this.currentBrowser?.rootElement.classList.remove('hic-root-selected')
@@ -201,7 +214,11 @@ class BrowserRegistry {
      */
     toggleTarget(browser) {
 
-        if (browser === this.currentBrowser) {
+        // A browser this registry does not own has no slot in its aim, and
+        // recording one would be the retained reference `releaseSlot` exists to
+        // avoid -- `targetedBrowsers` filters it out, so it would never be seen
+        // again either.
+        if (browser === this.currentBrowser || !this.browsers.includes(browser)) {
             return
         }
 
@@ -230,7 +247,7 @@ class BrowserRegistry {
      * @returns {Promise<{loaded: Array, failed: Array, skipped: Array}>}
      */
     async loadTracksIntoTargets(configs) {
-        return loadTracksIntoTargets(this.currentBrowser, this.targetedBrowsers, configs)
+        return fanOutTracks(this.currentBrowser, this.targetedBrowsers, configs)
     }
 
     /**
@@ -398,7 +415,6 @@ class BrowserRegistry {
             // `#assertNotDisposed`, not merely stale, so the registry should
             // not still be holding a reference to one.
             this.#targeted.delete(browser)
-            browser.rootElement?.classList.remove('hic-root-targeted')
             if (browser === this.currentBrowser) {
                 this.#select(this.browsers[0])
             }

--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -2,6 +2,7 @@ import {AlertDialog} from 'igv-ui'
 import EventBus from './eventBus.js'
 import HICEvent from './hicEvent.js'
 import {pairSynchable} from './syncGroup.js'
+import {loadTracksIntoTargets} from './targetGroup.js'
 import {normalizeSession} from './normalizeSession.js'
 // A cycle, deliberately: `createBrowser.js` resolves its registry from a
 // container, and `restoreSession` below needs browsers built. Neither module
@@ -35,6 +36,28 @@ import {createBrowserList} from './createBrowser.js'
  * have landed: the selected gene and the alert dialog. See #481.
  */
 class BrowserRegistry {
+
+    /**
+     * The browsers the user has explicitly aimed a load at, as a set of
+     * references. Private, and read only through `targetedBrowsers` below: what
+     * a caller gets is the *resolved* set, derived from `browsers` on every
+     * ask, so a browser that has left the registry cannot linger in it.
+     *
+     * The current browser is not normally in here -- it is targeted implicitly
+     * -- but it can be, when a browser that was already aimed at later becomes
+     * current. See `toggleTarget`.
+     */
+    #targeted = new Set()
+
+    /**
+     * Depth of the `#announce` wrapper below, so that a mutation which runs
+     * another one inside it -- `releaseSlot` falling the selection through to a
+     * survivor -- posts one `BrowserTargetChange` for the whole gesture rather
+     * than one per nested step.
+     */
+    #announceDepth = 0
+
+    #announceBefore = []
 
     /**
      * @param {Element} [container] - the host element this registry owns.
@@ -110,6 +133,10 @@ class BrowserRegistry {
      * browser, which is the contract juicebox-web subscribes to.
      */
     select(browser) {
+        this.#announce(() => this.#select(browser))
+    }
+
+    #select(browser) {
 
         if (browser === undefined) {
             if (mostRecentlySelectedBrowser === this.currentBrowser) {
@@ -129,6 +156,158 @@ class BrowserRegistry {
             browser.rootElement.classList.add('hic-root-selected')
             this.currentBrowser = browser
             EventBus.globalBus.post(HICEvent("BrowserSelect", browser))
+        }
+    }
+
+    /**
+     * The browsers a *load* reaches: the current one, plus everything the user
+     * has explicitly aimed at.
+     *
+     * NOTE: public API function
+     *
+     * A getter returning an array rather than a stored list, computed over
+     * `browsers` on every ask, so it cannot drift out of sync with them: a
+     * browser that has been deleted is gone from here whether or not anything
+     * remembered to say so. In registry order, which is panel order.
+     *
+     * **The current browser is implicitly targeted.** So with nothing
+     * explicitly aimed at, this is `[currentBrowser]` and a fan-out behaves
+     * exactly as a single-browser load does today. That is what makes the
+     * feature opt-in at the gesture rather than at the call site.
+     *
+     * A target set is *not* a sync group -- see `js/targetGroup.js` and
+     * `docs/adr/0015`.
+     */
+    get targetedBrowsers() {
+        return this.browsers.filter(browser => browser === this.currentBrowser || this.#targeted.has(browser))
+    }
+
+    /**
+     * Put `browser` in the target set, or take it out. The single mutator: one
+     * gesture -- shift-click on a panel's navbar -- and one method, rather than
+     * a `target`/`untarget` pair no gesture asks for.
+     *
+     * NOTE: public API function
+     *
+     * Shift-clicking the current browser is a no-op, because the current
+     * browser is targeted implicitly and there is no state in which it is not.
+     * Returning early rather than adding it keeps that honest: recording it
+     * would make it explicitly targeted, and it would then stay in the set
+     * after it stopped being current, which is not what the user's shift-click
+     * meant.
+     *
+     * The way *back* from a large target set is a plain click, which re-aims at
+     * one browser -- see `retarget`.
+     */
+    toggleTarget(browser) {
+
+        if (browser === this.currentBrowser) {
+            return
+        }
+
+        this.#announce(() => {
+            if (!this.#targeted.delete(browser)) {
+                this.#targeted.add(browser)
+            }
+        })
+    }
+
+    /**
+     * Load `configs` into every targeted browser at once, and report what
+     * happened.
+     *
+     * NOTE: public API function
+     *
+     * The rules live in `js/targetGroup.js`; this is the registry-shaped door
+     * to them. The **originating** browser is the current one: the menu a track
+     * came from was built for whatever browser the widgets are reading, and
+     * that browser is therefore the track's genome declaration.
+     *
+     * Raises no alert of its own. The caller reports the summary -- one report
+     * per gesture, on whatever notification surface the host has.
+     *
+     * @param {Array<Object>} configs - track configs, as `loadTracks` takes them
+     * @returns {Promise<{loaded: Array, failed: Array, skipped: Array}>}
+     */
+    async loadTracksIntoTargets(configs) {
+        return loadTracksIntoTargets(this.currentBrowser, this.targetedBrowsers, configs)
+    }
+
+    /**
+     * Clear the aim and make `browser` current: the plain click.
+     *
+     * Internal -- a host selects through `select` and aims through
+     * `toggleTarget`; this is the one gesture that does both, and it is the
+     * only way back from a large target set.
+     *
+     * The clear is deliberately *not* folded into `select` itself, even though
+     * every plain click ends there. `select` is also how a new browser becomes
+     * current, how a deleted browser's selection falls through to a survivor,
+     * and how a restore settles -- and none of those is the user re-aiming.
+     * Per the lifecycle table in #615, adding a panel must not destroy the aim
+     * the user set up.
+     */
+    retarget(browser) {
+        this.#announce(() => {
+            this.#targeted.clear()
+            this.#select(browser)
+        })
+    }
+
+    /**
+     * Is `browser` in the target set by an explicit gesture, rather than by
+     * being the current one?
+     *
+     * Internal, and the question only `HICBrowser.reset` asks: a reset disposes
+     * and rebuilds, and the target set has to survive that (unlike the sync
+     * group, which is a rule that gets recomputed -- targeting is a user's act
+     * a reset should not silently undo). `reset` captures this before the
+     * teardown and hands it back to `reclaimSlot`.
+     */
+    isTargetedExplicitly(browser) {
+        return this.#targeted.has(browser)
+    }
+
+    /**
+     * Run `mutate`, and post `BrowserTargetChange` if the resolved target set
+     * came out different.
+     *
+     * One place computes the set before and after, so every route that can
+     * change it -- an explicit toggle, a re-aim, a selection moving, a browser
+     * leaving or coming back -- announces without each having to work out
+     * whether it did. The badge class is applied here for the same reason.
+     *
+     * The event carries the resolved array, so a host need not re-derive the
+     * implicit-current rule, and the registry, because the bus is page-wide
+     * while a target set is per embed. Plural name because the subject is a
+     * set, unlike `BrowserSelect`.
+     */
+    #announce(mutate) {
+
+        if (0 === this.#announceDepth++) {
+            this.#announceBefore = this.targetedBrowsers
+        }
+
+        try {
+            mutate()
+        } finally {
+            if (0 === --this.#announceDepth) {
+
+                const before = this.#announceBefore
+                const after = this.targetedBrowsers
+
+                if (before.length !== after.length || after.some((browser, i) => browser !== before[i])) {
+
+                    for (const browser of before) {
+                        browser.rootElement?.classList.remove('hic-root-targeted')
+                    }
+                    for (const browser of after) {
+                        browser.rootElement?.classList.add('hic-root-targeted')
+                    }
+
+                    EventBus.globalBus.post(HICEvent("BrowserTargetChange", {registry: this, targetedBrowsers: after}))
+                }
+            }
         }
     }
 
@@ -212,10 +391,18 @@ class BrowserRegistry {
      * *evict* on what a registry's own teardown does to the container map.
      */
     releaseSlot(browser) {
-        this.browsers = this.browsers.filter(b => b !== browser)
-        if (browser === this.currentBrowser) {
-            this.select(this.browsers[0])
-        }
+        this.#announce(() => {
+            this.browsers = this.browsers.filter(b => b !== browser)
+            // Dropped rather than left to the `browsers` filter in
+            // `targetedBrowsers`: a disposed browser is fatal on use, via
+            // `#assertNotDisposed`, not merely stale, so the registry should
+            // not still be holding a reference to one.
+            this.#targeted.delete(browser)
+            browser.rootElement?.classList.remove('hic-root-targeted')
+            if (browser === this.currentBrowser) {
+                this.#select(this.browsers[0])
+            }
+        })
         this.refreshDeleteButtonVisibility()
     }
 
@@ -241,15 +428,22 @@ class BrowserRegistry {
      * @param {boolean} wasCurrent - whether this browser was the current one
      *   before it disposed itself.
      */
-    reclaimSlot(browser, index, wasCurrent) {
+    reclaimSlot(browser, index, wasCurrent, wasTargeted) {
 
-        this.browsers.splice(Math.min(index, this.browsers.length), 0, browser)
+        this.#announce(() => {
 
-        if (wasCurrent) {
-            this.currentBrowser = browser
-            browser.rootElement.classList.add('hic-root-selected')
-            mostRecentlySelectedBrowser = browser
-        }
+            this.browsers.splice(Math.min(index, this.browsers.length), 0, browser)
+
+            if (wasTargeted) {
+                this.#targeted.add(browser)
+            }
+
+            if (wasCurrent) {
+                this.currentBrowser = browser
+                browser.rootElement.classList.add('hic-root-selected')
+                mostRecentlySelectedBrowser = browser
+            }
+        })
 
         this.refreshDeleteButtonVisibility()
     }

--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -43,9 +43,11 @@ class BrowserRegistry {
      * a caller gets is the *resolved* set, derived from `browsers` on every
      * ask, so a browser that has left the registry cannot linger in it.
      *
-     * The current browser is not normally in here -- it is targeted implicitly
-     * -- but it can be, when a browser that was already aimed at later becomes
-     * current. See `toggleTarget`.
+     * The current browser **is** in here while an aim is in progress, even
+     * though it would be targeted implicitly anyway. That redundancy is
+     * load-bearing: an empty set is how `toggleTarget` knows the next
+     * shift-click is starting a *new* aim rather than adding to one, which is
+     * what makes the first click of an aim the one that selects.
      */
     #targeted = new Set()
 
@@ -156,14 +158,6 @@ class BrowserRegistry {
         // own registry is not necessarily the last one selected page-wide.
         mostRecentlySelectedBrowser = browser
 
-        // The invariant that keeps `toggleTarget`'s early return honest: the
-        // current browser is targeted *implicitly*, so it is never also in the
-        // explicit set. Without this, a browser aimed at and then selected --
-        // which a host does through `select`, not only through a plain click --
-        // would be un-removable while current (the toggle is a no-op there) and
-        // would silently stay targeted once the selection moved on.
-        this.#targeted.delete(browser)
-
         if (browser !== this.currentBrowser) {
             this.currentBrowser?.rootElement.classList.remove('hic-root-selected')
             browser.rootElement.classList.add('hic-root-selected')
@@ -218,11 +212,33 @@ class BrowserRegistry {
         // recording one would be the retained reference `releaseSlot` exists to
         // avoid -- `targetedBrowsers` filters it out, so it would never be seen
         // again either.
-        if (browser === this.currentBrowser || !this.browsers.includes(browser)) {
+        if (!this.browsers.includes(browser)) {
             return
         }
 
         this.#announce(() => {
+
+            // The first shift-click of a new aim also **selects**. The load is
+            // issued from the current browser, and the current browser is the
+            // track's genome declaration (`js/targetGroup.js`), so without this
+            // an aim inherits its genome from whichever panel happened to be
+            // current -- typically the last one built, which the user never
+            // touched. The panels they actually aimed at are then reported as
+            // `genome-mismatch` and the track lands in the one panel they did
+            // not choose. Selecting here makes the browser the aim *starts*
+            // from the browser it is measured against.
+            //
+            // Semantically odd -- a gesture named for targeting also moves the
+            // selection -- and deliberate: the alternative is an aim whose
+            // origin the user cannot see or set.
+            if (0 === this.#targeted.size) {
+                this.#targeted.add(browser)
+                this.#select(browser)
+                return
+            }
+
+            // Every later click just joins or leaves. The selection does not
+            // move again, so the aim keeps the origin its first click set.
             if (!this.#targeted.delete(browser)) {
                 this.#targeted.add(browser)
             }

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -387,7 +387,15 @@ class DataLoader {
     }
 
     /**
-     * Load tracks (1D and 2D) from configuration.
+     * Load tracks (1D and 2D) from configuration, reporting a failure in this
+     * embed's alert dialog.
+     *
+     * It catches and resolves rather than rejecting, and that is contract:
+     * `HICBrowser.loadTracks` is published surface, two hosts call it, and what
+     * they observe is that a bad track raises a modal and the promise settles.
+     * The body is `loadTracksOrThrow` below, which is what the target-set
+     * fan-out calls -- N loads reported once, on the host's own notification
+     * surface, cannot be built over a loader that swallows. #615.
      *
      * @param {Array<Object>} configs - Array of track configuration objects
      * @returns {Promise<void>}
@@ -396,6 +404,26 @@ class DataLoader {
         const errorPrefix = configs.length === 1 ?
             `Error loading track ${configs[0].name}` :
             "Error loading tracks";
+
+        try {
+            await this.loadTracksOrThrow(configs);
+        } catch (error) {
+            presentError(this.browser.registry, errorPrefix, error);
+            console.error(error);
+        }
+    }
+
+    /**
+     * The load itself: everything `loadTracks` above does except the reporting.
+     *
+     * The spinner is here rather than in the wrapper because it belongs to the
+     * work, not to the reporting -- both callers want it, and a caller that
+     * throws still has to put it away.
+     *
+     * @param {Array<Object>} configs - Array of track configuration objects
+     * @returns {Promise<void>}
+     */
+    async loadTracksOrThrow(configs) {
 
         try {
             this.browser.contactMatrixView.startSpinner();
@@ -478,9 +506,6 @@ class DataLoader {
                 }
             }
 
-        } catch (error) {
-            presentError(this.browser.registry, errorPrefix, error);
-            console.error(error);
         } finally {
             this.browser.contactMatrixView.stopSpinner();
         }

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -406,19 +406,21 @@ class DataLoader {
             "Error loading tracks";
 
         try {
-            await this.loadTracksOrThrow(configs);
+            await this.#loadTracks(configs);
         } catch (error) {
             presentError(this.browser.registry, errorPrefix, error);
             console.error(error);
+        } finally {
+            this.browser.contactMatrixView.stopSpinner();
         }
     }
 
     /**
-     * The load itself: everything `loadTracks` above does except the reporting.
+     * The load, rejecting on failure: `loadTracks` above without the reporting.
      *
-     * The spinner is here rather than in the wrapper because it belongs to the
-     * work, not to the reporting -- both callers want it, and a caller that
-     * throws still has to put it away.
+     * Internal in the sense the registry's `releaseSlot` is -- not declared
+     * surface, and reached from one place: `HICBrowser.loadTracksOrThrow`, which
+     * the target-set fan-out calls. #615.
      *
      * @param {Array<Object>} configs - Array of track configuration objects
      * @returns {Promise<void>}
@@ -426,88 +428,104 @@ class DataLoader {
     async loadTracksOrThrow(configs) {
 
         try {
-            this.browser.contactMatrixView.startSpinner();
-
-            const tracks = [];
-            const promises2D = [];
-
-            for (let config of configs) {
-                const fileName = isFile(config.url)
-                    ? config.url.name
-                    : config.filename || await FileUtils.getFilename(config.url);
-
-                const extension = hicUtils.getExtension(fileName);
-
-                if (['fasta', 'fa'].includes(extension)) {
-                    config.type = config.format = 'sequence';
-                }
-
-                // What the *load* discovers, and only that: a missing `max` means
-                // autoscale, and the height comes from the live layout. Neither
-                // is a question a session document can answer.
-                //
-                // The annotation colour and display mode used to be defaulted
-                // here too, conditioned on `config.type === 'annotation'`. They
-                // were a second copy of two `normalizeTrackConfigs` rules, kept
-                // through #533 because a track added at runtime met no normalize
-                // stage. It meets one at `HICBrowser.loadTracks` now, so the copy
-                // is gone and this loader defaults nothing a config carries
-                // (#536).
-                if (config.max === undefined) {
-                    config.autoscale = true;
-                }
-
-                const { trackHeight } = getLayoutDimensions();
-                config.height = trackHeight;
-
-                // 2D tracks: bedpe/interact by format or extension, or a juicebox
-                // loops/peaks list (.txt) for which igv.js can't infer a 1D format.
-                // Note: hicUtils.getExtension() strips .txt as an aux extension, so
-                // test the raw filename rather than `extension` for the .txt case.
-                const lowerName = fileName.toLowerCase();
-                const is2D = ['bedpe', 'interact'].includes(config.format)
-                    || ['bedpe', 'interact'].includes(extension)
-                    || (config.format === undefined
-                        && (lowerName.endsWith('.txt') || lowerName.endsWith('.txt.gz')));
-                if (is2D) {
-                    promises2D.push(Track2D.loadTrack2D(config, this.browser.genome));
-                } else {
-                    // igv reads the track through its own bundled loaders, which juicebox cannot
-                    // reach into — the config's `url` is the only lever. mapTrackConfig carries the
-                    // original alongside so toJSON can serialize it. See issue #450.
-                    const track = await igv.createTrack(mapTrackConfig(config), this.browser);
-
-                    if (typeof track.postInit === 'function') {
-                        await track.postInit();
-                    }
-
-                    tracks.push(track);
-                }
-            }
-
-            if (tracks.length > 0) {
-                this.browser.layoutController.updateLayoutWithTracks(tracks);
-
-                const gearContainer = document.querySelector('.hic-igv-right-hand-gutter');
-                if (this.browser.showTrackLabelAndGutter) {
-                    gearContainer.style.display = 'block';
-                } else {
-                    gearContainer.style.display = 'none';
-                }
-
-                await this.browser.updateLayout();
-            }
-
-            if (promises2D.length > 0) {
-                const tracks2D = await Promise.all(promises2D);
-                if (tracks2D && tracks2D.length > 0) {
-                    this.browser.tracks2D = this.browser.tracks2D.concat(tracks2D);
-                    this.browser.coordinator.onTrackLoad2D(this.browser.tracks2D);
-                }
-            }
-
+            await this.#loadTracks(configs);
         } finally {
             this.browser.contactMatrixView.stopSpinner();
+        }
+    }
+
+    /**
+     * The work both of the two above do, minus what each does about failure.
+     *
+     * The spinner is *started* here and stopped by each caller, rather than
+     * wrapped around this whole method, so that `loadTracks` keeps the exact
+     * order it has always had: report first, then put the spinner away. That
+     * order is observable -- the alert is modal -- and the split was required to
+     * leave the public method byte-identical in behaviour.
+     *
+     * @param {Array<Object>} configs - Array of track configuration objects
+     * @returns {Promise<void>}
+     */
+    async #loadTracks(configs) {
+
+        this.browser.contactMatrixView.startSpinner();
+
+        const tracks = [];
+        const promises2D = [];
+
+        for (let config of configs) {
+            const fileName = isFile(config.url)
+                ? config.url.name
+                : config.filename || await FileUtils.getFilename(config.url);
+
+            const extension = hicUtils.getExtension(fileName);
+
+            if (['fasta', 'fa'].includes(extension)) {
+                config.type = config.format = 'sequence';
+            }
+
+            // What the *load* discovers, and only that: a missing `max` means
+            // autoscale, and the height comes from the live layout. Neither
+            // is a question a session document can answer.
+            //
+            // The annotation colour and display mode used to be defaulted
+            // here too, conditioned on `config.type === 'annotation'`. They
+            // were a second copy of two `normalizeTrackConfigs` rules, kept
+            // through #533 because a track added at runtime met no normalize
+            // stage. It meets one at `HICBrowser.loadTracks` now, so the copy
+            // is gone and this loader defaults nothing a config carries
+            // (#536).
+            if (config.max === undefined) {
+                config.autoscale = true;
+            }
+
+            const { trackHeight } = getLayoutDimensions();
+            config.height = trackHeight;
+
+            // 2D tracks: bedpe/interact by format or extension, or a juicebox
+            // loops/peaks list (.txt) for which igv.js can't infer a 1D format.
+            // Note: hicUtils.getExtension() strips .txt as an aux extension, so
+            // test the raw filename rather than `extension` for the .txt case.
+            const lowerName = fileName.toLowerCase();
+            const is2D = ['bedpe', 'interact'].includes(config.format)
+                || ['bedpe', 'interact'].includes(extension)
+                || (config.format === undefined
+                    && (lowerName.endsWith('.txt') || lowerName.endsWith('.txt.gz')));
+            if (is2D) {
+                promises2D.push(Track2D.loadTrack2D(config, this.browser.genome));
+            } else {
+                // igv reads the track through its own bundled loaders, which juicebox cannot
+                // reach into — the config's `url` is the only lever. mapTrackConfig carries the
+                // original alongside so toJSON can serialize it. See issue #450.
+                const track = await igv.createTrack(mapTrackConfig(config), this.browser);
+
+                if (typeof track.postInit === 'function') {
+                    await track.postInit();
+                }
+
+                tracks.push(track);
+            }
+        }
+
+        if (tracks.length > 0) {
+            this.browser.layoutController.updateLayoutWithTracks(tracks);
+
+            const gearContainer = document.querySelector('.hic-igv-right-hand-gutter');
+            if (this.browser.showTrackLabelAndGutter) {
+                gearContainer.style.display = 'block';
+            } else {
+                gearContainer.style.display = 'none';
+            }
+
+            await this.browser.updateLayout();
+        }
+
+        if (promises2D.length > 0) {
+            const tracks2D = await Promise.all(promises2D);
+            if (tracks2D && tracks2D.length > 0) {
+                this.browser.tracks2D = this.browser.tracks2D.concat(tracks2D);
+                this.browser.coordinator.onTrackLoad2D(this.browser.tracks2D);
+            }
         }
     }
 

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -602,6 +602,20 @@ class HICBrowser {
         return this.dataLoader.loadTracks(normalizeTrackConfigs(configs));
     }
 
+    /**
+     * `loadTracks`, but it rejects instead of alerting.
+     *
+     * Internal, and the one the target-set fan-out calls: a fan-out reports
+     * once per gesture, on the host's own notification surface, so it needs to
+     * be able to tell a target's failure from its success -- which the public
+     * method cannot say, because it catches, alerts and resolves. Same
+     * normalization, same loader body; only the reporting differs. #615.
+     */
+    async loadTracksOrThrow(configs) {
+        this.#assertNotDisposed('loadTracksOrThrow');
+        return this.dataLoader.loadTracksOrThrow(normalizeTrackConfigs(configs));
+    }
+
     async loadNormalizationFile(url) {
         return this.dataLoader.loadNormalizationFile(url);
     }
@@ -745,7 +759,9 @@ class HICBrowser {
      * siblings, its registry slot, and being the current browser.
      *
      * The sync group is not restored: `reset()` has always unsynced, and the
-     * registry re-pairs on the next `sync()`.
+     * registry re-pairs on the next `sync()`. The **target set** is restored,
+     * and the two diverge on purpose -- see `wasTargeted` below and
+     * `docs/adr/0015`.
      */
     reset() {
 
@@ -755,6 +771,13 @@ class HICBrowser {
         const appContainer = this.rootElement.parentElement
         const slot = registry.browsers.indexOf(this)
         const wasCurrent = registry.currentBrowser === this
+
+        // Captured before the teardown, because `dispose()` drops this browser
+        // from the target set on its way out -- and unlike the sync group, the
+        // target set survives a reset. Sync membership is a rule that gets
+        // recomputed; targeting is a user's act, and a reset should not
+        // silently undo it. #615.
+        const wasTargeted = registry.isTargetedExplicitly(this)
 
         // The node to re-insert before, and it has to be one that survives the
         // teardown: `rootElement`'s immediate sibling is this browser's own
@@ -792,7 +815,7 @@ class HICBrowser {
         // Not registered before the reset -- during `init()`, or in a test --
         // so there is no slot to take back and nothing to select.
         if (-1 !== slot) {
-            registry.reclaimSlot(this, slot, wasCurrent)
+            registry.reclaimSlot(this, slot, wasCurrent, wasTargeted)
         }
     }
 

--- a/js/layoutController.js
+++ b/js/layoutController.js
@@ -4,7 +4,7 @@
 import Ruler from './ruler.js'
 import TrackPair, {setTrackReorderArrowColors} from './trackPair.js'
 import TrackRenderer from './trackRenderer.js';
-import {deleteBrowser, setCurrentBrowser} from './createBrowser.js'
+import {deleteBrowser} from './createBrowser.js'
 import HICEvent from "./hicEvent.js";
 import EventBus from "./eventBus.js";
 import { createDOMFromHTMLString } from "./utils.js"
@@ -288,10 +288,19 @@ function createNavBar(browser, root) {
     hicNavbarContainer.className = 'hic-navbar-container';
     root.appendChild(hicNavbarContainer);
 
+    // Plain click selects; shift-click aims. The navbar and not the whole panel,
+    // because a shift over the contact map already means crosshairs -- see
+    // `contactMatrixView`. A plain click is what it has always been, except
+    // that it now also clears the target set: it is the only way back from a
+    // large aim. #615, docs/adr/0015.
     hicNavbarContainer.addEventListener('click', e => {
         e.stopPropagation();
         e.preventDefault();
-        setCurrentBrowser(browser);
+        if (e.shiftKey) {
+            browser.registry.toggleTarget(browser);
+        } else {
+            browser.registry.retarget(browser);
+        }
     });
 
     const htmlContactMapHicNavBarMapContainer =

--- a/js/publicApi.js
+++ b/js/publicApi.js
@@ -199,6 +199,19 @@ export const REGISTRY_SURFACE = [
     // default. Decision 6.
     'sync',
 
+    // The target set, new in #615: which browsers a *load* reaches, the one
+    // gesture that changes it, and the fan-out itself. A different mechanism
+    // from the sync group, with different membership and different cargo --
+    // ADR-0015. Declared rather than discovered because a host is what calls
+    // the fan-out: the track menu that issues one lives in juicebox-web.
+    //
+    // Nothing existing became plural to get here. `currentBrowser`,
+    // `BrowserSelect` and `HICBrowser.loadTracks` mean exactly what they meant
+    // before; a host opts in by calling the new method.
+    'targetedBrowsers',
+    'toggleTarget',
+    'loadTracksIntoTargets',
+
     // A session describes one embed; these are where one is actually written
     // and read. The exported `toJSON`/`restoreSession` delegate here.
     'toJSON',
@@ -340,6 +353,7 @@ export const COORDINATOR_PAYLOAD_SHAPES = [
 export const EVENTS_POSTED = [
     {name: 'GenomeChange', bus: 'global'},
     {name: 'BrowserSelect', bus: 'global'},
+    {name: 'BrowserTargetChange', bus: 'global'},
     {name: 'TrackXYPairLoad', bus: 'global'},
     {name: 'TrackXYPairRemoval', bus: 'global'},
     {name: 'DidHideCrosshairs', bus: 'browser'},
@@ -360,6 +374,11 @@ export const EVENTS_POSTED = [
  * Declaration only; verifying it means posting a real track load.
  */
 export const EVENT_PAYLOAD_SHAPES = [
+    // Plural name because the subject is a set, unlike `BrowserSelect`, whose
+    // payload is the one browser. It carries the *resolved* array so a host
+    // need not re-derive the implicit-current rule, and the registry because
+    // the bus is page-wide while a target set is per embed. #615.
+    {event: 'BrowserTargetChange', payload: '{registry, targetedBrowsers}', readsInto: ['registry', 'targetedBrowsers']},
     {event: 'TrackXYPairLoad', payload: 'the TrackPair itself', readsInto: ['track', 'track.name', 'track.config.format']},
     {event: 'TrackXYPairRemoval', payload: 'the TrackPair itself', readsInto: ['track', 'track.name', 'track.config.format']}
 ]

--- a/js/publicApi.js
+++ b/js/publicApi.js
@@ -169,6 +169,17 @@ export const BROWSER_SURFACE = [
  * settled once -- and mean nothing to a caller outside it; and `alertDialog`,
  * which is the lazily built igv-ui dialog behind `presentAlert`. A host raises
  * an alert; which widget the registry does it with is ours to change.
+ *
+ * Also deliberately not declared, and new in #615: `retarget`, which is the
+ * plain-click gesture (a host that wants its effect calls `select`, and the
+ * clear that goes with it is the *user's* re-aim, not an API operation);
+ * `isTargetedExplicitly`, which exists so `HICBrowser.reset` can carry
+ * membership across its own teardown, as `releaseSlot` and `reclaimSlot`
+ * already carry the slot; and the browser's own `loadTracksOrThrow`, which is
+ * `loadTracks` without the alert and is what the fan-out is built on. A host
+ * that wants a rejecting load should be given a declared name for it rather
+ * than finding this one -- absence from this file is not permission, and
+ * naming them here is what makes that decision visible.
  */
 export const REGISTRY_SURFACE = [
     // The element this registry owns, which is what it is keyed by.
@@ -210,6 +221,11 @@ export const REGISTRY_SURFACE = [
     // before; a host opts in by calling the new method.
     'targetedBrowsers',
     'toggleTarget',
+    // Resolves to `{loaded, failed, skipped}`. The two skip reasons --
+    // `'no-dataset'` and `'genome-mismatch'` -- are as much contract as the
+    // field names: a host branching on a third spelling nobody declared is
+    // exactly the failure #471 was. They are defined in `js/targetGroup.js` and
+    // pinned by `test/testTargetGroup.js`.
     'loadTracksIntoTargets',
 
     // A session describes one embed; these are where one is actually written

--- a/js/targetGroup.js
+++ b/js/targetGroup.js
@@ -1,0 +1,116 @@
+/**
+ * The **target set**: the browsers a *load* reaches. Not a sync group.
+ *
+ * `js/syncGroup.js` holds the rule for what a browser publishes its canonical
+ * state to; this module holds the rule for what a track load fans out to. They
+ * are two different mechanisms for "one action reaching several browsers", and
+ * the distinction is the load-bearing part of the design -- membership here is
+ * an explicit user gesture rather than a computed rule, the cargo is dataset
+ * choices rather than canonical state, and the lifetime is until the user
+ * re-aims rather than standing. See `docs/adr/0015` and `CONTEXT.md`.
+ *
+ * One file per mechanism, so the distinction is visible in the tree and not
+ * only in the ADR. Like `pairSynchable` and `canResolveSyncState` next door,
+ * everything here is a pure function over browsers: no registry, no DOM, and so
+ * unit-testable against fabricated objects.
+ */
+
+/**
+ * Why this target cannot take the originating browser's tracks, or `undefined`
+ * if it can.
+ *
+ * Two skips, and both are *skips* rather than throws -- the precedent is
+ * `canResolveSyncState` (#605), which declines a state it cannot place rather
+ * than failing the publication.
+ *
+ * - **`'no-dataset'`**: an empty browser is a normal transient state, not an
+ *   error. A panel the user has opened but not yet loaded a map into is a
+ *   perfectly ordinary thing to have aimed at.
+ * - **`'genome-mismatch'`**: tracks carry no genome of their own, so the
+ *   *originating* browser is the track's genome declaration -- the menu the
+ *   track came from was built for that browser's genome. This is the skip that
+ *   prevents the nasty failure: not an error, just a track drawn at meaningless
+ *   coordinates in a panel nobody was watching.
+ *
+ * `genome` rather than `dataset.genomeId` because `genome` is what the 2D
+ * loader is handed (`Track2D.loadTrack2D(config, browser.genome)`) and what a
+ * 1D track resolves its chromosome names against.
+ *
+ * @param {Object} originating - the browser the load was issued from
+ * @param {Object} target - a browser in the target set
+ * @returns {string|undefined} the skip reason, or `undefined` to load
+ */
+function trackSkipReason(originating, target) {
+
+    if (undefined === target.dataset) {
+        return 'no-dataset'
+    }
+
+    if (target.genome?.id !== originating.genome?.id) {
+        return 'genome-mismatch'
+    }
+
+    return undefined
+}
+
+/**
+ * Load `configs` into every browser in `targets` that can take them.
+ *
+ * Concurrent and unbounded, over `Promise.allSettled`: one gesture, N loads,
+ * and no target's failure stops another's. Concurrency is deliberately *not*
+ * capped here -- #588 is the unbounded-track-load problem and it deserves one
+ * global answer wherever it lands, not a second, local one in this file. What
+ * this feature does is multiply that blast radius, which is why #588 names it.
+ *
+ * Each target gets its own copy of each config, because igv mutates what it is
+ * handed: `DataLoader.loadTracks` sets `autoscale`, `height`, and sometimes
+ * `type`/`format` on the object it is given, and igv's own track constructors
+ * keep a reference to it. Sharing one object across N browsers would let the
+ * first load's discoveries leak into the rest. The copy is shallow, which is
+ * what the mutation is.
+ *
+ * **Raises no alert.** It returns the summary and the caller reports -- one
+ * report per gesture, not one modal per browser, and *where* that report
+ * appears is a host's decision. juicebox-web and Spacewalk have different
+ * notification surfaces. This is why the fan-out needs a loader that throws:
+ * `HICBrowser.loadTracks` catches, alerts and resolves, so a fan-out over it
+ * could not tell failure from success.
+ *
+ * @param {Object} originating - the browser the load was issued from, and the
+ *   track's genome declaration
+ * @param {Array<Object>} targets - the resolved target set
+ * @param {Array<Object>} configs - track configs, as `loadTracks` takes them
+ * @param {Function} [load] - how one browser is loaded; the seam a test drives
+ * @returns {Promise<{loaded: Array, failed: Array, skipped: Array}>}
+ */
+async function loadTracksIntoTargets(originating, targets, configs, load = (browser, ownConfigs) => browser.loadTracksOrThrow(ownConfigs)) {
+
+    const summary = {loaded: [], failed: [], skipped: []}
+
+    const attempted = []
+
+    for (const target of targets) {
+        const reason = trackSkipReason(originating, target)
+        if (undefined === reason) {
+            attempted.push(target)
+        } else {
+            summary.skipped.push({browser: target, reason})
+        }
+    }
+
+    const settled = await Promise.allSettled(
+        attempted.map(target => load(target, configs.map(config => ({...config}))))
+    )
+
+    settled.forEach((outcome, i) => {
+        if ('fulfilled' === outcome.status) {
+            summary.loaded.push(attempted[i])
+        } else {
+            summary.failed.push({browser: attempted[i], error: outcome.reason})
+        }
+    })
+
+    return summary
+}
+
+export {trackSkipReason, loadTracksIntoTargets}

--- a/js/targetGroup.js
+++ b/js/targetGroup.js
@@ -56,6 +56,10 @@ function trackSkipReason(originating, target) {
 /**
  * Load `configs` into every browser in `targets` that can take them.
  *
+ * Named for the fan-out rather than for the registry method that calls it
+ * (`registry.loadTracksIntoTargets`), so a grep or a stack trace says which of
+ * the two is which.
+ *
  * Concurrent and unbounded, over `Promise.allSettled`: one gesture, N loads,
  * and no target's failure stops another's. Concurrency is deliberately *not*
  * capped here -- #588 is the unbounded-track-load problem and it deserves one
@@ -83,7 +87,7 @@ function trackSkipReason(originating, target) {
  * @param {Function} [load] - how one browser is loaded; the seam a test drives
  * @returns {Promise<{loaded: Array, failed: Array, skipped: Array}>}
  */
-async function loadTracksIntoTargets(originating, targets, configs, load = (browser, ownConfigs) => browser.loadTracksOrThrow(ownConfigs)) {
+async function fanOutTracks(originating, targets, configs, load = (browser, ownConfigs) => browser.loadTracksOrThrow(ownConfigs)) {
 
     const summary = {loaded: [], failed: [], skipped: []}
 
@@ -113,4 +117,4 @@ async function loadTracksIntoTargets(originating, targets, configs, load = (brow
     return summary
 }
 
-export {trackSkipReason, loadTracksIntoTargets}
+export {trackSkipReason, fanOutTracks}

--- a/test/testBrowserTargeting.js
+++ b/test/testBrowserTargeting.js
@@ -157,6 +157,34 @@ describe('the target set', () => {
         expect(registry.targetedBrowsers).toEqual([a])
     })
 
+    it('drops explicit membership when a browser becomes current', () => {
+        // A host selects through `select`, not only through the plain click. A
+        // browser aimed at and then selected must not stay in the explicit set:
+        // shift-clicking it while current is a no-op, so it would be
+        // un-removable, and it would silently stay targeted afterwards.
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+        registry.toggleTarget(b)
+
+        registry.select(b)
+        expect(registry.isTargetedExplicitly(b)).toBe(false)
+
+        registry.select(a)
+        expect(registry.targetedBrowsers).toEqual([a])
+    })
+
+    it('ignores a browser this registry does not own', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        registry.select(a)
+        const stranger = fakeBrowser('stranger', {genomeId: 'hg38'})
+
+        registry.toggleTarget(stranger)
+
+        expect(registry.targetedBrowsers).toEqual([a])
+        expect(registry.isTargetedExplicitly(stranger)).toBe(false)
+    })
+
     it('is cleared by a plain click on the browser that is already current', () => {
         // The case a "clear only on a real transition" rule would miss: the
         // user has aimed at three panels and clicks the one the widgets are
@@ -300,6 +328,20 @@ describe('the target set through a lifecycle', () => {
         registry.reclaimSlot(b, slot, false, wasTargeted)
 
         expect(registry.targetedBrowsers).toEqual([a, b])
+    })
+
+    it('lets go of the aim when the registry gives up its browsers', () => {
+        // `clear()` is the other half of the restore: `createBrowserList` calls
+        // it before rebuilding. The getter filters over `browsers`, so a
+        // reference left here would be invisible rather than harmless.
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+        registry.toggleTarget(b)
+
+        registry.clear()
+
+        expect(registry.isTargetedExplicitly(b)).toBe(false)
     })
 
     it('starts empty after a restore, and is never serialized', () => {

--- a/test/testBrowserTargeting.js
+++ b/test/testBrowserTargeting.js
@@ -70,6 +70,20 @@ function add(name, options) {
 
 const isTargeted = browser => browser.rootElement.classList.contains('hic-root-targeted')
 
+/**
+ * The gesture as a user makes it: shift-click each panel in turn.
+ *
+ * The first click of a new aim also selects, so `aim(a, b)` leaves `a` current
+ * -- and `a` is therefore the browser a fan-out is issued from and measured
+ * against. Fixtures say `aim(...)` rather than `select` + `toggleTarget` so they
+ * cannot express a state the gesture cannot reach.
+ */
+function aim(...browsers) {
+    for (const browser of browsers) {
+        registry.toggleTarget(browser)
+    }
+}
+
 let events
 
 const targetListener = event => events.push(event)
@@ -102,6 +116,8 @@ describe('the target set', () => {
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
         registry.select(a)
+        // a starts the aim -- the first click selects, and a is already current
+        registry.toggleTarget(a)
 
         registry.toggleTarget(b)
         expect(registry.targetedBrowsers).toEqual([a, b])
@@ -114,21 +130,74 @@ describe('the target set', () => {
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
         const c = add('c', {genomeId: 'hg38'})
-        registry.select(b)
 
-        registry.toggleTarget(c)
-        registry.toggleTarget(a)
+        aim(b, c, a)
 
+        expect(registry.currentBrowser).toBe(b)
         expect(registry.targetedBrowsers).toEqual([a, b, c])
     })
 
-    it('ignores a toggle of the current browser, which is targeted implicitly', () => {
+    it('makes the first shift-click of a new aim the current browser', () => {
+        // The load is issued from the current browser, and that browser is the
+        // track's genome declaration. Without this, an aim inherits its genome
+        // from whichever panel happened to be current -- typically the last one
+        // built -- and every panel the user aimed at is reported as a mismatch.
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        const untouched = add('untouched', {genomeId: 'mm10'})
+        registry.select(untouched)
+
+        registry.toggleTarget(a)
+
+        expect(registry.currentBrowser).toBe(a)
+        expect(registry.targetedBrowsers).toEqual([a])
+
+        registry.toggleTarget(b)
+
+        expect(registry.currentBrowser).toBe(a)
+        expect(registry.targetedBrowsers).toEqual([a, b])
+    })
+
+    it('does not move the selection again once an aim is under way', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        const c = add('c', {genomeId: 'hg38'})
+        registry.select(c)
+
+        registry.toggleTarget(a)
+        registry.toggleTarget(b)
+        registry.toggleTarget(b)
+        registry.toggleTarget(b)
+
+        expect(registry.currentBrowser).toBe(a)
+        expect(registry.targetedBrowsers).toEqual([a, b])
+    })
+
+    it('starts a fresh aim after the last explicit member leaves', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+
+        // a is the origin, and the only explicit member; taking it back out
+        // ends the aim, so the next click starts a new one and selects.
+        registry.toggleTarget(a)
+        registry.toggleTarget(a)
+        registry.toggleTarget(b)
+
+        expect(registry.currentBrowser).toBe(b)
+        expect(registry.targetedBrowsers).toEqual([b])
+    })
+
+    it('changes nothing visible when the current browser is shift-clicked', () => {
+        // #615: "shift-clicking it is a no-op". It is one in the resolved set
+        // and in the event -- it starts the aim, which is internal.
         const a = add('a', {genomeId: 'hg38'})
         registry.select(a)
         events.length = 0
 
         registry.toggleTarget(a)
 
+        expect(registry.currentBrowser).toBe(a)
         expect(registry.targetedBrowsers).toEqual([a])
         expect(events).toEqual([])
     })
@@ -148,30 +217,31 @@ describe('the target set', () => {
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
         const c = add('c', {genomeId: 'hg38'})
-        registry.select(a)
-        registry.toggleTarget(b)
-        registry.toggleTarget(c)
+        aim(a, b, c)
 
         registry.retarget(a)
 
         expect(registry.targetedBrowsers).toEqual([a])
     })
 
-    it('drops explicit membership when a browser becomes current', () => {
-        // A host selects through `select`, not only through the plain click. A
-        // browser aimed at and then selected must not stay in the explicit set:
-        // shift-clicking it while current is a no-op, so it would be
-        // un-removable, and it would silently stay targeted afterwards.
+    it('keeps an aim across a selection a host makes', () => {
+        // `select` is a host's call, not the user's re-aim -- only a plain click
+        // clears. So an aim survives the selection moving, and the browsers the
+        // user chose are still the ones a load reaches.
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
+        const c = add('c', {genomeId: 'hg38'})
         registry.select(a)
+        registry.toggleTarget(a)
         registry.toggleTarget(b)
 
-        registry.select(b)
-        expect(registry.isTargetedExplicitly(b)).toBe(false)
+        registry.select(c)
 
-        registry.select(a)
-        expect(registry.targetedBrowsers).toEqual([a])
+        expect(registry.targetedBrowsers).toEqual([a, b, c])
+
+        registry.retarget(c)
+
+        expect(registry.targetedBrowsers).toEqual([c])
     })
 
     it('ignores a browser this registry does not own', () => {
@@ -191,8 +261,7 @@ describe('the target set', () => {
         // already reading.
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
-        registry.select(a)
-        registry.toggleTarget(b)
+        aim(a, b)
 
         registry.retarget(a)
 
@@ -205,7 +274,7 @@ describe('BrowserTargetChange', () => {
     it('fires on a toggle, carrying the registry and the resolved set', () => {
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
-        registry.select(a)
+        aim(a)
         events.length = 0
 
         registry.toggleTarget(b)
@@ -230,8 +299,7 @@ describe('BrowserTargetChange', () => {
     it('fires once for a plain click that both clears and re-aims', () => {
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
-        registry.select(a)
-        registry.toggleTarget(b)
+        aim(a, b)
         events.length = 0
 
         registry.retarget(b)
@@ -254,8 +322,7 @@ describe('BrowserTargetChange', () => {
     it('drives the badge class, which is not the selected class', () => {
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
-        registry.select(a)
-        registry.toggleTarget(b)
+        aim(a, b)
 
         expect(isTargeted(a)).toBe(true)
         expect(isTargeted(b)).toBe(true)
@@ -272,8 +339,7 @@ describe('the target set through a lifecycle', () => {
     it('drops a deleted browser', () => {
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
-        registry.select(a)
-        registry.toggleTarget(b)
+        aim(a, b)
         events.length = 0
 
         registry.delete(b)
@@ -289,8 +355,7 @@ describe('the target set through a lifecycle', () => {
         // has to be gone, not just filtered out on the way past.
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
-        registry.select(a)
-        registry.toggleTarget(b)
+        aim(a, b)
 
         registry.delete(b)
         registry.reclaimSlot(b, 1, false, false)
@@ -301,8 +366,7 @@ describe('the target set through a lifecycle', () => {
     it('does not add a newly created browser to the set', () => {
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
-        registry.select(a)
-        registry.toggleTarget(b)
+        aim(a, b)
 
         const c = add('c', {genomeId: 'hg38'})
 
@@ -319,8 +383,7 @@ describe('the target set through a lifecycle', () => {
         // captured before it disposed itself.
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
-        registry.select(a)
-        registry.toggleTarget(b)
+        aim(a, b)
 
         const wasTargeted = registry.isTargetedExplicitly(b)
         const slot = registry.browsers.indexOf(b)
@@ -336,8 +399,7 @@ describe('the target set through a lifecycle', () => {
         // reference left here would be invisible rather than harmless.
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
-        registry.select(a)
-        registry.toggleTarget(b)
+        aim(a, b)
 
         registry.clear()
 
@@ -347,8 +409,7 @@ describe('the target set through a lifecycle', () => {
     it('starts empty after a restore, and is never serialized', () => {
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
-        registry.select(a)
-        registry.toggleTarget(b)
+        aim(a, b)
 
         // The open of `restoreSession`, without the rebuild it cannot do
         // without a document.
@@ -367,8 +428,7 @@ describe('loadTracksIntoTargets', () => {
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
         const other = add('other', {genomeId: 'hg38'})
-        registry.select(a)
-        registry.toggleTarget(b)
+        aim(a, b)
 
         const summary = await registry.loadTracksIntoTargets(configs)
 
@@ -393,9 +453,11 @@ describe('loadTracksIntoTargets', () => {
         const a = add('a', {genomeId: 'hg38'})
         const empty = add('empty')
         const mouse = add('mouse', {genomeId: 'mm10'})
-        registry.select(a)
-        registry.toggleTarget(empty)
-        registry.toggleTarget(mouse)
+
+        // Aimed from the hg38 panel, which is what the two skips are measured
+        // against -- and, since the first click selects, what the user's own
+        // first shift-click establishes.
+        aim(a, empty, mouse)
 
         const summary = await registry.loadTracksIntoTargets(configs)
 
@@ -411,8 +473,7 @@ describe('loadTracksIntoTargets', () => {
     it('reports a failure rather than raising an alert', async () => {
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
-        registry.select(a)
-        registry.toggleTarget(b)
+        aim(a, b)
         b.failing = true
 
         // A registry built without a container has no alert dialog and no
@@ -427,8 +488,7 @@ describe('loadTracksIntoTargets', () => {
     it('hands each target its own copy of each config', async () => {
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
-        registry.select(a)
-        registry.toggleTarget(b)
+        aim(a, b)
 
         await registry.loadTracksIntoTargets(configs)
 

--- a/test/testBrowserTargeting.js
+++ b/test/testBrowserTargeting.js
@@ -1,0 +1,397 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest'
+import BrowserRegistry from '../js/browserRegistry.js'
+import EventBus from '../js/eventBus.js'
+
+/**
+ * The target set on the registry -- #615, `docs/adr/0015`.
+ *
+ * The rules themselves are pure and live in `js/targetGroup.js`, pinned by
+ * `test/testTargetGroup.js`. What is asserted here is the registry's half:
+ * membership, the implicit current browser, the event, and the lifecycle table
+ * -- what a delete, a reset and a restore each do to the aim.
+ *
+ * The browsers are fabricated, as in `test/testBrowserRegistry.js`: the
+ * registry reads only a handful of members off one, which is what makes it
+ * constructible without a document. Per ADR-0013 the shift-click handler and
+ * the badge get no automated test; the class the badge is keyed on is asserted
+ * here because the registry is what applies it.
+ */
+
+function fakeElement() {
+    const classes = new Set()
+    return {
+        classList: {
+            add: name => classes.add(name),
+            remove: name => classes.delete(name),
+            contains: name => classes.has(name)
+        },
+        remove() {}
+    }
+}
+
+let registry
+
+function fakeBrowser(name, {genomeId} = {}) {
+    const browser = {
+        name,
+        registry,
+        rootElement: fakeElement(),
+        browserPanelDeleteButton: {style: {display: 'none'}},
+        synchedBrowsers: new Set(),
+        loadedConfigs: [],
+        failing: false,
+        unsyncSelf() {},
+        async loadTracksOrThrow(configs) {
+            if (this.failing) {
+                throw new Error(`boom in ${this.name}`)
+            }
+            this.loadedConfigs.push(configs)
+        },
+        dispose() {
+            this.unsyncSelf()
+            this.registry.releaseSlot(this)
+        }
+    }
+    if (genomeId !== undefined) {
+        browser.dataset = {genomeId}
+        browser.genome = {id: genomeId}
+    }
+    return browser
+}
+
+/**
+ * A browser added the way a real one is: registered, then selected.
+ */
+function add(name, options) {
+    const browser = fakeBrowser(name, options)
+    registry.add(browser)
+    return browser
+}
+
+const isTargeted = browser => browser.rootElement.classList.contains('hic-root-targeted')
+
+let events
+
+const targetListener = event => events.push(event)
+
+beforeEach(() => {
+    registry = new BrowserRegistry()
+    events = []
+    EventBus.globalBus.subscribe('BrowserTargetChange', targetListener)
+})
+
+afterEach(() => {
+    EventBus.globalBus.unsubscribe('BrowserTargetChange', targetListener)
+})
+
+describe('the target set', () => {
+
+    it('is the current browser alone when nothing has been aimed at', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        add('b', {genomeId: 'hg38'})
+        registry.select(a)
+
+        expect(registry.targetedBrowsers).toEqual([a])
+    })
+
+    it('is empty while the registry is empty', () => {
+        expect(registry.targetedBrowsers).toEqual([])
+    })
+
+    it('takes a browser in and out on toggle', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+
+        registry.toggleTarget(b)
+        expect(registry.targetedBrowsers).toEqual([a, b])
+
+        registry.toggleTarget(b)
+        expect(registry.targetedBrowsers).toEqual([a])
+    })
+
+    it('is in registry order, which is panel order', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        const c = add('c', {genomeId: 'hg38'})
+        registry.select(b)
+
+        registry.toggleTarget(c)
+        registry.toggleTarget(a)
+
+        expect(registry.targetedBrowsers).toEqual([a, b, c])
+    })
+
+    it('ignores a toggle of the current browser, which is targeted implicitly', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        registry.select(a)
+        events.length = 0
+
+        registry.toggleTarget(a)
+
+        expect(registry.targetedBrowsers).toEqual([a])
+        expect(events).toEqual([])
+    })
+
+    it('follows the selection, since the current browser is always in it', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+
+        registry.select(a)
+        expect(registry.targetedBrowsers).toEqual([a])
+
+        registry.select(b)
+        expect(registry.targetedBrowsers).toEqual([b])
+    })
+
+    it('is cleared by a plain click, which is the way back from a large aim', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        const c = add('c', {genomeId: 'hg38'})
+        registry.select(a)
+        registry.toggleTarget(b)
+        registry.toggleTarget(c)
+
+        registry.retarget(a)
+
+        expect(registry.targetedBrowsers).toEqual([a])
+    })
+
+    it('is cleared by a plain click on the browser that is already current', () => {
+        // The case a "clear only on a real transition" rule would miss: the
+        // user has aimed at three panels and clicks the one the widgets are
+        // already reading.
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+        registry.toggleTarget(b)
+
+        registry.retarget(a)
+
+        expect(registry.targetedBrowsers).toEqual([a])
+    })
+})
+
+describe('BrowserTargetChange', () => {
+
+    it('fires on a toggle, carrying the registry and the resolved set', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+        events.length = 0
+
+        registry.toggleTarget(b)
+
+        expect(events.length).toBe(1)
+        expect(events[0].data.registry).toBe(registry)
+        expect(events[0].data.targetedBrowsers).toEqual([a, b])
+    })
+
+    it('fires when the selection moves, because that moves the implicit member', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+        events.length = 0
+
+        registry.select(b)
+
+        expect(events.length).toBe(1)
+        expect(events[0].data.targetedBrowsers).toEqual([b])
+    })
+
+    it('fires once for a plain click that both clears and re-aims', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+        registry.toggleTarget(b)
+        events.length = 0
+
+        registry.retarget(b)
+
+        expect(events.length).toBe(1)
+        expect(events[0].data.targetedBrowsers).toEqual([b])
+    })
+
+    it('does not fire when nothing about the set changed', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        registry.select(a)
+        events.length = 0
+
+        registry.select(a)
+        registry.retarget(a)
+
+        expect(events).toEqual([])
+    })
+
+    it('drives the badge class, which is not the selected class', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+        registry.toggleTarget(b)
+
+        expect(isTargeted(a)).toBe(true)
+        expect(isTargeted(b)).toBe(true)
+        expect(a.rootElement.classList.contains('hic-root-selected')).toBe(true)
+        expect(b.rootElement.classList.contains('hic-root-selected')).toBe(false)
+
+        registry.retarget(a)
+        expect(isTargeted(b)).toBe(false)
+    })
+})
+
+describe('the target set through a lifecycle', () => {
+
+    it('drops a deleted browser', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+        registry.toggleTarget(b)
+        events.length = 0
+
+        registry.delete(b)
+
+        expect(registry.targetedBrowsers).toEqual([a])
+        expect(isTargeted(b)).toBe(false)
+        expect(events.length).toBe(1)
+        expect(events[0].data.targetedBrowsers).toEqual([a])
+    })
+
+    it('does not let a deleted browser back in through a new one taking its place', () => {
+        // A disposed browser is fatal on use, not merely stale: the reference
+        // has to be gone, not just filtered out on the way past.
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+        registry.toggleTarget(b)
+
+        registry.delete(b)
+        registry.reclaimSlot(b, 1, false, false)
+
+        expect(registry.targetedBrowsers).toEqual([a])
+    })
+
+    it('does not add a newly created browser to the set', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+        registry.toggleTarget(b)
+
+        const c = add('c', {genomeId: 'hg38'})
+
+        // `add` selects, so the new browser is current and therefore targeted
+        // implicitly -- but the aim the user set up is intact underneath it.
+        registry.select(a)
+        expect(registry.targetedBrowsers).toEqual([a, b])
+        expect(registry.isTargetedExplicitly(c)).toBe(false)
+    })
+
+    it('survives a reset, which the sync group does not', () => {
+        // The teardown-and-rebuild `HICBrowser.reset` performs, as the registry
+        // sees it: the slot released, then reclaimed with what the browser
+        // captured before it disposed itself.
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+        registry.toggleTarget(b)
+
+        const wasTargeted = registry.isTargetedExplicitly(b)
+        const slot = registry.browsers.indexOf(b)
+        b.dispose()
+        registry.reclaimSlot(b, slot, false, wasTargeted)
+
+        expect(registry.targetedBrowsers).toEqual([a, b])
+    })
+
+    it('starts empty after a restore, and is never serialized', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+        registry.toggleTarget(b)
+
+        // The open of `restoreSession`, without the rebuild it cannot do
+        // without a document.
+        registry.deleteAll()
+
+        expect(registry.targetedBrowsers).toEqual([])
+        expect(JSON.stringify(registry.toJSON())).not.toContain('target')
+    })
+})
+
+describe('loadTracksIntoTargets', () => {
+
+    const configs = [{url: 'https://example.com/a.bigWig', name: 'a'}]
+
+    it('loads into every targeted browser and reports them', async () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        const other = add('other', {genomeId: 'hg38'})
+        registry.select(a)
+        registry.toggleTarget(b)
+
+        const summary = await registry.loadTracksIntoTargets(configs)
+
+        expect(summary.loaded).toEqual([a, b])
+        expect(summary.failed).toEqual([])
+        expect(summary.skipped).toEqual([])
+        expect(other.loadedConfigs).toEqual([])
+    })
+
+    it('reaches only the current browser when nothing has been aimed at', async () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+
+        const summary = await registry.loadTracksIntoTargets(configs)
+
+        expect(summary.loaded).toEqual([a])
+        expect(b.loadedConfigs).toEqual([])
+    })
+
+    it('skips a target with no map and one on another genome, against the originating browser', async () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const empty = add('empty')
+        const mouse = add('mouse', {genomeId: 'mm10'})
+        registry.select(a)
+        registry.toggleTarget(empty)
+        registry.toggleTarget(mouse)
+
+        const summary = await registry.loadTracksIntoTargets(configs)
+
+        expect(summary.loaded).toEqual([a])
+        expect(summary.skipped).toEqual([
+            {browser: empty, reason: 'no-dataset'},
+            {browser: mouse, reason: 'genome-mismatch'}
+        ])
+        expect(empty.loadedConfigs).toEqual([])
+        expect(mouse.loadedConfigs).toEqual([])
+    })
+
+    it('reports a failure rather than raising an alert', async () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+        registry.toggleTarget(b)
+        b.failing = true
+
+        // A registry built without a container has no alert dialog and no
+        // document to build one in, so an alert here would throw. That is the
+        // assertion: juicebox.js raises none, the caller reports.
+        const summary = await registry.loadTracksIntoTargets(configs)
+
+        expect(summary.loaded).toEqual([a])
+        expect(summary.failed.map(({browser}) => browser)).toEqual([b])
+    })
+
+    it('hands each target its own copy of each config', async () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.select(a)
+        registry.toggleTarget(b)
+
+        await registry.loadTracksIntoTargets(configs)
+
+        expect(a.loadedConfigs[0][0]).toEqual(configs[0])
+        expect(a.loadedConfigs[0][0]).not.toBe(configs[0])
+        expect(b.loadedConfigs[0][0]).not.toBe(a.loadedConfigs[0][0])
+    })
+})

--- a/test/testTargetGroup.js
+++ b/test/testTargetGroup.js
@@ -1,0 +1,136 @@
+import {describe, it, expect} from 'vitest'
+import {trackSkipReason, loadTracksIntoTargets} from '../js/targetGroup.js'
+
+/**
+ * The target-set rules -- see #615 and `docs/adr/0015`.
+ *
+ * `js/targetGroup.js` is the rule alone: which targets a load reaches, and what
+ * comes back when it has. It reads no module state and touches no DOM, so the
+ * browsers here are fabricated objects carrying only what the rules read -- a
+ * `dataset` and a `genome` with an id -- exactly as `test/testSyncGroup.js`
+ * fabricates browsers for the pairing rule.
+ */
+
+function fakeBrowser(name, {genomeId, dataset = {}} = {}) {
+    const browser = {name}
+    if (genomeId !== undefined) {
+        browser.dataset = dataset
+        browser.genome = {id: genomeId}
+    }
+    return browser
+}
+
+describe('trackSkipReason', () => {
+
+    const hg38 = fakeBrowser('originating', {genomeId: 'hg38'})
+
+    it('does not skip a target on the originating browser\'s genome', () => {
+        expect(trackSkipReason(hg38, fakeBrowser('peer', {genomeId: 'hg38'}))).toBeUndefined()
+    })
+
+    it('does not skip the originating browser itself', () => {
+        expect(trackSkipReason(hg38, hg38)).toBeUndefined()
+    })
+
+    it('skips a target with no dataset', () => {
+        expect(trackSkipReason(hg38, fakeBrowser('empty'))).toBe('no-dataset')
+    })
+
+    it('skips a target on a different genome', () => {
+        expect(trackSkipReason(hg38, fakeBrowser('mouse', {genomeId: 'mm10'}))).toBe('genome-mismatch')
+    })
+
+    // The empty-browser check comes first, and has to: a browser with no
+    // dataset has no genome either, so testing the genome first would report
+    // every empty panel as a mismatch and hide the ordinary case behind the
+    // alarming one.
+    it('reports an empty target as empty rather than as a mismatch', () => {
+        expect(trackSkipReason(hg38, fakeBrowser('empty'))).toBe('no-dataset')
+    })
+})
+
+describe('loadTracksIntoTargets', () => {
+
+    const configs = [{url: 'https://example.com/a.bigWig', name: 'a'}]
+
+    function recordingLoad(record, failing = new Set()) {
+        return async (browser, ownConfigs) => {
+            record.push({browser, configs: ownConfigs})
+            if (failing.has(browser)) {
+                throw new Error(`boom in ${browser.name}`)
+            }
+        }
+    }
+
+    it('loads into every eligible target and reports them', async () => {
+        const a = fakeBrowser('a', {genomeId: 'hg38'})
+        const b = fakeBrowser('b', {genomeId: 'hg38'})
+        const record = []
+
+        const summary = await loadTracksIntoTargets(a, [a, b], configs, recordingLoad(record))
+
+        expect(summary.loaded).toEqual([a, b])
+        expect(summary.failed).toEqual([])
+        expect(summary.skipped).toEqual([])
+        expect(record.map(({browser}) => browser)).toEqual([a, b])
+    })
+
+    it('reports the two skip paths without attempting a load', async () => {
+        const a = fakeBrowser('a', {genomeId: 'hg38'})
+        const empty = fakeBrowser('empty')
+        const mouse = fakeBrowser('mouse', {genomeId: 'mm10'})
+        const record = []
+
+        const summary = await loadTracksIntoTargets(a, [a, empty, mouse], configs, recordingLoad(record))
+
+        expect(summary.loaded).toEqual([a])
+        expect(summary.skipped).toEqual([
+            {browser: empty, reason: 'no-dataset'},
+            {browser: mouse, reason: 'genome-mismatch'}
+        ])
+        expect(record.map(({browser}) => browser)).toEqual([a])
+    })
+
+    it('reports a failing target without stopping the others', async () => {
+        const a = fakeBrowser('a', {genomeId: 'hg38'})
+        const b = fakeBrowser('b', {genomeId: 'hg38'})
+        const c = fakeBrowser('c', {genomeId: 'hg38'})
+        const record = []
+
+        const summary = await loadTracksIntoTargets(a, [a, b, c], configs, recordingLoad(record, new Set([b])))
+
+        expect(summary.loaded).toEqual([a, c])
+        expect(summary.failed.map(({browser}) => browser)).toEqual([b])
+        expect(summary.failed[0].error.message).toBe('boom in b')
+    })
+
+    it('hands each target its own copy of each config', async () => {
+        const a = fakeBrowser('a', {genomeId: 'hg38'})
+        const b = fakeBrowser('b', {genomeId: 'hg38'})
+        const record = []
+
+        await loadTracksIntoTargets(a, [a, b], configs, recordingLoad(record))
+
+        const [first, second] = record
+        expect(first.configs[0]).toEqual(configs[0])
+        expect(first.configs[0]).not.toBe(configs[0])
+        expect(second.configs[0]).not.toBe(first.configs[0])
+    })
+
+    it('leaves the caller\'s configs unmutated when a loader writes to what it is handed', async () => {
+        const a = fakeBrowser('a', {genomeId: 'hg38'})
+        const mutating = async (browser, ownConfigs) => {
+            ownConfigs[0].autoscale = true
+        }
+
+        await loadTracksIntoTargets(a, [a], configs, mutating)
+
+        expect(configs[0].autoscale).toBeUndefined()
+    })
+
+    it('returns an empty summary for an empty target set', async () => {
+        const a = fakeBrowser('a', {genomeId: 'hg38'})
+        expect(await loadTracksIntoTargets(a, [], configs, recordingLoad([])))
+            .toEqual({loaded: [], failed: [], skipped: []})
+    })
+})

--- a/test/testTargetGroup.js
+++ b/test/testTargetGroup.js
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest'
-import {trackSkipReason, loadTracksIntoTargets} from '../js/targetGroup.js'
+import {trackSkipReason, fanOutTracks} from '../js/targetGroup.js'
 
 /**
  * The target-set rules -- see #615 and `docs/adr/0015`.
@@ -49,7 +49,7 @@ describe('trackSkipReason', () => {
     })
 })
 
-describe('loadTracksIntoTargets', () => {
+describe('fanOutTracks', () => {
 
     const configs = [{url: 'https://example.com/a.bigWig', name: 'a'}]
 
@@ -67,7 +67,7 @@ describe('loadTracksIntoTargets', () => {
         const b = fakeBrowser('b', {genomeId: 'hg38'})
         const record = []
 
-        const summary = await loadTracksIntoTargets(a, [a, b], configs, recordingLoad(record))
+        const summary = await fanOutTracks(a, [a, b], configs, recordingLoad(record))
 
         expect(summary.loaded).toEqual([a, b])
         expect(summary.failed).toEqual([])
@@ -81,7 +81,7 @@ describe('loadTracksIntoTargets', () => {
         const mouse = fakeBrowser('mouse', {genomeId: 'mm10'})
         const record = []
 
-        const summary = await loadTracksIntoTargets(a, [a, empty, mouse], configs, recordingLoad(record))
+        const summary = await fanOutTracks(a, [a, empty, mouse], configs, recordingLoad(record))
 
         expect(summary.loaded).toEqual([a])
         expect(summary.skipped).toEqual([
@@ -97,7 +97,7 @@ describe('loadTracksIntoTargets', () => {
         const c = fakeBrowser('c', {genomeId: 'hg38'})
         const record = []
 
-        const summary = await loadTracksIntoTargets(a, [a, b, c], configs, recordingLoad(record, new Set([b])))
+        const summary = await fanOutTracks(a, [a, b, c], configs, recordingLoad(record, new Set([b])))
 
         expect(summary.loaded).toEqual([a, c])
         expect(summary.failed.map(({browser}) => browser)).toEqual([b])
@@ -109,7 +109,7 @@ describe('loadTracksIntoTargets', () => {
         const b = fakeBrowser('b', {genomeId: 'hg38'})
         const record = []
 
-        await loadTracksIntoTargets(a, [a, b], configs, recordingLoad(record))
+        await fanOutTracks(a, [a, b], configs, recordingLoad(record))
 
         const [first, second] = record
         expect(first.configs[0]).toEqual(configs[0])
@@ -123,14 +123,14 @@ describe('loadTracksIntoTargets', () => {
             ownConfigs[0].autoscale = true
         }
 
-        await loadTracksIntoTargets(a, [a], configs, mutating)
+        await fanOutTracks(a, [a], configs, mutating)
 
         expect(configs[0].autoscale).toBeUndefined()
     })
 
     it('returns an empty summary for an empty target set', async () => {
         const a = fakeBrowser('a', {genomeId: 'hg38'})
-        expect(await loadTracksIntoTargets(a, [], configs, recordingLoad([])))
+        expect(await fanOutTracks(a, [], configs, recordingLoad([])))
             .toEqual({loaded: [], failed: [], skipped: []})
     })
 })


### PR DESCRIPTION
Closes #615.

Adds a **target set** per registry: the browsers a *load* reaches. Shift-click a panel's navbar to aim at it, plain-click to clear the aim and make that panel current. The current browser is always targeted, so with nothing shift-clicked everything behaves exactly as it does today.

A target set is **not** a sync group. `docs/adr/0015` records why there are now two mechanisms for "one action reaching several browsers": ADR-0014 settled that dataset choices never cross a sync group, and this is the other half of that sentence — they propagate, by a different mechanism, with different membership and a different lifetime.

## Surface

- `js/targetGroup.js`, beside `js/syncGroup.js` — the skip predicate and the fan-out as pure functions over browsers.
- On the registry, all three declared in `REGISTRY_SURFACE`:
  - `targetedBrowsers` — a getter over `browsers`, so it cannot drift out of sync with them.
  - `toggleTarget(browser)` — one gesture, one mutator.
  - `loadTracksIntoTargets(configs)` → `{loaded, failed, skipped}`.
- New global event `BrowserTargetChange`, carrying the resolved array and the registry.
- Nothing existing became plural: `currentBrowser`, `BrowserSelect`, `HICBrowser.loadTracks` and `layoutController.removeTrackXYPair` mean what they meant before. A host opts in by calling the new method.

## Behaviour

Concurrent and unbounded over `Promise.allSettled`, each target getting its own copy of each config. A target with no dataset, or on a genome other than the originating browser's, is **skipped and reported** rather than thrown — the precedent is #605's `canResolveSyncState`. juicebox.js raises no alert; the caller reports, once per gesture, on whatever notification surface the host has.

`DataLoader.loadTracks` keeps its swallow-and-alert contract byte-identical, ordering included. The work moved to a private `#loadTracks`, with `loadTracksOrThrow` as the entry the fan-out needs — a loader that swallows cannot tell a fan-out which target failed.

## One thing settled during testing

The first shift-click of a new aim **also selects** (ADR-0015 decision 4a). It was built the other way first, and the harness showed why that is wrong: the fan-out is issued from the current browser, and the current browser is the track's genome declaration. Since `add()` selects, that was the last panel built — so aiming at two hg38 panels while an mm10 panel was current reported both as `genome-mismatch` and loaded the track into the panel the user never touched. Selecting on the first click makes the browser an aim *starts from* the browser it is *measured against*.

## Testing

`test/testTargetGroup.js` (11) covers the rules; `test/testBrowserTargeting.js` (29) covers the registry's half — membership, the implicit member, both skip paths, the lifecycle table and the event. Per ADR-0013 the shift-click handler and the badge get no automated test. Full suite: 1151 passing.

`dev/multi-browser-targeting.html` carries a map-less panel and an mm10 panel deliberately — those are the two skip paths, and a harness that only showed the happy path is the one that would let the skip rule rot. It names each aim's origin and genome, and has a "Go to annotations" button that computes the 2D extent from `browser.tracks2D`.

## Out of scope, deliberately

Contact maps, deletion (the one-click-to-create, N-to-undo asymmetry is accepted and recorded), 2D annotation attributes, and juicebox-web — the track menu that would call this lives there, so no user sees the feature until that host is repointed at a release carrying it.

Related: #588. This does not cause it, but it multiplies its blast radius — one click now issues N times the track loads. Concurrency is deliberately not capped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GegUxubpJ3CyM1jFtr78oU