### PR TITLE
Tell the head of an aim apart from a plain selection

### DIFF
--- a/css/juicebox.css
+++ b/css/juicebox.css
@@ -201,7 +201,7 @@
   margin: 4px;
   background-color: white;
   border-style: solid;
-  border-width: 2px;
+  border-width: 3px;
   border-color: #bfbfbf;
 }
 
@@ -1304,8 +1304,17 @@ div[id$=content-container] div[id$=x-scrollbar-container] div[id$=x-axis-scrollb
    class and a second visual, not the selected border -- a user still needs to
    see at a glance which panel the widgets are reading. */
 .hic-root-targeted {
-  outline: 2px dashed #3a8ab4;
-  outline-offset: -2px;
+  outline: 3px dashed #3a8ab4;
+  outline-offset: -3px;
+}
+
+/* The browser the aim starts from: current *and* explicitly targeted. Blue
+   rather than the plain selected grey, so the first shift-click reads as the
+   head of a target set rather than as an ordinary selection. Declared after
+   `.hic-root-selected` -- an anchor carries both classes and equal
+   specificity, so source order decides the color. */
+.hic-root-target-anchor {
+  border-color: #3a8ab4;
 }
 
 .unselect {

--- a/css/juicebox.scss
+++ b/css/juicebox.scss
@@ -237,7 +237,7 @@ $default-font-family: 'Open Sans', sans-serif;
   margin: 4px;
   background-color: white;
   border-style: solid;
-  border-width: 2px;
+  border-width: 3px;
   border-color: #bfbfbf;
 }
 
@@ -1178,8 +1178,17 @@ div[id$="content-container"] {
    class and a second visual, not the selected border -- a user still needs to
    see at a glance which panel the widgets are reading. */
 .hic-root-targeted {
-  outline: 2px dashed #3a8ab4;
-  outline-offset: -2px;
+  outline: 3px dashed #3a8ab4;
+  outline-offset: -3px;
+}
+
+/* The browser the aim starts from: current *and* explicitly targeted. Blue
+   rather than the plain selected grey, so the first shift-click reads as the
+   head of a target set rather than as an ordinary selection. Declared after
+   `.hic-root-selected` -- an anchor carries both classes and equal
+   specificity, so source order decides the color. */
+.hic-root-target-anchor {
+  border-color: #3a8ab4;
 }
 .unselect {
   -webkit-touch-callout: none;

--- a/dev/multi-browser-targeting.html
+++ b/dev/multi-browser-targeting.html
@@ -38,12 +38,16 @@
             margin: 8px 0;
         }
 
-        /* The badge the registry drives, exaggerated here so the three states --
-           current (which is also targeted), targeted, neither -- are obvious at a
-           glance. The library's own rule is in css/juicebox.scss. */
+        /* The badges the registry drives, exaggerated here so the four states --
+           plainly selected, the anchor of an aim, aimed at, neither -- are obvious
+           at a glance. The library's own rules are in css/juicebox.scss. */
         .hic-root-targeted {
-            outline: 3px dashed #3a8ab4;
-            outline-offset: -3px;
+            outline: 4px dashed #3a8ab4;
+            outline-offset: -4px;
+        }
+
+        .hic-root-target-anchor {
+            border-color: #3a8ab4;
         }
 
         #panels {
@@ -68,7 +72,8 @@
     <b>Shift-click a panel's navbar</b> to put it in the target set; <b>plain-click</b>
     a navbar to clear the set and make that panel current. The current panel is always
     targeted, so with nothing shift-clicked a load behaves exactly as it does today.
-    Dashed outline = targeted; solid border = current.
+    Dark solid border = current, no aim; blue solid border = the first shift-click,
+    which is both current and the head of the aim; blue dashed outline = aimed at.
 </p>
 
 <p class="note">

--- a/docs/adr/0015-targeting-is-not-a-sync-group.md
+++ b/docs/adr/0015-targeting-is-not-a-sync-group.md
@@ -93,16 +93,30 @@ same aim do not move the selection, so the origin stays where the user put it.
 Shift-clicking the current browser remains a no-op in everything observable — the
 resolved set and the event are unchanged — and internally it starts the aim.
 
-**4b. The badge ships in the library, not in the harness.** `hic-root-targeted`
-is applied by the registry, beside `hic-root-selected`, and styled in
-`css/juicebox.scss`. The gesture that sets a target set is library-side —
-shift-click is bound in `layoutController` — so its feedback has to be, or every
-host would have to reimplement the same outline to stop the gesture from looking
-broken. It is a *second* class and a second visual deliberately: the selected
-border keeps meaning what it means, because a user still needs to see at a glance
-which panel the widgets are reading. The three states are current (which is also
-targeted), targeted, and neither. `dev/multi-browser-targeting.html` overrides the
-rule with a louder one; that is a harness decision, not the library's.
+**4b. The badges ship in the library, not in the harness.** `hic-root-targeted`
+and `hic-root-target-anchor` are applied by the registry, beside
+`hic-root-selected`, and styled in `css/juicebox.scss`. The gesture that sets a
+target set is library-side — shift-click is bound in `layoutController` — so its
+feedback has to be, or every host would have to reimplement the same outline to
+stop the gesture from looking broken. They are *separate* classes and separate
+visuals deliberately: the selected border keeps meaning what it means, because a
+user still needs to see at a glance which panel the widgets are reading.
+
+Four appearances, because the first shift-click must not look like a plain click:
+
+| state | appearance |
+| --- | --- |
+| unselected | grey border |
+| selected, no aim | dark border |
+| the anchor — current *and* explicitly targeted, i.e. the first shift-click | blue border |
+| aimed at, not current | blue dashed outline |
+
+The current browser is targeted implicitly, but an implicit set of one is just a
+selection, so it carries no badge — only an *explicit* target wears one. Borders
+are a pixel thicker than before across every state so the color reads at a
+glance; the width lives on `.hic-root` itself, not on the state classes, so
+selecting a panel cannot resize it. `dev/multi-browser-targeting.html` overrides
+the rules with louder ones; that is a harness decision, not the library's.
 
 **5. Skip, do not throw.** A target with no dataset, or on a genome other than the
 **originating** browser's, is skipped and reported as skipped. Tracks carry no

--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -329,18 +329,64 @@ class BrowserRegistry {
                 const before = this.#announceBefore
                 const after = this.targetedBrowsers
 
+                // Repainted every time, not only when the set changed: the
+                // *shape* of the set can change while its membership does not
+                // -- the anchor is whichever targeted browser is also current,
+                // and a selection moving inside the set moves the badge
+                // without adding or removing a member.
+                this.#paintTargetBadges(before)
+
                 if (before.length !== after.length || after.some((browser, i) => browser !== before[i])) {
-
-                    for (const browser of before) {
-                        browser.rootElement?.classList.remove('hic-root-targeted')
-                    }
-                    for (const browser of after) {
-                        browser.rootElement?.classList.add('hic-root-targeted')
-                    }
-
                     EventBus.globalBus.post(HICEvent("BrowserTargetChange", {registry: this, targetedBrowsers: after}))
                 }
             }
+        }
+    }
+
+    /**
+     * Put the target-set badges on the panels, and take them off the ones that
+     * no longer carry them.
+     *
+     * Three appearances, because a user has to tell three states apart at a
+     * glance -- the plain selection, the browser an aim *starts* from, and the
+     * rest of the aim:
+     *
+     * - plain click, no aim: the selected border only (grey). The current
+     *   browser is implicitly targeted, but a set of one is just a selection
+     *   and badging it would make every panel look aimed at.
+     * - the anchor -- current *and* explicitly targeted, i.e. the first
+     *   shift-click: `hic-root-target-anchor`, which recolors the selected
+     *   border blue. Solid, because it is still the browser the widgets read.
+     * - every later shift-click: `hic-root-targeted`, the dashed blue outline.
+     *
+     * Reads `#targeted` rather than `targetedBrowsers` on purpose: the getter
+     * folds the implicit current browser in, and the distinction being drawn
+     * here is exactly the one it folds away.
+     *
+     * @param {Array} departed - browsers that were in the set before the
+     *   mutation. Painted too, so one that has since left the registry -- a
+     *   delete, a reset's teardown -- has its badge taken off rather than
+     *   keeping it on a detached element that may yet be reused.
+     */
+    #paintTargetBadges(departed = []) {
+
+        for (const browser of new Set([...departed, ...this.browsers])) {
+
+            const classList = browser.rootElement?.classList
+
+            if (undefined === classList) {
+                continue
+            }
+
+            const explicit = this.#targeted.has(browser)
+            const anchor = explicit && browser === this.currentBrowser
+
+            // add/remove rather than the two-argument `toggle`: the class list
+            // is the one DOM surface the registry touches, and this keeps the
+            // fakes the tests build to the two methods every other call here
+            // already uses.
+            classList[anchor ? 'add' : 'remove']('hic-root-target-anchor')
+            classList[explicit && !anchor ? 'add' : 'remove']('hic-root-targeted')
         }
     }
 

--- a/test/testBrowserTargeting.js
+++ b/test/testBrowserTargeting.js
@@ -70,6 +70,13 @@ function add(name, options) {
 
 const isTargeted = browser => browser.rootElement.classList.contains('hic-root-targeted')
 
+// The head of an aim: current *and* explicitly targeted. Carries its own class
+// so a first shift-click does not look like a plain click.
+const isAnchor = browser => browser.rootElement.classList.contains('hic-root-target-anchor')
+
+// Aimed at, however it is drawn.
+const isBadged = browser => isTargeted(browser) || isAnchor(browser)
+
 /**
  * The gesture as a user makes it: shift-click each panel in turn.
  *
@@ -324,13 +331,32 @@ describe('BrowserTargetChange', () => {
         const b = add('b', {genomeId: 'hg38'})
         aim(a, b)
 
-        expect(isTargeted(a)).toBe(true)
+        // The anchor and the rest of the aim are drawn differently: `a` is the
+        // browser the widgets read *and* the head of the set, `b` is only aimed
+        // at.
+        expect(isAnchor(a)).toBe(true)
+        expect(isTargeted(a)).toBe(false)
         expect(isTargeted(b)).toBe(true)
+        expect(isAnchor(b)).toBe(false)
         expect(a.rootElement.classList.contains('hic-root-selected')).toBe(true)
         expect(b.rootElement.classList.contains('hic-root-selected')).toBe(false)
 
         registry.retarget(a)
-        expect(isTargeted(b)).toBe(false)
+        expect(isBadged(a)).toBe(false)
+        expect(isBadged(b)).toBe(false)
+    })
+
+    it('does not badge a plain selection, which is a set of one', () => {
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+
+        registry.retarget(b)
+
+        // `b` is targeted -- the current browser always is -- but implicitly,
+        // and an implicit set of one is just a selection.
+        expect(registry.targetedBrowsers).toEqual([b])
+        expect(isBadged(b)).toBe(false)
+        expect(isBadged(a)).toBe(false)
     })
 })
 
@@ -345,7 +371,7 @@ describe('the target set through a lifecycle', () => {
         registry.delete(b)
 
         expect(registry.targetedBrowsers).toEqual([a])
-        expect(isTargeted(b)).toBe(false)
+        expect(isBadged(b)).toBe(false)
         expect(events.length).toBe(1)
         expect(events[0].data.targetedBrowsers).toEqual([a])
     })


### PR DESCRIPTION
Follow-up tweaks to #616.

The current browser is targeted implicitly, so every selected panel wore the dashed target outline — a plain click and the first shift-click of an aim looked the same. Now:

| state | appearance |
| --- | --- |
| unselected | grey border |
| selected, no aim | dark border |
| the anchor — current *and* explicitly targeted (the first shift-click) | **blue** border |
| aimed at, not current | blue dashed outline |

- Only an *explicit* target is badged; an implicit set of one is just a selection.
- New class `hic-root-target-anchor`, declared after `.hic-root-selected` so it wins the color on the anchor.
- Borders 2px → 3px, and the dashed outline likewise. The width lives on `.hic-root` itself, not on the state classes, so selecting a panel cannot resize it (no `box-sizing: border-box` here).
- Badges repaint on every announce, not only when the set changed — the anchor is whichever member is also current, so a selection moving inside a set moves the badge without touching membership. Departed browsers are repainted too, so a deleted panel does not keep a badge on a detached element.

ADR 0015 §4b and the `dev/multi-browser-targeting.html` legend updated. Tests: 1152 pass, with a new case that a plain selection carries no badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UpEjy8sYsqUZzNHY3iyYZ