### PR TITLE
Stop a delete from re-selecting the browser it deleted, and let an aim of one lapse

### DIFF
--- a/docs/adr/0015-targeting-is-not-a-sync-group.md
+++ b/docs/adr/0015-targeting-is-not-a-sync-group.md
@@ -135,6 +135,15 @@ the publication.
 | browser added | does **not** join — a panel just created was not part of the aim the user set up |
 | `browser.reset()` | **survives** |
 | session restore | cleared; never serialized |
+| fewer than two browsers left | **lapses** — an explicit set of one is just a selection |
+
+The last row is enforced in one place, `#announce`, because both routes into it
+end there: a shift-click on the only panel, and deletes whittling an aim down to
+its last member. Neither should leave the user looking at the anchor border of a
+multi-select that has no second member. It costs nothing, because the *resolved*
+set is `[currentBrowser]` either way — what lapses is the badge, not a target —
+and an aim of one that later gains a neighbour does not come back: adding a panel
+must not resurrect an aim the user can no longer see. #621.
 
 The reset row is the one that diverges from the sync group, and on purpose: sync
 membership is a *rule* that gets recomputed, so losing it costs nothing; targeting

--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -347,6 +347,19 @@ class BrowserRegistry {
         } finally {
             if (0 === --this.#announceDepth) {
 
+                // An aim needs something to aim *between*: with fewer than two
+                // browsers the explicit set says nothing the selection does not
+                // already say, and drawing the anchor on a lone panel tells the
+                // user they are in a multi-select that has no second member.
+                // Both routes into that state end here -- a shift-click on the
+                // only panel, and deletes whittling an aim down to one -- so
+                // this is the one place it is refused. The *resolved* set is
+                // unchanged either way (the current browser is targeted
+                // implicitly), so this drops a badge, never a target. #621.
+                if (this.browsers.length < 2) {
+                    this.#targeted.clear()
+                }
+
                 const before = this.#announceBefore
                 const after = this.targetedBrowsers
 

--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -138,12 +138,26 @@ class BrowserRegistry {
      * Make `browser` the current one, or clear the selection when given
      * `undefined`. Posts `BrowserSelect` only on a real transition to a
      * browser, which is the contract juicebox-web subscribes to.
+     *
+     * A browser this registry does not own is ignored, not an error -- see
+     * `#select`.
      */
     select(browser) {
         this.#announce(() => this.#select(browser))
     }
 
     #select(browser) {
+
+        // A browser this registry does not own -- one already deleted, above
+        // all -- can never become current. The membership check is here rather
+        // than only at the callers because this is the one door: `select`,
+        // `retarget`, `toggleTarget` and `releaseSlot` all come through it, and
+        // the invariant *the current browser is one of `browsers`* should not
+        // depend on each of them remembering. A stray click that lands after a
+        // delete is the case that made this necessary. #619.
+        if (browser !== undefined && !this.browsers.includes(browser)) {
+            return
+        }
 
         if (browser === undefined) {
             if (mostRecentlySelectedBrowser === this.currentBrowser) {
@@ -281,6 +295,13 @@ class BrowserRegistry {
      * the user set up.
      */
     retarget(browser) {
+
+        // Early, as in `toggleTarget`: a plain click on a browser this registry
+        // does not own should not clear the aim either. #619.
+        if (!this.browsers.includes(browser)) {
+            return
+        }
+
         this.#announce(() => {
             this.#targeted.clear()
             this.#select(browser)

--- a/js/layoutController.js
+++ b/js/layoutController.js
@@ -319,7 +319,17 @@ function createNavBar(browser, root) {
     browser.menuPresentDismiss.addEventListener('click', e => browser.toggleMenu());
 
     browser.browserPanelDeleteButton = hicNavbarContainer.querySelector('.fa-minus-circle');
-    browser.browserPanelDeleteButton.addEventListener('click', e => deleteBrowser(browser));
+
+    // Stopped here, and it is load-bearing: this button is *inside* the navbar
+    // whose click handler selects. The propagation path is computed when the
+    // click is dispatched, so removing `rootElement` mid-dispatch does not take
+    // the navbar out of it -- the same click would go on to `retarget` the
+    // browser that has just disposed, undoing the selection `releaseSlot` fell
+    // through to a survivor and making a zombie current. #619.
+    browser.browserPanelDeleteButton.addEventListener('click', e => {
+        e.stopPropagation();
+        deleteBrowser(browser);
+    });
 
     // Delete button is only visible if there is more than one browser
     browser.browserPanelDeleteButton.style.display = 'none';

--- a/test/testBrowserRegistry.js
+++ b/test/testBrowserRegistry.js
@@ -259,6 +259,31 @@ describe('BrowserRegistry', () => {
             expect(selectEvents).toHaveLength(0)
         })
 
+        it('cannot be re-selected once deleted, so a stray click leaves a survivor current', () => {
+            // The delete button sits inside the navbar whose click handler
+            // selects, and the propagation path is fixed when the click is
+            // dispatched -- so a click that deletes used to go on and
+            // `retarget` the browser it had just disposed. The result was a
+            // registry whose current browser was a zombie and whose panels all
+            // looked unselected. `js/layoutController.js` stops the click; this
+            // is the registry refusing the gesture whatever the DOM does. #619.
+            const a = fakeBrowser('a')
+            const b = fakeBrowser('b')
+            registry.add(a)
+            registry.add(b)
+            registry.select(b)
+            selectEvents.length = 0
+
+            registry.delete(b)
+            registry.retarget(b)
+            registry.select(b)
+
+            expect(registry.currentBrowser).toBe(a)
+            expect(isSelected(a)).toBe(true)
+            expect(isSelected(b)).toBe(false)
+            expect(selectEvents.map(e => e.data)).toEqual([a])
+        })
+
         it('leaves selection undefined once deleting empties the registry', () => {
             const a = fakeBrowser('a')
             registry.add(a)

--- a/test/testBrowserTargeting.js
+++ b/test/testBrowserTargeting.js
@@ -361,6 +361,24 @@ describe('BrowserTargetChange', () => {
         expect(isBadged(b)).toBe(false)
     })
 
+    it('is not started by a shift-click on the only browser there is', () => {
+        // An aim needs something to aim between. A user who shift-clicks a lone
+        // panel -- or absent-mindedly holds shift after deleting their way down
+        // to one -- should not be shown the anchor border for a multi-select
+        // with no second member. #621.
+        const a = add('a', {genomeId: 'hg38'})
+        events.length = 0
+
+        registry.toggleTarget(a)
+
+        expect(registry.isTargetedExplicitly(a)).toBe(false)
+        expect(isBadged(a)).toBe(false)
+        // Still current, still the resolved set: the badge went, not the target.
+        expect(registry.currentBrowser).toBe(a)
+        expect(registry.targetedBrowsers).toEqual([a])
+        expect(events).toEqual([])
+    })
+
     it('does not badge a plain selection, which is a set of one', () => {
         const a = add('a', {genomeId: 'hg38'})
         const b = add('b', {genomeId: 'hg38'})
@@ -389,6 +407,27 @@ describe('the target set through a lifecycle', () => {
         expect(isBadged(b)).toBe(false)
         expect(events.length).toBe(1)
         expect(events[0].data.targetedBrowsers).toEqual([a])
+
+        // And the survivor stops being drawn as the head of an aim: what is
+        // left is one browser, which is a plain selection. #621.
+        expect(registry.isTargetedExplicitly(a)).toBe(false)
+        expect(isBadged(a)).toBe(false)
+    })
+
+    it('comes back once a second browser arrives, an aim of one having lapsed', () => {
+        // The lapse is not a punishment: adding a panel must not be the thing
+        // that resurrects an aim the user can no longer see, so the survivor
+        // starts plain and the next shift-click begins a fresh aim.
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        aim(a, b)
+        registry.delete(b)
+
+        const c = add('c', {genomeId: 'hg38'})
+
+        expect(registry.targetedBrowsers).toEqual([c])
+        expect(isBadged(a)).toBe(false)
+        expect(isBadged(c)).toBe(false)
     })
 
     it('does not let a deleted browser back in through a new one taking its place', () => {

--- a/test/testBrowserTargeting.js
+++ b/test/testBrowserTargeting.js
@@ -262,6 +262,21 @@ describe('the target set', () => {
         expect(registry.isTargetedExplicitly(stranger)).toBe(false)
     })
 
+    it('is left alone by a plain click on a browser this registry does not own', () => {
+        // The other half of the delete-button bug: the stray click both
+        // re-selected the corpse and, through `retarget`, wiped the aim. #619.
+        const a = add('a', {genomeId: 'hg38'})
+        const b = add('b', {genomeId: 'hg38'})
+        registry.toggleTarget(a)
+        registry.toggleTarget(b)
+
+        const stranger = fakeBrowser('stranger', {genomeId: 'hg38'})
+        registry.retarget(stranger)
+
+        expect(registry.targetedBrowsers).toEqual([a, b])
+        expect(registry.currentBrowser).toBe(a)
+    })
+
     it('is cleared by a plain click on the browser that is already current', () => {
         // The case a "clear only on a real transition" rule would miss: the
         // user has aimed at three panels and clicks the one the widgets are

--- a/test/testRegistryLookup.js
+++ b/test/testRegistryLookup.js
@@ -213,6 +213,10 @@ describe('the zero-argument getters', () => {
         const [one, two] = twoRegistries()
         const a = fakeBrowser('a', one)
         const b = fakeBrowser('b', two)
+        // Registered, not merely back-pointed: a registry only selects browsers
+        // it owns, which is what keeps a deleted one from becoming current.
+        one.register(a)
+        two.register(b)
 
         setCurrentBrowser(a)
         expect(getCurrentBrowser()).toBe(a)
@@ -241,6 +245,7 @@ describe('the zero-argument getters', () => {
         // page-wide pointer is what names the registry to clear.
         const [one] = twoRegistries()
         const a = fakeBrowser('a', one)
+        one.register(a)
 
         setCurrentBrowser(a)
         setCurrentBrowser(undefined)
@@ -261,6 +266,8 @@ describe('the zero-argument getters', () => {
         const [one, two] = twoRegistries()
         const a = fakeBrowser('a', one)
         const b = fakeBrowser('b', two)
+        one.register(a)
+        two.register(b)
 
         setCurrentBrowser(a)
         setCurrentBrowser(b)


### PR DESCRIPTION
Fixes #619 **and** #621 — merging this closes both.

Select a panel in `dev/multi-browser-targeting.html`, delete that same panel, and every surviving panel showed no selection. The registry was doing the right thing and having it undone by the same click.

The delete button is inside `hicNavbarContainer`, which carries the click handler that selects. The propagation path is computed when the click is dispatched, so removing `rootElement` mid-dispatch does not take the navbar out of it: after `releaseSlot` had fallen the selection through to a survivor, the same click ran `retarget` on the just-disposed browser. `hic-root-selected` went onto a detached element -- hence "nothing is selected" -- and `currentBrowser` was left pointing at a zombie, which is the origin of every load and the genome a fan-out is measured against.

Two changes:

- **The cause.** `e.stopPropagation()` in the delete-button listener (`js/layoutController.js`).
- **The invariant.** `#select` ignores a browser this registry does not own, and `retarget` early-returns for a non-member the way `toggleTarget` already did (`js/browserRegistry.js`). *The current browser is one of `browsers`* -- decision 7 of ADR-0004 -- should not depend on every caller remembering.

The selection policy itself is unchanged, and is the right one: deleting the current browser falls through to the first survivor, and `currentBrowser` is `undefined` only while the registry is empty.

## Tests

Both new tests fail without the registry guard and pass with it:

- `test/testBrowserRegistry.js` -- a deleted browser cannot be re-selected, so a stray click leaves a survivor current, with exactly one `BrowserSelect`.
- `test/testBrowserTargeting.js` -- a plain click on a browser the registry does not own leaves the aim alone.

Two tests in `test/testRegistryLookup.js` selected fakes they had never registered; that is under-specified now rather than merely untidy, so they register first. Full suite: 1154 passing.

Per ADR-0013 the DOM click handler itself gets no automated test -- the registry guard is what makes the outcome safe whatever the DOM does. Verified by hand in the targeting harness.

Not fixed here: the hamburger (`fa-bars`) bubbles to the same handler, so opening a panel menu also selects that panel. That reads as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sf2CdESJxfMPq3Ab7ymT22

---

## Also here: an aim of one lapses (fixes #621)

Found in the same session, on the far side of the fix above. Delete down to a single panel and shift-click it: `toggleTarget` read the empty target set as the first click of a new aim and turned the border blue -- the anchor affordance for a multi-select with no second member. Aiming at two panels and deleting all but one arrived at the same place with no shift at all.

An aim needs something to aim *between*. Both routes end in `#announce`, so the rule is enforced there: with fewer than two browsers the explicit set is cleared. The resolved set is `[currentBrowser]` either way, so it drops a badge, never a target, and posts no `BrowserTargetChange`. An aim of one does not come back when a panel is added -- adding a panel must not resurrect an aim the user can no longer see.

ADR-0015's lifecycle table gains the row. Three tests cover it (the shift-click, the delete-down-to-one, and the add afterwards); all three fail without the change.

