### PR TITLE
Correct the ceremony's lockfile claim, found by using it

### DIFF
--- a/docs/release-ceremony.md
+++ b/docs/release-ceremony.md
@@ -111,10 +111,10 @@ House style, from the existing releases:
 Two repos, each its own PR off a feature branch. Both pin
 `"juicebox.js": "github:aidenlab/juicebox.js#v<version>"`.
 
-| Repo | Path | Branch | Section | Source dir |
-|---|---|---|---|---|
-| juicebox-web | `../juicebox-web` | `master` | `devDependencies` | `js/` |
-| spacewalk | `../../SpacewalkDevelopment/spacewalk` | `main` | `dependencies` | `src/` |
+| Repo | Path | Branch | Section | Source dir | `package-lock.json` |
+|---|---|---|---|---|---|
+| juicebox-web | `../juicebox-web` | `master` | `devDependencies` | `js/` | **tracked — commit it** |
+| spacewalk | `../../SpacewalkDevelopment/spacewalk` | `main` | `dependencies` | `src/` | gitignored |
 
 Spacewalk is **not** a sibling of this repo — it lives under
 `SpacewalkDevelopment/`, and its source is `src/`, not `js/`.
@@ -123,8 +123,20 @@ Spacewalk is **not** a sibling of this repo — it lives under
 drifted to `#master` before and is on `#master` as this is written, which makes
 the bump a re-pin rather than a version bump.
 
-`package-lock.json` is gitignored in both consumers, so each bump PR is a
-one-line `package.json` change.
+**The two repos treat `package-lock.json` differently**, so the two bump PRs are
+not the same shape. Spacewalk gitignores it and its PR is a one-line
+`package.json` change. **juicebox-web tracks it** — the lockfile carries the
+resolved tag and commit, and leaving it out of the PR means merging a
+`package.json` that disagrees with the lockfile beside it. Stage both there.
+
+Check rather than remember: `git ls-files --error-unmatch package-lock.json`.
+
+**Check the consumer's working tree before branching.** These are working repos
+and a bump lands in the middle of whatever was already in progress there —
+juicebox-web had an unrelated dependency edit uncommitted when v4.3.0 was cut.
+`git stash push -- package.json package-lock.json`, branch, bump, then pop it
+back on the base branch. A `git add -A` in a consumer sweeps someone else's work
+into a release PR.
 
 ## The traps
 


### PR DESCRIPTION
Doc-only. Two corrections to `docs/release-ceremony.md`, both surfaced by cutting v4.3.0 against it.

## The lockfile claim was half wrong

The doc said `package-lock.json` is gitignored in **both** consumers, so each bump PR is a one-line `package.json` change. Spacewalk, yes. **juicebox-web tracks it** — so its bump PR is two files, and staging only `package.json` there would merge a manifest that disagrees with the lockfile sitting beside it.

The fact moves into the consumer table as a column, where it is read at the moment it matters, and the prose gives the check — `git ls-files --error-unmatch package-lock.json` — so the next reader verifies instead of trusting the sentence that was just wrong.

## Check the consumer's working tree before branching

juicebox-web had an unrelated dependency edit sitting uncommitted when v4.3.0 was cut. These are working repos, and a bump lands in the middle of whatever was already in progress; a `git add -A` in a consumer sweeps someone else's work into a release PR. The stash-branch-bump-pop sequence is now written down.

---

Everything else in the doc held. The three-file bump commit, the lightweight tag, the pack check, the forced install and the `gh pr list` scoping all played out exactly as described — the `#master` drift warning was live, and the forced install was what confirmed both consumers were actually on 4.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVmTxF7k3tx9FssqAZ6UmP