### PR TITLE
Pair maps by shared chromosomes, and report a refused sync

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -126,7 +126,11 @@ _Avoid_: browser session, browser context, embed.
 
 **Sync group** — the set of browsers a browser publishes its canonical state to.
 Membership is a rule rather than a container: a browser joins when it has not
-opted out and its dataset is compatible with the other's. What travels the group
+opted out and its dataset is compatible with the other's — *compatible* meaning
+the two chromosome tables share enough named chromosomes, at agreeing sizes, to
+be the same assembly (`Dataset.compareChromosomes`), not that the tables are
+identical. A subset `.hic` therefore joins, and the per-state question is left to
+`canResolveSyncState`. What travels the group
 is canonical state and, by deliberate exception, view preferences — never dataset
 choices. See `docs/adr/0014`. Dataset choices reach several browsers by the other
 mechanism, the **target set** — `docs/adr/0015`.
@@ -139,6 +143,10 @@ chromosomes differently and offer a different resolution array. A projection
 Membership decides who is handed one; whether a particular one can be acted on
 is a separate question, because a receiver's genome need not know every name a
 peer can publish — `canResolveSyncState` in `js/syncGroup.js`, issue #605.
+Both refusals — no compatible peer, and a peer state naming a chromosome this
+map lacks — are reported to the host as **`onSyncRefused`** rather than dropped
+silently (#626). It is a notification, not a repair: both refusals are correct,
+and what was missing was any way to tell that one had happened.
 _Avoid_: sync payload, target state.
 
 **Target set** — the browsers a *load* reaches: the ones the user has

--- a/docs/adr/0003-public-api-contract.md
+++ b/docs/adr/0003-public-api-contract.md
@@ -141,9 +141,11 @@ These are contract too, and are easy to miss because they are one dot further ou
   incomplete within a week.
 - `coordinator.addCallback(name, fn)` — Spacewalk registers `onMapLoaded`,
   `onBackgroundColorChange` and `onForegroundColorChange`. The coordinator accepts
-  **six** names and throws on anything else, so all six are published behaviour;
-  `onControlMapLoaded`, `onLocusChange` and `onGenomeChange` are registerable and
-  currently unused.
+  **seven** names and throws on anything else, so all seven are published
+  behaviour; `onControlMapLoaded`, `onLocusChange`, `onGenomeChange` and
+  `onSyncRefused` are registerable and currently unused. `onSyncRefused` was
+  added by #626 and is the one of the seven that reports a *non-event*: a panel
+  that did not follow its sibling, and which rule declined it.
 - `dataset.isLive`, `activeDataset.isLive` — Spacewalk
 
 **Event payloads are contract too.** juicebox-web's `TrackXYPairLoad` /

--- a/js/browserCoordinator.js
+++ b/js/browserCoordinator.js
@@ -58,7 +58,8 @@ class BrowserCoordinator {
             onLocusChange: [],
             onGenomeChange: [],
             onBackgroundColorChange: [],
-            onForegroundColorChange: []
+            onForegroundColorChange: [],
+            onSyncRefused: []
         };
     }
 
@@ -380,6 +381,35 @@ class BrowserCoordinator {
             if (this.browser.state) {
                 this.widgets.normalizationWidget.announceSubstitution(reason, this.browser.state);
             }
+        }
+    }
+
+    /**
+     * Report that this browser did not follow a sibling panel, and why.
+     *
+     * A pure notification: nothing here changes what is drawn. Both refusals it
+     * carries are *correct* -- a map cannot be panned to a chromosome it does
+     * not contain, and two unrelated assemblies should not sync -- so there is
+     * nothing to repair. What was wrong until #626 is that both were silent, and
+     * a host watching two panels drift apart had no way to learn which of the
+     * two rules had fired, or that a rule had fired at all.
+     *
+     * No widget surface, which is the difference from `onNormalizationSubstituted`
+     * next door. ADR-0012 put a substitution on the normalization selector
+     * because a selector is *already* displaying the value that got substituted;
+     * a refused sync has no such control to contradict, and inventing a badge for
+     * it would be new UI answering a question hosts have not asked yet. The
+     * `console.warn` is the developer-facing half and the callback is the host
+     * facing half; either can grow a surface later without moving this call.
+     *
+     * @param {Object} detail
+     * @param {string} detail.reason - `'no-compatible-peer'` or `'unresolved-chromosome'`
+     * @param {string} detail.message - The same thing in a sentence
+     */
+    onSyncRefused(detail) {
+        console.warn(`juicebox: panel not synced -- ${detail.message}`);
+        for (const callback of this.externalCallbacks.onSyncRefused) {
+            callback({ ...detail, browser: this.browser });
         }
     }
 

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -218,6 +218,19 @@ class DataLoader {
             );
             if (peer) {
                 await this.browser.syncState(peer.getSyncState());
+            } else {
+                // Only worth reporting when there was in fact something to pair
+                // with. A first panel loading into an empty registry finds no
+                // peer and that is not a refusal, it is an empty room. #626.
+                const others = registry.browsers.filter(b => b !== this.browser && b.dataset);
+                if (others.length > 0) {
+                    this.browser.coordinator.onSyncRefused({
+                        reason: 'no-compatible-peer',
+                        message: `no open panel holds a compatible map (this is ${this.browser.dataset.genomeId}, the others are ${others.map(b => b.dataset.genomeId).join(', ')})`,
+                        genomeId: this.browser.dataset.genomeId,
+                        peerGenomeIds: others.map(b => b.dataset.genomeId)
+                    });
+                }
             }
 
             return dataset;

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -1284,7 +1284,23 @@ class HICBrowser {
      * it -- see the comment there.
      */
     async syncState(targetState) {
-        if (!targetState || !isSynchable(this) || !this.state || !canResolveSyncState(this.genome, targetState)) {
+        if (!targetState || !isSynchable(this) || !this.state) {
+            return;
+        }
+
+        // Reported rather than dropped since #626. The other three conditions
+        // above stay silent on purpose: two are "nothing to sync yet" and the
+        // third is the host's own `synchable: false`, which it does not need
+        // telling about. This one is the surprise -- the pair is legitimate, the
+        // panels are side by side, and only this particular state cannot cross.
+        if (!canResolveSyncState(this.genome, targetState)) {
+            this.coordinator.onSyncRefused({
+                reason: 'unresolved-chromosome',
+                message: `this map has no ${[targetState.chr1Name, targetState.chr2Name].join(' / ')}`,
+                chr1Name: targetState.chr1Name,
+                chr2Name: targetState.chr2Name,
+                genomeId: this.dataset?.genomeId
+            });
             return;
         }
 

--- a/js/hicDataset.js
+++ b/js/hicDataset.js
@@ -166,22 +166,53 @@ class Dataset {
     }
 
     /**
-     * Compare chromosomes with another dataset
+     * Do these two maps describe the same assembly?
+     *
+     * Compares the chromosomes the two tables **share**, by name. Until #626 it
+     * compared them positionally and demanded the tables be the same length,
+     * which made the rule "byte-identical chromosome table" rather than "same
+     * assembly": one extra scaffold, or the same scaffolds in another order, and
+     * two maps of the same genome did not pair. `Dataset.isCompatible` hides
+     * that for hg19/hg38/mm10 by short-circuiting on the genome id, so what the
+     * old rule actually governed was every *other* assembly -- including mm9 and
+     * dm6, which `matchGenome` below canonicalizes but `isCompatible` does not
+     * list. Two dm6 maps from different pipelines never synced. #626.
+     *
+     * A **name shared with a different size** is the disqualifying evidence: it
+     * says these are different assemblies wearing the same labels, which is
+     * exactly how hg19 and hg38 differ. A name present on one side only is not
+     * evidence either way -- a subset `.hic` is an ordinary artifact -- so it is
+     * skipped rather than counted against the pair.
+     *
+     * The threshold mirrors `matchGenome`'s own four-chromosome line, relaxed to
+     * the smaller table so that a subset map still pairs when every real
+     * chromosome it carries is accounted for. Pairing a subset is deliberate:
+     * `canResolveSyncState` (`syncGroup.js`) is what declines the individual
+     * states it cannot place, and it is a per-state question, not a per-pair one.
+     *
+     * `All` is excluded. It is a zoom rung, not a chromosome (ADR-0010), and its
+     * size is in kb besides, so comparing it compares two different units.
+     *
      * @param {Dataset} otherDataset - Other dataset to compare
-     * @returns {boolean} True if chromosomes match
+     * @returns {boolean} True if both maps look like the same assembly
      */
     compareChromosomes(otherDataset) {
-        const chrs = this.chromosomes;
-        const otherChrs = otherDataset.chromosomes;
-        if (chrs.length !== otherChrs.length) {
-            return false;
+
+        const real = chromosomes => (chromosomes || []).filter(c => 'all' !== c.name.toLowerCase());
+
+        const mine = real(this.chromosomes);
+        const theirs = real(otherDataset?.chromosomes);
+        const theirSizeByName = new Map(theirs.map(c => [c.name.toLowerCase(), c.size]));
+
+        let shared = 0;
+        for (const chromosome of mine) {
+            const size = theirSizeByName.get(chromosome.name.toLowerCase());
+            if (undefined === size) continue;
+            if (size !== chromosome.size) return false;
+            shared++;
         }
-        for (let i = 0; i < chrs.length; i++) {
-            if (chrs[i].size !== otherChrs[i].size) {
-                return false;
-            }
-        }
-        return true;
+
+        return shared > 0 && shared >= Math.min(4, mine.length, theirs.length);
     }
 
     /**

--- a/js/publicApi.js
+++ b/js/publicApi.js
@@ -310,7 +310,8 @@ export const COORDINATOR_CALLBACKS = [
     'onLocusChange',
     'onGenomeChange',
     'onBackgroundColorChange',
-    'onForegroundColorChange'
+    'onForegroundColorChange',
+    'onSyncRefused'
 ]
 
 /**

--- a/test/testSyncOnLoad.js
+++ b/test/testSyncOnLoad.js
@@ -1,0 +1,250 @@
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest'
+import Dataset from '../js/hicDataset.js'
+import ContactMatrixView from '../js/contactMatrixView.js'
+import HICBrowser from '../js/hicBrowser.js'
+import DataLoader from '../js/dataLoader.js'
+import {createBrowser} from '../js/createBrowser.js'
+import {withContainers} from './utils/browserFixture.js'
+import State from '../js/hicState.js'
+import BrowserCoordinator from '../js/browserCoordinator.js'
+
+/**
+ * The user's scenario, end to end: load a map into a panel, move it, add a
+ * second panel, load a map into that. Does the second panel arrive at the
+ * first panel's view?
+ *
+ * The seam is `Dataset.loadDataset` -- the network read -- and nothing above
+ * it. `stubbedLoads.js` cannot be used here: it stubs `loadHicFile` whole, and
+ * `loadHicFile`'s closing sync block is the code under test.
+ *
+ * The stand-in dataset is built on the real `Dataset.prototype`, so
+ * `isCompatible` and `compareChromosomes` are the shipping implementations
+ * rather than a fixture's paraphrase. That matters: the fixture in
+ * `restoreDataset.js` overrides `isCompatible` to a bare genome-id comparison,
+ * which is exactly the decision this bug turns on.
+ */
+
+const HG19 = [
+    ['chr1', 249250621], ['chr2', 243199373], ['chr3', 198022430], ['chr4', 191154276],
+    ['chr5', 180915260], ['chr6', 171115067], ['chr7', 159138663], ['chr8', 146364022],
+    ['chr9', 141213431], ['chr10', 135534747], ['chr11', 135006516], ['chr12', 133851895],
+    ['chr13', 115169878], ['chr14', 107349540], ['chr15', 102531392], ['chr16', 90354753],
+    ['chr17', 81195210], ['chr18', 78077248], ['chr19', 59128983], ['chr20', 63025520],
+    ['chr21', 48129895], ['chr22', 51304566], ['chrX', 155270560], ['chrY', 59373566],
+]
+
+const BP_RESOLUTIONS = [2500000, 1000000, 500000, 250000, 100000, 50000, 25000, 10000, 5000]
+
+function chromosomeTable(rows) {
+    const named = rows.map(([name, size], i) => ({index: i + 1, name, size}))
+    const all = {index: 0, name: 'All', size: named.reduce((sum, c) => sum + c.size, 0)}
+    return [all, ...named]
+}
+
+const matrix = (resolutions = BP_RESOLUTIONS) => ({
+    getZoomDataByIndex(index, unit) {
+        const binSize = resolutions[index]
+        return binSize === undefined ? undefined : {zoom: {index, unit, binSize}}
+    },
+    findZoomForResolution(binSize) {
+        for (let z = resolutions.length - 1; z > 0; z--) if (resolutions[z] >= binSize) return z
+        return 0
+    },
+})
+
+/** A dataset on the real prototype: only data and the network-backed methods differ. */
+function fakeDataset({genomeId, rows, resolutions, config}) {
+    const chromosomes = chromosomeTable(rows)
+    const bpResolutions = resolutions || BP_RESOLUTIONS
+    return Object.assign(Object.create(Dataset.prototype), {
+        name: config.name,
+        url: config.url,
+        datasetType: 'hic',
+        genomeId,
+        chromosomes,
+        bpResolutions,
+        wholeGenomeChromosome: chromosomes[0],
+        normalizationTypes: ['NONE'],
+        async getMatrix() { return matrix(bpResolutions) },
+        hicFile: {config: {}},
+    })
+}
+
+/**
+ * Queue the maps each successive `loadHicFile` should get, in load order.
+ * Returns nothing; the spy is torn down with the rest of the mocks.
+ */
+function serveMaps(maps) {
+    const queue = [...maps]
+    vi.spyOn(Dataset, 'loadDataset').mockImplementation(async config => {
+        const spec = queue.shift()
+        return fakeDataset({...spec, config})
+    })
+}
+
+const WHOLE_HG19 = {genomeId: 'hg19', rows: HG19}
+const SUBSET_HG19 = {genomeId: 'hg19', rows: HG19.slice(0, 1)}          // All + chr1 only
+const MM10 = [
+    ['chr1', 195471971], ['chr2', 182113224], ['chr3', 160039680], ['chr4', 156508116],
+    ['chr5', 151834684], ['chr6', 149736546], ['chr7', 145441459], ['chr8', 129401213],
+]
+const EXTRA_SCAFFOLD = {genomeId: 'hg19_scaffolds', rows: [...HG19, ['scaffold_7', 12345]]}
+const PLAIN_HG19 = {genomeId: 'hg19_no_alt', rows: HG19}
+/** A map binned no finer than 100kb -- a low-coverage or coarse .hic. */
+const COARSE_HG19 = {genomeId: 'hg19', rows: HG19, resolutions: [2500000, 1000000, 500000, 250000, 100000]}
+
+describe('a second panel loading a map syncs to the first panel', () => {
+
+    const dom = withContainers()
+
+    beforeEach(() => {
+        vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(DataLoader.prototype, 'loadTracks').mockImplementation(async () => undefined)
+    })
+
+    afterEach(() => vi.restoreAllMocks())
+
+    /**
+     * Panel 1 loads, is panned/zoomed to a locus, then panel 2 loads.
+     * Returns both browsers.
+     */
+    async function twoPanels(container, firstMap, secondMap, view) {
+        serveMaps([firstMap, secondMap])
+        const a = await createBrowser(container, {url: 'https://example.com/a.hic'})
+        await a.setState(view)
+        const b = await createBrowser(container, {url: 'https://example.com/b.hic'})
+        return [a, b]
+    }
+
+    /** chr2 vs chr2, zoom 5, origin (7, 9) -- an unmistakably non-default view. */
+    const MOVED = () => new State(2, 2, 5, 7, 9, 1, 'NONE')
+
+    it('syncs when both maps are the same whole assembly', async () => {
+        const [a, b] = await twoPanels(dom.container, WHOLE_HG19, WHOLE_HG19, MOVED())
+        expect(a.state.chr1).toBe(2)
+        expect(b.state.chr1).toBe(2)
+        expect(b.state.chr2).toBe(2)
+        expect(b.state.zoom).toBe(5)
+    })
+
+    it('syncs when the second map is a chr1-only subset and panel 1 sits on chr1', async () => {
+        const [, b] = await twoPanels(dom.container, WHOLE_HG19, SUBSET_HG19, new State(1, 1, 5, 7, 9, 1, 'NONE'))
+        expect(b.state.chr1).toBe(1)
+        expect(b.state.chr2).toBe(1)
+    })
+
+    it('syncs two maps of one assembly whose chromosome tables differ', async () => {
+        // #626. Both are hg19, but neither id is one `isCompatible`
+        // short-circuits on and one carries an extra scaffold, so the pair used
+        // to fall to `compareChromosomes`' byte-identical rule and be refused.
+        const [a, b] = await twoPanels(dom.container, PLAIN_HG19, EXTRA_SCAFFOLD, MOVED())
+        expect(a.state.chr1).toBe(2)
+        expect(b.state.chr1).toBe(2)
+        expect(b.state.x).toBe(7)
+        expect(b.state.y).toBe(9)
+    })
+
+    it('syncs when panel 1 is coarser or finer than the second map allows', async () => {
+        // Panel 1 at zoom 8 (5kb); panel 2's finest rung is 100kb. Ruled out as
+        // a cause during #626 and pinned here so it stays ruled out.
+        const [, b] = await twoPanels(dom.container, WHOLE_HG19, COARSE_HG19, new State(2, 2, 8, 700, 900, 1, 'NONE'))
+        expect(b.state.chr1).toBe(2)
+    })
+
+    it('syncs when panel 1 sits at the whole-genome view', async () => {
+        const [, b] = await twoPanels(dom.container, WHOLE_HG19, WHOLE_HG19, new State(0, 0, 0, 0, 0, 1, 'NONE'))
+        expect(b.state.chr1).toBe(0)
+    })
+})
+
+describe('a panel that cannot follow its sibling says so', () => {
+
+    const dom = withContainers()
+
+    beforeEach(() => {
+        vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(DataLoader.prototype, 'loadTracks').mockImplementation(async () => undefined)
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    })
+
+    afterEach(() => vi.restoreAllMocks())
+
+    /** Load panel 1, move it, then load panel 2 while watching for the report. */
+    async function loadAndWatch(container, firstMap, secondMap, view) {
+        serveMaps([firstMap, secondMap])
+        const a = await createBrowser(container, {url: 'https://example.com/a.hic'})
+        await a.setState(view)
+
+        // Spied, not stubbed: the real body has to run, because the
+        // `console.warn` and the `externalCallbacks` fan-out inside it are half
+        // of what this suite is claiming.
+        const spy = vi.spyOn(BrowserCoordinator.prototype, 'onSyncRefused')
+
+        const b = await createBrowser(container, {url: 'https://example.com/b.hic'})
+        const refusals = spy.mock.calls.map(([detail]) => detail)
+        spy.mockRestore()
+        return [a, b, refusals]
+    }
+
+    it('reports the chromosome the second map does not have', async () => {
+        // The guard itself is correct and stays: chr2 cannot be shown on a map
+        // that stops at chr1. What #626 adds is that the host is told.
+        const [, b, refusals] = await loadAndWatch(
+            dom.container, WHOLE_HG19, SUBSET_HG19, new State(2, 2, 5, 7, 9, 1, 'NONE'))
+
+        expect(b.state.chr1).not.toBe(2)
+        expect(refusals).toHaveLength(1)
+        expect(refusals[0].reason).toBe('unresolved-chromosome')
+        expect(refusals[0].chr1Name).toBe('chr2')
+        expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('chr2'))
+    })
+
+    it('reports a peer whose map is a different assembly', async () => {
+        const [, , refusals] = await loadAndWatch(
+            dom.container, WHOLE_HG19, {genomeId: 'mm10', rows: MM10}, new State(2, 2, 5, 7, 9, 1, 'NONE'))
+
+        expect(refusals).toHaveLength(1)
+        expect(refusals[0].reason).toBe('no-compatible-peer')
+        expect(refusals[0].peerGenomeIds).toEqual(['hg19'])
+        expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('hg19'))
+    })
+
+    it('says nothing when the first panel loads into an empty registry', async () => {
+        // No peer, but no refusal either: an empty room is not a rejection.
+        serveMaps([WHOLE_HG19])
+        const spy = vi.spyOn(BrowserCoordinator.prototype, 'onSyncRefused')
+        await createBrowser(dom.container, {url: 'https://example.com/a.hic'})
+        const calls = spy.mock.calls.length
+        spy.mockRestore()
+
+        expect(calls).toBe(0)
+    })
+
+    it('delivers the refusal to a host callback registered with addCallback', async () => {
+        // The other cases here watch the coordinator method; this one watches
+        // what a host actually receives, which is the published contract
+        // (ADR-0003) and the half that a severed fan-out would silently drop.
+        serveMaps([WHOLE_HG19])
+        const browser = await createBrowser(dom.container, {url: 'https://example.com/a.hic'})
+
+        const received = []
+        const unsubscribe = browser.coordinator.addCallback('onSyncRefused', detail => received.push(detail))
+        browser.coordinator.onSyncRefused({reason: 'unresolved-chromosome', message: 'no chrZ'})
+        unsubscribe()
+        browser.coordinator.onSyncRefused({reason: 'unresolved-chromosome', message: 'ignored'})
+
+        expect(received).toHaveLength(1)
+        expect(received[0].reason).toBe('unresolved-chromosome')
+        expect(received[0].browser).toBe(browser)
+    })
+
+    it('says nothing on an ordinary successful sync', async () => {
+        const [, b, refusals] = await loadAndWatch(
+            dom.container, WHOLE_HG19, WHOLE_HG19, new State(2, 2, 5, 7, 9, 1, 'NONE'))
+
+        expect(b.state.chr1).toBe(2)
+        expect(refusals).toEqual([])
+    })
+})


### PR DESCRIPTION
Closes #626.

Two independent silent drops made a second panel *sometimes* fail to follow the first. Different causes, different fixes.

## Cause A — the pair was never formed

`Dataset.compareChromosomes` demanded byte-identical chromosome tables: same length, same order, same sizes. `isCompatible` hides that for **hg38, hg19, mm10** by short-circuiting on genome id, so what the old rule actually governed was every *other* assembly — including **mm9 and dm6**, which `matchGenome` in the same file canonicalizes but `isCompatible` does not list. Two dm6 maps from different pipelines never synced.

It now compares the chromosomes the two tables **share**, by name:

- a name shared at a **different size** disqualifies the pair — that is precisely how hg19 and hg38 differ
- a name present on one side only is **skipped**, not counted against it — a subset `.hic` is an ordinary artifact
- the overlap must be large enough to be evidence: `Math.min(4, ...)` of the smaller table, mirroring `matchGenome`'s own four-chromosome line so a subset still pairs when every real chromosome it carries is accounted for
- `All` is excluded — a zoom rung, not a chromosome (ADR-0010), and its size is in kb

Pairing a subset is deliberate. `canResolveSyncState` is the per-**state** question and stays where it is.

## Cause B — the state was refused, silently

`canResolveSyncState` (#605) declines a peer state naming a chromosome this map's genome cannot place. **The guard is correct and is unchanged** — a map that stops at chr1 cannot be panned to chr2, and #605 added it to stop a TypeError.

What it lacked was a voice. `onSyncRefused` is a new coordinator callback — `console.warn` for the developer, `externalCallbacks` fan-out for the host — carrying `reason` (`'no-compatible-peer'` / `'unresolved-chromosome'`), the chromosome names and the genome ids.

No widget surface, and that is the deliberate difference from `onNormalizationSubstituted` next door: ADR-0012 put a substitution on the normalization selector because a selector was *already* displaying the value that got contradicted. A refused sync has no such control, and inventing a badge would be new UI answering a question no host has asked.

**Contract change:** this is a seventh registerable callback name, which ADR-0003 pins. The ADR's "six names" line and `COORDINATOR_CALLBACKS` move with it. Existing hosts are unaffected — nothing is renamed or removed.

## Ruled out

Investigated, found innocent, pinned green so they stay ruled out:

- a second map with a **coarser resolution ladder** than panel 1's zoom
- panel 1 sitting at the **whole-genome** view

## Testing

`test/testSyncOnLoad.js` — 10 tests, ~1s — drives the real `loadHicFile` through two real browsers with only `Dataset.loadDataset` stubbed.

Two things this suite had to do differently, both load-bearing:

- **`stubbedLoads.js` could not be used.** It stubs `loadHicFile` *whole*, and the sync block is the last thing in `loadHicFile`. The seam moves one step out, as `restoreDataset.js` did for #557.
- **The stand-in dataset sits on the real `Dataset.prototype`**, so `isCompatible` and `compareChromosomes` are the shipping implementations. `restoreDataset.js` overrides `isCompatible` to a bare genome-id comparison — the exact decision this bug turns on — and would have hidden Cause A entirely.

Per ADR-0013's `--sabotage` convention, every new test was checked to go red under sabotage of the thing it claims: the old `compareChromosomes`, the coordinator fan-out, and each of the two call sites. The first pass caught a hole in the tests themselves — a capture spy that replaced the coordinator body, so the fan-out was never exercised — which is why there is now a case registering a real host callback through `addCallback`.

Full suite: **1166 passing, 64 files**, no regressions.

## Docs

`CONTEXT.md` (*Sync group*, *Sync state*) records that *compatible* now means "same assembly", not "identical tables", and that both refusals are reported. ADR-0003 updated for the seventh callback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwQuxPjPtiTgWe7AaZQRvC