### PR TITLE
Name restoreDataset's isCompatible override as a stand-in

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -311,7 +311,9 @@ middle of that ladder. Only two rungs reach `browser.setState`.
 `test/testRestoreGolden.js` snapshots all four (#557). There was a fifth, a
 `config.synchState` rung, deleted by #566: it was unreachable, and the job it
 was written for in 2017 had been taken over by the sync step at the end of a
-load.
+load. That closing step, and everything else `loadHicFile` does once the state
+has landed, is dark to any suite built on `test/utils/stubbedLoads.js`, which
+stubs `loadHicFile` whole — see the header there, and #628.
 
 A **stated viewport** is a `{width, height}` a fixture declares rather than
 measures. The test environment is `node`, JSDOM is opt-in per suite and does no

--- a/test/utils/restoreDataset.js
+++ b/test/utils/restoreDataset.js
@@ -143,20 +143,26 @@ function buildDataset(chrs, config) {
         // The shipping method short-circuits on three known genome-id pairs
         // (hg19/GRCh37, hg38/GRCh38, mm10/GRCm38) and otherwise falls to
         // `compareChromosomes`, which compares the chromosomes two tables share
-        // (#626). This is a bare id comparison: on this fixture, same id always
-        // pairs and every other pair is refused.
+        // (#626). This is a bare id comparison: on this fixture, same id is
+        // always compatible and every other pairing is refused.
         //
         // That is the right answer for the suites here -- they are about the
-        // restore ladder, and want a pairing rule that is one line of a test's
-        // own arithmetic rather than the assembly question. It is the wrong
-        // answer for anyone whose subject *is* the pairing rule: a test standing
-        // on this fixture is testing this override, not `isCompatible`, and will
-        // pass for maps the shipping rule refuses. #626 was two such defects,
-        // and no suite on this fixture could have caught either.
+        // restore ladder, and want a compatibility rule that is one line of a
+        // test's own arithmetic rather than the assembly question. It is the
+        // wrong answer for anyone whose subject *is* the compatibility rule: a
+        // test standing on this fixture is testing this override, not
+        // `isCompatible`, and it errs in both directions -- it will pair maps
+        // the shipping rule refuses, and refuse maps it pairs, hg19 against
+        // GRCh37 among them. That second direction is #626's cause A, which no
+        // suite on this fixture could have caught.
         //
-        // A pairing-rule test builds on the real `Dataset.prototype` instead --
+        // A compatibility-rule test builds on the real `Dataset.prototype` --
         // see `test/testSyncOnLoad.js`, which does exactly that and is why the
-        // bug was visible at all. #628.
+        // bug was visible at all. It cannot be done from here: this fixture is a
+        // plain object literal on no prototype, and the file imports nothing on
+        // purpose (see `datasetModule` below), so there is no real method to
+        // fall through to. Deleting the override is not an option -- made to
+        // throw, it takes 48 tests across eight suites down. #628.
         isCompatible(other) {
             return other?.genomeId === this.genomeId
         },

--- a/test/utils/restoreDataset.js
+++ b/test/utils/restoreDataset.js
@@ -139,6 +139,24 @@ function buildDataset(chrs, config) {
         datasetType: 'hic',
         chromosomes: chrs,
         bpResolutions: BP_RESOLUTIONS,
+        // Stands in for `Dataset.isCompatible`, and does **not** reproduce it.
+        // The shipping method short-circuits on three known genome-id pairs
+        // (hg19/GRCh37, hg38/GRCh38, mm10/GRCm38) and otherwise falls to
+        // `compareChromosomes`, which compares the chromosomes two tables share
+        // (#626). This is a bare id comparison: on this fixture, same id always
+        // pairs and every other pair is refused.
+        //
+        // That is the right answer for the suites here -- they are about the
+        // restore ladder, and want a pairing rule that is one line of a test's
+        // own arithmetic rather than the assembly question. It is the wrong
+        // answer for anyone whose subject *is* the pairing rule: a test standing
+        // on this fixture is testing this override, not `isCompatible`, and will
+        // pass for maps the shipping rule refuses. #626 was two such defects,
+        // and no suite on this fixture could have caught either.
+        //
+        // A pairing-rule test builds on the real `Dataset.prototype` instead --
+        // see `test/testSyncOnLoad.js`, which does exactly that and is why the
+        // bug was visible at all. #628.
         isCompatible(other) {
             return other?.genomeId === this.genomeId
         },

--- a/test/utils/stubbedLoads.js
+++ b/test/utils/stubbedLoads.js
@@ -23,16 +23,24 @@ import {restoreDataset} from './restoreDataset.js'
  * records, so a two-chromosome stand-in with no `getMatrix` is not a dataset
  * this path can be driven against at all.
  *
- * **What stubbing `loadHicFile` whole makes dark.** The replacement below runs
- * the first two rungs and stops. Everything the real `loadHicFile` does after
- * the state lands -- the norm-vector branch, `registry.sync()`, the peer search
- * and the sync-on-load call that closes it -- is not executed by any suite that
- * stands on this fixture. That block ran unexercised until #626, whose two
- * defects both lived in it. A test whose subject is anything past the state
- * chokepoint has to move the seam one step out, to `Dataset.loadDataset`, and
- * let the ladder run for real: `restoreDataset.js`'s header is the #557 case for
- * doing so, and `test/testSyncOnLoad.js` is the sync case. Choosing this fixture
- * for such a test is choosing to not run the code under test. #628.
+ * **What stubbing `loadHicFile` whole makes dark.** The replacement below is the
+ * `config.state` rung and nothing else: it does not branch, so a config carrying
+ * `config.locus` falls to `decodeState(undefined)`, which is `State.default()`,
+ * and the locus is never parsed -- the real ladder's `parseGotoInput` rung does
+ * not run here at all. And everything the real
+ * `loadHicFile` does *after* the state lands is simply absent --
+ * `coordinator.onMapLoaded`, the norm-vector branch, `registry.sync()`, the peer
+ * search and the sync-on-load call that closes the method. No suite standing on
+ * this fixture executes any of it.
+ *
+ * That tail ran unexercised until #626, and both of #626's causes were reached
+ * through it (the defect itself was in `compareChromosomes`; the second cause
+ * was `canResolveSyncState` refusing correctly but silently). A test whose
+ * subject is anything past the state chokepoint has to move the seam one step
+ * out, to `Dataset.loadDataset`, and let the ladder run for real:
+ * `restoreDataset.js`'s header is the #557 case for doing so, and
+ * `test/testSyncOnLoad.js` is the sync case. Choosing this fixture for such a
+ * test is choosing to not run the code under test. #628.
  *
  * The two update paths are stubbed for the same reason `browserFixture` stubs
  * the 2D context: what a session carries is state, and every route out of a

--- a/test/utils/stubbedLoads.js
+++ b/test/utils/stubbedLoads.js
@@ -23,6 +23,17 @@ import {restoreDataset} from './restoreDataset.js'
  * records, so a two-chromosome stand-in with no `getMatrix` is not a dataset
  * this path can be driven against at all.
  *
+ * **What stubbing `loadHicFile` whole makes dark.** The replacement below runs
+ * the first two rungs and stops. Everything the real `loadHicFile` does after
+ * the state lands -- the norm-vector branch, `registry.sync()`, the peer search
+ * and the sync-on-load call that closes it -- is not executed by any suite that
+ * stands on this fixture. That block ran unexercised until #626, whose two
+ * defects both lived in it. A test whose subject is anything past the state
+ * chokepoint has to move the seam one step out, to `Dataset.loadDataset`, and
+ * let the ladder run for real: `restoreDataset.js`'s header is the #557 case for
+ * doing so, and `test/testSyncOnLoad.js` is the sync case. Choosing this fixture
+ * for such a test is choosing to not run the code under test. #628.
+ *
  * The two update paths are stubbed for the same reason `browserFixture` stubs
  * the 2D context: what a session carries is state, and every route out of a
  * repaint ends at either the network or a pixel. Rendering has its own tests.


### PR DESCRIPTION
Closes #628.

`restoreDataset.js`'s `isCompatible` answered with a bare genome-id comparison and said nothing about it. Every other simplification in that file explains what it stands in for; this one read as the rule.

**Deletion was the better outcome the ticket asked about, and it is not available.** Made to throw, the override takes 48 tests across eight suites down. The fixture is a plain object literal on no prototype, and the file imports nothing on purpose (a `vi.mock('../js/hicDataset.js')` factory pulls it in), so there is no real `Dataset.prototype.isCompatible` to fall through to. The comment now says that, so the next reader does not re-run the probe.

The note also names the direction the override gets wrong that is easy to miss: it *refuses* hg19 against GRCh37, which the shipping short-circuit pairs — #626's cause A.

Second hunk: `stubbedLoads.js` now names its own dark block. It stubs `loadHicFile` whole, so it is the `config.state` rung alone — no `locus` branch — and `onMapLoaded`, the norm-vector branch, `registry.sync()`, the peer search and the sync-on-load call never run. `CONTEXT.md`'s restore-door entry points at it, so it is findable from where a reader looks for the ladder.

Comment-only. Full suite green (1166 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPv2LSCfGpZwV8BTTdC4is