### PR TITLE
Say that every restore door reaches the chokepoint

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -307,7 +307,12 @@ in, one stage further down. There are four, and they are branches rather than
 published methods: `dataLoader.loadHicFile` walks a three-**rung** ladder — a
 config-level `locus`, a `state` token, and the `State.default()` fallback — and
 `dataLoader.loadLiveContactMap` is a fourth door walking its own copy of the
-middle of that ladder. Only two rungs reach `browser.setState`.
+middle of that ladder. All four reach `browser.setState`, the chokepoint: the
+`locus` rung reaches it with `State.default()` and *then* lets `parseGotoInput`
+move the browser, which is why the state a door hands over is never the state in
+force afterwards and why `onMapLoaded` reads its state back off the browser
+(#558). Until #559 the `locus` rung went to `parseGotoInput` without reaching the
+chokepoint at all, and ending that is ADR-0009 decision 1.
 `test/testRestoreGolden.js` snapshots all four (#557). There was a fifth, a
 `config.synchState` rung, deleted by #566: it was unreachable, and the job it
 was written for in 2017 had been taken over by the sync step at the end of a


### PR DESCRIPTION
Closes #630.

`CONTEXT.md`'s **Restore door** entry ended on "Only two rungs reach `browser.setState`". True before #559, and false since — the `locus` rung reaches the chokepoint with `State.default()` before `parseGotoInput` moves the browser (`js/dataLoader.js:164-167`), and the fourth door, `loadLiveContactMap`, reaches it as well (`js/dataLoader.js:309`). The glossary was answering ADR-0009 decision 1's own question with the answer that decision repealed.

Checked against `js/dataLoader.js` as it stands, per the ticket, not against the ADR text.

The replacement also says why the correction matters past the sentence: the `locus` rung reaches the chokepoint and *then* moves the browser, so what a door hands over is never the state in force afterwards — the reason `onMapLoaded` reads its state back off the browser (#558).

Glossary only, no code change. Full suite green (1166 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPv2LSCfGpZwV8BTTdC4is