### PR TITLE
Recompute sync membership instead of accumulating it

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -130,7 +130,9 @@ opted out and its dataset is compatible with the other's — *compatible* meanin
 the two chromosome tables share enough named chromosomes, at agreeing sizes, to
 be the same assembly (`Dataset.compareChromosomes`), not that the tables are
 identical. A subset `.hic` therefore joins, and the per-state question is left to
-`canResolveSyncState`. What travels the group
+`canResolveSyncState`. Being a rule, it is derived afresh — `registry.sync()` —
+wherever the open maps change: a load, a failed load, a browser arriving or
+leaving, a restore. It is never accumulated (#635). What travels the group
 is canonical state and, by deliberate exception, view preferences — never dataset
 choices. See `docs/adr/0014`. Dataset choices reach several browsers by the other
 mechanism, the **target set** — `docs/adr/0015`.

--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -116,6 +116,10 @@ class BrowserRegistry {
      */
     add(browser) {
         this.register(browser)
+        // A browser arriving with its map already loaded -- `createBrowser`
+        // loads before it hands over -- changes the open maps, and the load's
+        // own recompute ran while this one was not yet in the list. #635.
+        this.sync()
         this.select(browser)
         this.refreshDeleteButtonVisibility()
     }
@@ -515,6 +519,12 @@ class BrowserRegistry {
                 this.#select(this.browsers[0])
             }
         })
+        // The open maps have changed. Here rather than in `delete` and
+        // `deleteAll`, because every door out -- those two, a host's own
+        // `dispose()`, a `reset()` -- passes through this slot. `dispose()`
+        // has already cut this browser's edges; what this adds is that the
+        // survivors' membership is derived, not merely what was left. #635.
+        this.sync()
         this.refreshDeleteButtonVisibility()
     }
 
@@ -567,13 +577,33 @@ class BrowserRegistry {
     }
 
     /**
-     * Join the compatible browsers into each other's sync group. Defaults to
+     * Derive the sync group afresh: afterwards every browser in the list holds
+     * exactly its partners under `pairSynchable`, and nothing else. Defaults to
      * this registry's browsers; an explicit list is how a caller syncs a subset
      * (and, per decision 6 of the ADR, how a cross-registry group would later
      * be expressed).
+     *
+     * Recomputed rather than accumulated, per ADR-0016 decision 6. It used to
+     * only add, so a panel that loaded an incompatible map kept the pairing its
+     * old map earned and went on receiving states its new genome cannot place.
+     * Membership is a pure function of the open maps; nothing about it is worth
+     * remembering between calls.
+     *
+     * An edge to a browser *outside* the list is dropped from both ends, so
+     * the result is symmetric whatever the caller passes. It runs wherever the
+     * open maps change: a load or a failed one (`dataLoader.js`), a browser
+     * arriving (`add`) or leaving (`releaseSlot`), and a restore.
      */
-    sync(browsers) {
-        for (const [b1, b2] of pairSynchable(browsers || this.browsers)) {
+    sync(browsers = this.browsers) {
+
+        for (const browser of browsers) {
+            for (const peer of browser.synchedBrowsers) {
+                peer.synchedBrowsers.delete(browser)
+            }
+            browser.synchedBrowsers.clear()
+        }
+
+        for (const [b1, b2] of pairSynchable(browsers)) {
             b1.synchedBrowsers.add(b2)
             b2.synchedBrowsers.add(b1)
         }
@@ -654,9 +684,11 @@ class BrowserRegistry {
 
         await createBrowserList(this.container, session)
 
-        if (false !== session.syncDatasets) {
-            this.sync()
-        }
+        // Whatever `syncDatasets` says. `false` already reached every browser
+        // as `synchable: false` in the normalization above, so the recompute
+        // pairs nothing -- and skipping it would leave whatever the loads
+        // assembled on their way in standing instead of derived. #635.
+        this.sync()
     }
 
     /**

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -239,6 +239,13 @@ class DataLoader {
             this.browser.contactMapLabel.title = "";
             config.name = name;
 
+            // `clearDataset()` stripped this browser from its peers but left its
+            // own set standing (#492), for the load to address the group on its
+            // way past. A load that fails never reaches the recompute above, so
+            // it runs here: the open maps have changed, whatever state this
+            // browser is left in. #635.
+            this.browser.registry.sync();
+
             // A bot challenge is the one failure the host app cannot explain to the user, since the
             // tell is a response header it never sees. Everything else is left to the host, which
             // may already report the rethrow — see issue #441.

--- a/js/normalizeSession.js
+++ b/js/normalizeSession.js
@@ -263,9 +263,11 @@ function resolveBackgroundColor(config) {
  * `createBrowserList` did and is the reading that makes the session-level member
  * worth having.
  *
- * Only a literal `false` opts out, matching the `false !== session.syncDatasets`
- * test `BrowserRegistry.restoreSession` makes about the same field. Absent or
- * true writes nothing, so a browser that opted out on its own is left alone.
+ * Only a literal `false` opts out. Absent or true writes nothing, so a browser
+ * that opted out on its own is left alone. This is now the *only* reader of the
+ * field: `BrowserRegistry.restoreSession` used to test it too, and skip its
+ * closing `sync()` on `false`; since #635 it recomputes regardless, and what
+ * is written here is why that recompute pairs nothing.
  */
 function resolveSyncDatasets(session, configs) {
 

--- a/test/testBrowserTargeting.js
+++ b/test/testBrowserTargeting.js
@@ -53,7 +53,9 @@ function fakeBrowser(name, {genomeId} = {}) {
         }
     }
     if (genomeId !== undefined) {
-        browser.dataset = {genomeId}
+        // `isCompatible` because the registry recomputes the sync group
+        // whenever a browser arrives or leaves -- #635.
+        browser.dataset = {genomeId, isCompatible: other => other.genomeId === genomeId}
         browser.genome = {id: genomeId}
     }
     return browser

--- a/test/testDataLoaderErrors.js
+++ b/test/testDataLoaderErrors.js
@@ -24,7 +24,8 @@ function stubBrowser() {
         userInteractionShield: { style: {} },
         controlDataset: undefined,
         // Alerts land in the browser's own embed, not a page-wide singleton -- #481.
-        registry: { presentAlert: (message) => presented.push(message) }
+        // A failed load recomputes sync membership on its way out -- #635.
+        registry: { presentAlert: (message) => presented.push(message), sync: () => undefined }
     };
 }
 

--- a/test/testSyncMembership.js
+++ b/test/testSyncMembership.js
@@ -5,7 +5,7 @@ import DataLoader from '../js/dataLoader.js'
 import {createBrowser} from '../js/createBrowser.js'
 import {registryForContainer} from '../js/browserRegistry.js'
 import {withContainers} from './utils/browserFixture.js'
-import {HG19, MM10, UNREACHABLE, serveMaps} from './utils/servedMaps.js'
+import {WHOLE_HG19, WHOLE_MM10, UNREACHABLE, serveMaps} from './utils/servedMaps.js'
 
 /**
  * Sync membership is a pure function of the open maps, derived fresh wherever
@@ -17,9 +17,6 @@ import {HG19, MM10, UNREACHABLE, serveMaps} from './utils/servedMaps.js'
  * how the registry stores it.
  */
 
-const WHOLE_HG19 = {genomeId: 'hg19', rows: HG19}
-const WHOLE_MM10 = {genomeId: 'mm10', rows: MM10}
-
 const url = name => `https://example.com/${name}.hic`
 
 /** Each browser's partners, by panel order, so a failure names who holds whom. */
@@ -27,7 +24,7 @@ function membership(browsers) {
     return browsers.map(browser => [...browser.synchedBrowsers].map(peer => browsers.indexOf(peer)))
 }
 
-describe('sync membership follows the open maps', () => {
+describe('sync membership', () => {
 
     const dom = withContainers()
 
@@ -40,120 +37,112 @@ describe('sync membership follows the open maps', () => {
 
     afterEach(() => vi.restoreAllMocks())
 
-    it('pairs a panel created with a compatible map', async () => {
-        // `createBrowser` loads before it registers, so the load's own
-        // recompute cannot see the newcomer; joining the registry is itself a
-        // change to the open maps.
-        serveMaps([WHOLE_HG19, WHOLE_HG19])
-        const a = await createBrowser(dom.container, {url: url('a')})
-        const b = await createBrowser(dom.container, {url: url('b')})
+    describe('follows the open maps', () => {
 
-        expect(membership([a, b])).toEqual([[1], [0]])
+        it('pairs a panel created with a compatible map', async () => {
+            // `createBrowser` loads before it registers, so the load's own
+            // recompute cannot see the newcomer; joining the registry is itself a
+            // change to the open maps.
+            serveMaps([WHOLE_HG19, WHOLE_HG19])
+            const a = await createBrowser(dom.container, {url: url('a')})
+            const b = await createBrowser(dom.container, {url: url('b')})
+
+            expect(membership([a, b])).toEqual([[1], [0]])
+        })
+
+        it('unpairs a panel on both sides when it loads an incompatible map', async () => {
+            serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
+            const a = await createBrowser(dom.container, {url: url('a')})
+            const b = await createBrowser(dom.container, {url: url('b')})
+            expect(membership([a, b])).toEqual([[1], [0]])
+
+            await b.loadHicFile({url: url('mouse')})
+
+            expect(membership([a, b])).toEqual([[], []])
+        })
+
+        it('no longer hands a panel its former peer\'s states once it has moved on', async () => {
+            serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
+            const a = await createBrowser(dom.container, {url: url('a')})
+            const b = await createBrowser(dom.container, {url: url('b')})
+            await b.loadHicFile({url: url('mouse')})
+
+            const received = vi.spyOn(b, 'syncState')
+            a.syncToOtherBrowsers()
+
+            expect(received).not.toHaveBeenCalled()
+        })
+
+        it('pairs an unpaired panel that loads a compatible map', async () => {
+            serveMaps([WHOLE_HG19, WHOLE_MM10, WHOLE_HG19])
+            const a = await createBrowser(dom.container, {url: url('a')})
+            const b = await createBrowser(dom.container, {url: url('mouse')})
+            expect(membership([a, b])).toEqual([[], []])
+
+            await b.loadHicFile({url: url('b')})
+
+            expect(membership([a, b])).toEqual([[1], [0]])
+        })
+
+        it('drops a panel from every group when its load fails and leaves it without a map', async () => {
+            serveMaps([WHOLE_HG19, WHOLE_HG19, UNREACHABLE])
+            const a = await createBrowser(dom.container, {url: url('a')})
+            const b = await createBrowser(dom.container, {url: url('b')})
+
+            await expect(b.loadHicFile({url: url('gone')})).rejects.toThrow()
+
+            expect(b.dataset).toBeUndefined()
+            expect(membership([a, b])).toEqual([[], []])
+        })
+
+        it('leaves the survivors of a delete paired among themselves and nobody holding the deleted one', async () => {
+            serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
+            const a = await createBrowser(dom.container, {url: url('a')})
+            const b = await createBrowser(dom.container, {url: url('b')})
+            const c = await createBrowser(dom.container, {url: url('c')})
+            const d = await createBrowser(dom.container, {url: url('mouse')})
+
+            a.registry.delete(b)
+
+            expect(membership([a, c, d])).toEqual([[1], [0], []])
+        })
     })
 
-    it('unpairs a panel on both sides when it loads an incompatible map', async () => {
-        serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
-        const a = await createBrowser(dom.container, {url: url('a')})
-        const b = await createBrowser(dom.container, {url: url('b')})
-        expect(membership([a, b])).toEqual([[1], [0]])
+    describe('in a restored session', () => {
 
-        await b.loadHicFile({url: url('mouse')})
+        const session = (extra = {}) => ({
+            ...extra,
+            browsers: [{url: url('a')}, {url: url('b')}, {url: url('mouse')}]
+        })
 
-        expect(membership([a, b])).toEqual([[], []])
-    })
+        it('pairs the compatible browsers when the session syncs datasets', async () => {
+            serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
+            const registry = registryForContainer(dom.container)
 
-    it('no longer hands a panel its former peer\'s states once it has moved on', async () => {
-        serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
-        const a = await createBrowser(dom.container, {url: url('a')})
-        const b = await createBrowser(dom.container, {url: url('b')})
-        await b.loadHicFile({url: url('mouse')})
+            await registry.restoreSession(session({syncDatasets: true}))
 
-        const received = vi.spyOn(b, 'syncState')
-        a.syncToOtherBrowsers()
+            expect(membership(registry.browsers)).toEqual([[1], [0], []])
+        })
 
-        expect(received).not.toHaveBeenCalled()
-    })
+        it('pairs nothing when the session does not sync datasets', async () => {
+            serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
+            const registry = registryForContainer(dom.container)
 
-    it('pairs an unpaired panel that loads a compatible map', async () => {
-        serveMaps([WHOLE_HG19, WHOLE_MM10, WHOLE_HG19])
-        const a = await createBrowser(dom.container, {url: url('a')})
-        const b = await createBrowser(dom.container, {url: url('mouse')})
-        expect(membership([a, b])).toEqual([[], []])
+            await registry.restoreSession(session({syncDatasets: false}))
 
-        await b.loadHicFile({url: url('b')})
+            expect(membership(registry.browsers)).toEqual([[], [], []])
+        })
 
-        expect(membership([a, b])).toEqual([[1], [0]])
-    })
+        it('replaces the membership a previous session left behind', async () => {
+            serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_MM10, WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
+            const registry = registryForContainer(dom.container)
+            await registry.restoreSession(session())
+            const previous = [...registry.browsers]
 
-    it('drops a panel from every group when its load fails and leaves it without a map', async () => {
-        serveMaps([WHOLE_HG19, WHOLE_HG19, UNREACHABLE])
-        const a = await createBrowser(dom.container, {url: url('a')})
-        const b = await createBrowser(dom.container, {url: url('b')})
+            await registry.restoreSession(session({syncDatasets: false}))
 
-        await expect(b.loadHicFile({url: url('gone')})).rejects.toThrow()
-
-        expect(b.dataset).toBeUndefined()
-        expect(membership([a, b])).toEqual([[], []])
-    })
-
-    it('leaves the survivors of a delete paired among themselves and nobody holding the deleted one', async () => {
-        serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
-        const a = await createBrowser(dom.container, {url: url('a')})
-        const b = await createBrowser(dom.container, {url: url('b')})
-        const c = await createBrowser(dom.container, {url: url('c')})
-        const d = await createBrowser(dom.container, {url: url('mouse')})
-
-        a.registry.delete(b)
-
-        expect(membership([a, c, d])).toEqual([[1], [0], []])
-    })
-})
-
-describe('a restored session\'s sync membership', () => {
-
-    const dom = withContainers()
-
-    beforeEach(() => {
-        vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
-        vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
-        vi.spyOn(DataLoader.prototype, 'loadTracks').mockImplementation(async () => undefined)
-        vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    })
-
-    afterEach(() => vi.restoreAllMocks())
-
-    const session = (extra = {}) => ({
-        ...extra,
-        browsers: [{url: url('a')}, {url: url('b')}, {url: url('mouse')}]
-    })
-
-    it('pairs the compatible browsers when the session syncs datasets', async () => {
-        serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
-        const registry = registryForContainer(dom.container)
-
-        await registry.restoreSession(session({syncDatasets: true}))
-
-        expect(membership(registry.browsers)).toEqual([[1], [0], []])
-    })
-
-    it('pairs nothing when the session does not sync datasets', async () => {
-        serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
-        const registry = registryForContainer(dom.container)
-
-        await registry.restoreSession(session({syncDatasets: false}))
-
-        expect(membership(registry.browsers)).toEqual([[], [], []])
-    })
-
-    it('replaces the membership a previous session left behind', async () => {
-        serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_MM10, WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
-        const registry = registryForContainer(dom.container)
-        await registry.restoreSession(session())
-        const previous = [...registry.browsers]
-
-        await registry.restoreSession(session({syncDatasets: false}))
-
-        expect(membership(registry.browsers)).toEqual([[], [], []])
-        expect(previous.every(browser => browser.synchedBrowsers.size === 0)).toBe(true)
+            expect(membership(registry.browsers)).toEqual([[], [], []])
+            expect(previous.every(browser => browser.synchedBrowsers.size === 0)).toBe(true)
+        })
     })
 })

--- a/test/testSyncMembership.js
+++ b/test/testSyncMembership.js
@@ -1,0 +1,159 @@
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest'
+import ContactMatrixView from '../js/contactMatrixView.js'
+import HICBrowser from '../js/hicBrowser.js'
+import DataLoader from '../js/dataLoader.js'
+import {createBrowser} from '../js/createBrowser.js'
+import {registryForContainer} from '../js/browserRegistry.js'
+import {withContainers} from './utils/browserFixture.js'
+import {HG19, MM10, UNREACHABLE, serveMaps} from './utils/servedMaps.js'
+
+/**
+ * Sync membership is a pure function of the open maps, derived fresh wherever
+ * the set of open maps changes rather than only ever added to. #635, ADR-0016
+ * decision 6.
+ *
+ * Every case drives the real load path, stubbed only at `Dataset.loadDataset`,
+ * and reads `synchedBrowsers` -- what `syncToOtherBrowsers` walks -- rather than
+ * how the registry stores it.
+ */
+
+const WHOLE_HG19 = {genomeId: 'hg19', rows: HG19}
+const WHOLE_MM10 = {genomeId: 'mm10', rows: MM10}
+
+const url = name => `https://example.com/${name}.hic`
+
+/** Each browser's partners, by panel order, so a failure names who holds whom. */
+function membership(browsers) {
+    return browsers.map(browser => [...browser.synchedBrowsers].map(peer => browsers.indexOf(peer)))
+}
+
+describe('sync membership follows the open maps', () => {
+
+    const dom = withContainers()
+
+    beforeEach(() => {
+        vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(DataLoader.prototype, 'loadTracks').mockImplementation(async () => undefined)
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    })
+
+    afterEach(() => vi.restoreAllMocks())
+
+    it('pairs a panel created with a compatible map', async () => {
+        // `createBrowser` loads before it registers, so the load's own
+        // recompute cannot see the newcomer; joining the registry is itself a
+        // change to the open maps.
+        serveMaps([WHOLE_HG19, WHOLE_HG19])
+        const a = await createBrowser(dom.container, {url: url('a')})
+        const b = await createBrowser(dom.container, {url: url('b')})
+
+        expect(membership([a, b])).toEqual([[1], [0]])
+    })
+
+    it('unpairs a panel on both sides when it loads an incompatible map', async () => {
+        serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
+        const a = await createBrowser(dom.container, {url: url('a')})
+        const b = await createBrowser(dom.container, {url: url('b')})
+        expect(membership([a, b])).toEqual([[1], [0]])
+
+        await b.loadHicFile({url: url('mouse')})
+
+        expect(membership([a, b])).toEqual([[], []])
+    })
+
+    it('no longer hands a panel its former peer\'s states once it has moved on', async () => {
+        serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
+        const a = await createBrowser(dom.container, {url: url('a')})
+        const b = await createBrowser(dom.container, {url: url('b')})
+        await b.loadHicFile({url: url('mouse')})
+
+        const received = vi.spyOn(b, 'syncState')
+        a.syncToOtherBrowsers()
+
+        expect(received).not.toHaveBeenCalled()
+    })
+
+    it('pairs an unpaired panel that loads a compatible map', async () => {
+        serveMaps([WHOLE_HG19, WHOLE_MM10, WHOLE_HG19])
+        const a = await createBrowser(dom.container, {url: url('a')})
+        const b = await createBrowser(dom.container, {url: url('mouse')})
+        expect(membership([a, b])).toEqual([[], []])
+
+        await b.loadHicFile({url: url('b')})
+
+        expect(membership([a, b])).toEqual([[1], [0]])
+    })
+
+    it('drops a panel from every group when its load fails and leaves it without a map', async () => {
+        serveMaps([WHOLE_HG19, WHOLE_HG19, UNREACHABLE])
+        const a = await createBrowser(dom.container, {url: url('a')})
+        const b = await createBrowser(dom.container, {url: url('b')})
+
+        await expect(b.loadHicFile({url: url('gone')})).rejects.toThrow()
+
+        expect(b.dataset).toBeUndefined()
+        expect(membership([a, b])).toEqual([[], []])
+    })
+
+    it('leaves the survivors of a delete paired among themselves and nobody holding the deleted one', async () => {
+        serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
+        const a = await createBrowser(dom.container, {url: url('a')})
+        const b = await createBrowser(dom.container, {url: url('b')})
+        const c = await createBrowser(dom.container, {url: url('c')})
+        const d = await createBrowser(dom.container, {url: url('mouse')})
+
+        a.registry.delete(b)
+
+        expect(membership([a, c, d])).toEqual([[1], [0], []])
+    })
+})
+
+describe('a restored session\'s sync membership', () => {
+
+    const dom = withContainers()
+
+    beforeEach(() => {
+        vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(DataLoader.prototype, 'loadTracks').mockImplementation(async () => undefined)
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    })
+
+    afterEach(() => vi.restoreAllMocks())
+
+    const session = (extra = {}) => ({
+        ...extra,
+        browsers: [{url: url('a')}, {url: url('b')}, {url: url('mouse')}]
+    })
+
+    it('pairs the compatible browsers when the session syncs datasets', async () => {
+        serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
+        const registry = registryForContainer(dom.container)
+
+        await registry.restoreSession(session({syncDatasets: true}))
+
+        expect(membership(registry.browsers)).toEqual([[1], [0], []])
+    })
+
+    it('pairs nothing when the session does not sync datasets', async () => {
+        serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
+        const registry = registryForContainer(dom.container)
+
+        await registry.restoreSession(session({syncDatasets: false}))
+
+        expect(membership(registry.browsers)).toEqual([[], [], []])
+    })
+
+    it('replaces the membership a previous session left behind', async () => {
+        serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_MM10, WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
+        const registry = registryForContainer(dom.container)
+        await registry.restoreSession(session())
+        const previous = [...registry.browsers]
+
+        await registry.restoreSession(session({syncDatasets: false}))
+
+        expect(membership(registry.browsers)).toEqual([[], [], []])
+        expect(previous.every(browser => browser.synchedBrowsers.size === 0)).toBe(true)
+    })
+})

--- a/test/testSyncOnLoad.js
+++ b/test/testSyncOnLoad.js
@@ -6,7 +6,7 @@ import {createBrowser} from '../js/createBrowser.js'
 import {withContainers} from './utils/browserFixture.js'
 import State from '../js/hicState.js'
 import BrowserCoordinator from '../js/browserCoordinator.js'
-import {HG19, MM10, serveMaps} from './utils/servedMaps.js'
+import {HG19, WHOLE_HG19, WHOLE_MM10, serveMaps} from './utils/servedMaps.js'
 
 /**
  * The user's scenario, end to end: load a map into a panel, move it, add a
@@ -17,7 +17,6 @@ import {HG19, MM10, serveMaps} from './utils/servedMaps.js'
  * it; see `test/utils/servedMaps.js` for why that is the seam.
  */
 
-const WHOLE_HG19 = {genomeId: 'hg19', rows: HG19}
 const SUBSET_HG19 = {genomeId: 'hg19', rows: HG19.slice(0, 1)}          // All + chr1 only
 const EXTRA_SCAFFOLD = {genomeId: 'hg19_scaffolds', rows: [...HG19, ['scaffold_7', 12345]]}
 const PLAIN_HG19 = {genomeId: 'hg19_no_alt', rows: HG19}
@@ -134,7 +133,7 @@ describe('a panel that cannot follow its sibling says so', () => {
 
     it('reports a peer whose map is a different assembly', async () => {
         const [, , refusals] = await loadAndWatch(
-            dom.container, WHOLE_HG19, {genomeId: 'mm10', rows: MM10}, new State(2, 2, 5, 7, 9, 1, 'NONE'))
+            dom.container, WHOLE_HG19, WHOLE_MM10, new State(2, 2, 5, 7, 9, 1, 'NONE'))
 
         expect(refusals).toHaveLength(1)
         expect(refusals[0].reason).toBe('no-compatible-peer')

--- a/test/testSyncOnLoad.js
+++ b/test/testSyncOnLoad.js
@@ -1,5 +1,4 @@
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest'
-import Dataset from '../js/hicDataset.js'
 import ContactMatrixView from '../js/contactMatrixView.js'
 import HICBrowser from '../js/hicBrowser.js'
 import DataLoader from '../js/dataLoader.js'
@@ -7,6 +6,7 @@ import {createBrowser} from '../js/createBrowser.js'
 import {withContainers} from './utils/browserFixture.js'
 import State from '../js/hicState.js'
 import BrowserCoordinator from '../js/browserCoordinator.js'
+import {HG19, MM10, serveMaps} from './utils/servedMaps.js'
 
 /**
  * The user's scenario, end to end: load a map into a panel, move it, add a
@@ -14,80 +14,11 @@ import BrowserCoordinator from '../js/browserCoordinator.js'
  * first panel's view?
  *
  * The seam is `Dataset.loadDataset` -- the network read -- and nothing above
- * it. `stubbedLoads.js` cannot be used here: it stubs `loadHicFile` whole, and
- * `loadHicFile`'s closing sync block is the code under test.
- *
- * The stand-in dataset is built on the real `Dataset.prototype`, so
- * `isCompatible` and `compareChromosomes` are the shipping implementations
- * rather than a fixture's paraphrase. That matters: the fixture in
- * `restoreDataset.js` overrides `isCompatible` to a bare genome-id comparison,
- * which is exactly the decision this bug turns on.
+ * it; see `test/utils/servedMaps.js` for why that is the seam.
  */
-
-const HG19 = [
-    ['chr1', 249250621], ['chr2', 243199373], ['chr3', 198022430], ['chr4', 191154276],
-    ['chr5', 180915260], ['chr6', 171115067], ['chr7', 159138663], ['chr8', 146364022],
-    ['chr9', 141213431], ['chr10', 135534747], ['chr11', 135006516], ['chr12', 133851895],
-    ['chr13', 115169878], ['chr14', 107349540], ['chr15', 102531392], ['chr16', 90354753],
-    ['chr17', 81195210], ['chr18', 78077248], ['chr19', 59128983], ['chr20', 63025520],
-    ['chr21', 48129895], ['chr22', 51304566], ['chrX', 155270560], ['chrY', 59373566],
-]
-
-const BP_RESOLUTIONS = [2500000, 1000000, 500000, 250000, 100000, 50000, 25000, 10000, 5000]
-
-function chromosomeTable(rows) {
-    const named = rows.map(([name, size], i) => ({index: i + 1, name, size}))
-    const all = {index: 0, name: 'All', size: named.reduce((sum, c) => sum + c.size, 0)}
-    return [all, ...named]
-}
-
-const matrix = (resolutions = BP_RESOLUTIONS) => ({
-    getZoomDataByIndex(index, unit) {
-        const binSize = resolutions[index]
-        return binSize === undefined ? undefined : {zoom: {index, unit, binSize}}
-    },
-    findZoomForResolution(binSize) {
-        for (let z = resolutions.length - 1; z > 0; z--) if (resolutions[z] >= binSize) return z
-        return 0
-    },
-})
-
-/** A dataset on the real prototype: only data and the network-backed methods differ. */
-function fakeDataset({genomeId, rows, resolutions, config}) {
-    const chromosomes = chromosomeTable(rows)
-    const bpResolutions = resolutions || BP_RESOLUTIONS
-    return Object.assign(Object.create(Dataset.prototype), {
-        name: config.name,
-        url: config.url,
-        datasetType: 'hic',
-        genomeId,
-        chromosomes,
-        bpResolutions,
-        wholeGenomeChromosome: chromosomes[0],
-        normalizationTypes: ['NONE'],
-        async getMatrix() { return matrix(bpResolutions) },
-        hicFile: {config: {}},
-    })
-}
-
-/**
- * Queue the maps each successive `loadHicFile` should get, in load order.
- * Returns nothing; the spy is torn down with the rest of the mocks.
- */
-function serveMaps(maps) {
-    const queue = [...maps]
-    vi.spyOn(Dataset, 'loadDataset').mockImplementation(async config => {
-        const spec = queue.shift()
-        return fakeDataset({...spec, config})
-    })
-}
 
 const WHOLE_HG19 = {genomeId: 'hg19', rows: HG19}
 const SUBSET_HG19 = {genomeId: 'hg19', rows: HG19.slice(0, 1)}          // All + chr1 only
-const MM10 = [
-    ['chr1', 195471971], ['chr2', 182113224], ['chr3', 160039680], ['chr4', 156508116],
-    ['chr5', 151834684], ['chr6', 149736546], ['chr7', 145441459], ['chr8', 129401213],
-]
 const EXTRA_SCAFFOLD = {genomeId: 'hg19_scaffolds', rows: [...HG19, ['scaffold_7', 12345]]}
 const PLAIN_HG19 = {genomeId: 'hg19_no_alt', rows: HG19}
 /** A map binned no finer than 100kb -- a low-coverage or coarse .hic. */

--- a/test/utils/servedMaps.js
+++ b/test/utils/servedMaps.js
@@ -28,6 +28,10 @@ export const MM10 = [
     ['chr5', 151834684], ['chr6', 149736546], ['chr7', 145441459], ['chr8', 129401213],
 ]
 
+/** A whole-genome map of each assembly -- the ordinary case. */
+export const WHOLE_HG19 = {genomeId: 'hg19', rows: HG19}
+export const WHOLE_MM10 = {genomeId: 'mm10', rows: MM10}
+
 const BP_RESOLUTIONS = [2500000, 1000000, 500000, 250000, 100000, 50000, 25000, 10000, 5000]
 
 function chromosomeTable(rows) {

--- a/test/utils/servedMaps.js
+++ b/test/utils/servedMaps.js
@@ -1,0 +1,87 @@
+import {vi} from 'vitest'
+import Dataset from '../../js/hicDataset.js'
+
+/**
+ * Maps served to the real load path, stubbed only at `Dataset.loadDataset` --
+ * the network read -- and nothing above it. `stubbedLoads.js` cannot stand in:
+ * it stubs `loadHicFile` whole, and the sync steps that method ends with are
+ * what the suites using this are about.
+ *
+ * The stand-in dataset is built on the real `Dataset.prototype`, so
+ * `isCompatible` and `compareChromosomes` are the shipping implementations
+ * rather than a fixture's paraphrase. That matters: the fixture in
+ * `restoreDataset.js` overrides `isCompatible` to a bare genome-id comparison,
+ * which is exactly the decision these suites turn on.
+ */
+
+export const HG19 = [
+    ['chr1', 249250621], ['chr2', 243199373], ['chr3', 198022430], ['chr4', 191154276],
+    ['chr5', 180915260], ['chr6', 171115067], ['chr7', 159138663], ['chr8', 146364022],
+    ['chr9', 141213431], ['chr10', 135534747], ['chr11', 135006516], ['chr12', 133851895],
+    ['chr13', 115169878], ['chr14', 107349540], ['chr15', 102531392], ['chr16', 90354753],
+    ['chr17', 81195210], ['chr18', 78077248], ['chr19', 59128983], ['chr20', 63025520],
+    ['chr21', 48129895], ['chr22', 51304566], ['chrX', 155270560], ['chrY', 59373566],
+]
+
+export const MM10 = [
+    ['chr1', 195471971], ['chr2', 182113224], ['chr3', 160039680], ['chr4', 156508116],
+    ['chr5', 151834684], ['chr6', 149736546], ['chr7', 145441459], ['chr8', 129401213],
+]
+
+const BP_RESOLUTIONS = [2500000, 1000000, 500000, 250000, 100000, 50000, 25000, 10000, 5000]
+
+function chromosomeTable(rows) {
+    const named = rows.map(([name, size], i) => ({index: i + 1, name, size}))
+    const all = {index: 0, name: 'All', size: named.reduce((sum, c) => sum + c.size, 0)}
+    return [all, ...named]
+}
+
+const matrix = (resolutions = BP_RESOLUTIONS) => ({
+    getZoomDataByIndex(index, unit) {
+        const binSize = resolutions[index]
+        return binSize === undefined ? undefined : {zoom: {index, unit, binSize}}
+    },
+    findZoomForResolution(binSize) {
+        for (let z = resolutions.length - 1; z > 0; z--) if (resolutions[z] >= binSize) return z
+        return 0
+    },
+})
+
+/** A dataset on the real prototype: only data and the network-backed methods differ. */
+function fakeDataset({genomeId, rows, resolutions, config}) {
+    const chromosomes = chromosomeTable(rows)
+    const bpResolutions = resolutions || BP_RESOLUTIONS
+    return Object.assign(Object.create(Dataset.prototype), {
+        name: config.name,
+        url: config.url,
+        datasetType: 'hic',
+        genomeId,
+        chromosomes,
+        bpResolutions,
+        wholeGenomeChromosome: chromosomes[0],
+        normalizationTypes: ['NONE'],
+        async getMatrix() { return matrix(bpResolutions) },
+        hicFile: {config: {}},
+    })
+}
+
+/**
+ * A map spec that makes its load fail, as an unreachable URL would: the read
+ * rejects, and `loadHicFile` is left to clean up after it.
+ */
+export const UNREACHABLE = {unreachable: true}
+
+/**
+ * Queue the maps each successive `loadHicFile` should get, in load order.
+ * Returns nothing; the spy is torn down with the rest of the mocks.
+ */
+export function serveMaps(maps) {
+    const queue = [...maps]
+    vi.spyOn(Dataset, 'loadDataset').mockImplementation(async config => {
+        const spec = queue.shift()
+        if (spec.unreachable) {
+            throw new Error(`could not read ${config.url}`)
+        }
+        return fakeDataset({...spec, config})
+    })
+}


### PR DESCRIPTION
Closes #635. Part of #634; ADR-0016 decision 6.

## What changes

`registry.sync()` now rebuilds every browser's `synchedBrowsers` from `pairSynchable` instead of only adding to it. Stale links are removed from both ends, so membership is always symmetric.

It runs wherever the set of open maps changes:

- **after a load:** the existing call in `loadHicFile`
- **after a failed load:** a new call in its `catch` block
- **after delete / deleteAll:** in `releaseSlot`, which every way out passes through, including a host's own `dispose()` and `reset()`
- **after `restoreSession`:** now unconditional. `syncDatasets: false` already sets every browser to `synchable: false` during normalization, so the recompute pairs nothing.
- **in `add`:** not listed in the ticket, but needed. `createBrowser` loads a map *before* registering the browser, so a panel created with a `url` never joined any group. **Visible change:** such panels now pair where they didn't before.

The pairing rule itself (`isCompatible`) is unchanged, and there is no UI.

## Tests

- New `test/testSyncMembership.js` goes through the real load path, stubbed only at `Dataset.loadDataset`, and checks `synchedBrowsers` directly.
- The fake-map helpers moved from `testSyncOnLoad.js` into `test/utils/servedMaps.js` so both files share them.
- The fakes in `testBrowserTargeting.js` and `testDataLoaderErrors.js` gained the `isCompatible` / `sync` they now need.
- Full suite: 1175 passed.

## Not in this PR

- **#638:** the live-map loader never recomputes, so a paired panel that loads a live map keeps a one-sided link to its old peer. Fixing it would make live maps pair for the first time, which is a behaviour decision for the Spacewalk path.
- If `sync()` ever threw inside the failed-load `catch`, it would replace the original error. Low risk, so left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9UmXS9G8vg77i28dBja8L
