### PR TITLE
Pair panels only on two-way chromosome parity (Dataset.canSyncWith)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -125,30 +125,37 @@ isolation that lets two embeds coexist on a page — see `docs/adr/0004`.
 _Avoid_: browser session, browser context, embed.
 
 **Sync group** — the set of browsers a browser publishes its canonical state to.
-Membership is a rule rather than a container: a browser joins when it has not
-opted out and its dataset is compatible with the other's — *compatible* meaning
-the two chromosome tables share enough named chromosomes, at agreeing sizes, to
-be the same assembly (`Dataset.compareChromosomes`), not that the tables are
-identical. A subset `.hic` therefore joins, and the per-state question is left to
-`canResolveSyncState`. Being a rule, it is derived afresh — `registry.sync()` —
-wherever the open maps change: a load, a failed load, a browser arriving or
-leaving, a restore. It is never accumulated (#635). What travels the group
-is canonical state and, by deliberate exception, view preferences — never dataset
-choices. See `docs/adr/0014`. Dataset choices reach several browsers by the other
-mechanism, the **target set** — `docs/adr/0015`.
+Membership is a rule rather than a container, and it is **static**: settled when
+panels pair and unchanged while anyone pans (`docs/adr/0016`). A browser joins
+when it has not opted out and its dataset `canSyncWith` the other's — the same
+assembly (`Dataset.isCompatible`) **and** two-way chromosome parity: each map can
+place every real chromosome the other carries, through the aliasing,
+case-insensitive `Genome.getChromosome` lookup, `All` excluded. Parity is not
+identical tables — `1`/`chr1`, `MT`/`chrM`, case and table order do not matter —
+but a subset `.hic` no longer joins a whole-genome group of the same assembly
+(#632 reverses #627 here). Two-way parity is an equivalence relation, so groups
+are **partitions**: every mapped, synchable panel is in exactly one. Being a
+rule, it is derived afresh — `registry.sync()` — wherever the open maps change:
+a load, a failed load, a browser arriving or leaving, a restore. It is never
+accumulated (#635). What travels the group is canonical state and, by deliberate
+exception, view preferences — never dataset choices. See `docs/adr/0014`.
+Dataset choices reach several browsers by the other mechanism, the **target
+set** — `docs/adr/0015`.
 _Avoid_: sync set, linked browsers.
 
 **Sync state** — canonical state as a *peer* reads it: chromosomes by name and a
 bin size rather than a zoom index, because the receiving browser may order its
 chromosomes differently and offer a different resolution array. A projection
 (`State.getSyncState(dataset)`), consumed by `State.sync` on the other side.
-Membership decides who is handed one; whether a particular one can be acted on
-is a separate question, because a receiver's genome need not know every name a
-peer can publish — `canResolveSyncState` in `js/syncGroup.js`, issue #605.
-Both refusals — no compatible peer, and a peer state naming a chromosome this
-map lacks — are reported to the host as **`onSyncRefused`** rather than dropped
-silently (#626). It is a notification, not a repair: both refusals are correct,
-and what was missing was any way to tell that one had happened.
+Membership decides who is handed one, and since #632 membership already
+guarantees the receiver can place it: per-state resolution is an **assert**, not
+a decision. `canResolveSyncState` in `js/syncGroup.js` (#605) stays as a guard
+that `console.error`s if the pairing rule ever admits a pair it should not have.
+The refusal a host can still see is the load-time one — a newly loaded panel
+with no peer it can sync with while other panels hold maps — reported as
+**`onSyncRefused`** (`'no-compatible-peer'`) rather than dropped silently (#626).
+`'unresolved-chromosome'` stays in that callback's `reason` union but is no
+longer emitted.
 _Avoid_: sync payload, target state.
 
 **Target set** — the browsers a *load* reaches: the ones the user has

--- a/docs/adr/0003-public-api-contract.md
+++ b/docs/adr/0003-public-api-contract.md
@@ -145,7 +145,10 @@ These are contract too, and are easy to miss because they are one dot further ou
   behaviour; `onControlMapLoaded`, `onLocusChange`, `onGenomeChange` and
   `onSyncRefused` are registerable and currently unused. `onSyncRefused` was
   added by #626 and is the one of the seven that reports a *non-event*: a panel
-  that did not follow its sibling, and which rule declined it.
+  that did not follow its sibling, and why. Since #632 only one of its two
+  `reason` values is emitted (`'no-compatible-peer'`, on load); the other,
+  `'unresolved-chromosome'`, stays in the payload contract so host code that
+  branches on it keeps working. ADR-0016.
 - `dataset.isLive`, `activeDataset.isLive` — Spacewalk
 
 **Event payloads are contract too.** juicebox-web's `TrackXYPairLoad` /

--- a/js/browserCoordinator.js
+++ b/js/browserCoordinator.js
@@ -394,6 +394,11 @@ class BrowserCoordinator {
      * a host watching two panels drift apart had no way to learn which of the
      * two rules had fired, or that a rule had fired at all.
      *
+     * Since #632 only the load-time refusal is emitted. Membership is settled
+     * when panels pair (ADR-0016), so a map missing a chromosome its peer
+     * carries never pairs in the first place, and the per-state refusal it used
+     * to produce is now a `console.error` assert in `HICBrowser.syncState`.
+     *
      * No widget surface, which is the difference from `onNormalizationSubstituted`
      * next door. ADR-0012 put a substitution on the normalization selector
      * because a selector is *already* displaying the value that got substituted;
@@ -403,7 +408,9 @@ class BrowserCoordinator {
      * facing half; either can grow a surface later without moving this call.
      *
      * @param {Object} detail
-     * @param {string} detail.reason - `'no-compatible-peer'` or `'unresolved-chromosome'`
+     * @param {string} detail.reason - `'no-compatible-peer'` or `'unresolved-chromosome'`.
+     *   `'unresolved-chromosome'` is no longer emitted since #632; it stays in the
+     *   union so host code that branches on it keeps compiling and running.
      * @param {string} detail.message - The same thing in a sentence
      */
     onSyncRefused(detail) {

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -210,11 +210,13 @@ class DataLoader {
 
             // Find a browser to sync with, if any. The opt-out is `syncState`'s
             // own guard, as it was before #562 -- this filter has never looked
-            // at `synchable`.
+            // at `synchable`. `canSyncWith`, the pairing predicate, not the
+            // control-map one below: a peer this panel could not pair with is
+            // not one whose view it should adopt. ADR-0016 decision 2.
             const peer = registry.browsers.find(
                 b => b !== this.browser &&
                      b.dataset &&
-                     b.dataset.isCompatible(this.browser.dataset)
+                     b.dataset.canSyncWith(this.browser.dataset)
             );
             if (peer) {
                 await this.browser.syncState(peer.getSyncState());

--- a/js/genome.js
+++ b/js/genome.js
@@ -72,7 +72,7 @@ class Genome {
                 const alias = name.startsWith("chr") ? name.substring(3) : "chr" + name;
                 chrAliasTable[alias] = name;
                 if (name === "chrM") chrAliasTable["MT"] = "chrM";
-                if (name === "MT") chrAliasTable["chrmM"] = "MT";
+                if (name === "MT") chrAliasTable["chrM"] = "MT";
             }
             this.chromosomeLookupTable[name.toLowerCase()] = chromosome;
         }

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -1279,28 +1279,24 @@ class HICBrowser {
      *
      * The second half of the gate is `canResolveSyncState`, also from
      * `syncGroup.js`: a state naming a chromosome this browser's genome cannot
-     * place is skipped silently rather than carried into `State.sync`, which
-     * would throw on it (#605). It sits beside the membership rule but outside
-     * it -- see the comment there.
+     * place is skipped rather than carried into `State.sync`, which would throw
+     * on it (#605). Since #632 it is an assert -- pairing already requires
+     * two-way chromosome parity, so it cannot fire unless that rule is wrong.
+     * See the comment there and ADR-0016 decision 5.
      */
     async syncState(targetState) {
         if (!targetState || !isSynchable(this) || !this.state) {
             return;
         }
 
-        // Reported rather than dropped since #626. The other three conditions
-        // above stay silent on purpose: two are "nothing to sync yet" and the
-        // third is the host's own `synchable: false`, which it does not need
-        // telling about. This one is the surprise -- the pair is legitimate, the
-        // panels are side by side, and only this particular state cannot cross.
+        // Unreachable by construction since #632: `pairSynchable` admits only
+        // pairs with two-way chromosome parity, so every state a partner
+        // publishes names chromosomes this genome can place. If it fires, the
+        // pairing rule is wrong -- a message for us, on `console.error`, and not
+        // for the host, which `onSyncRefused` carried here until #632 and which
+        // the user can no longer have caused. ADR-0016 decision 5.
         if (!canResolveSyncState(this.genome, targetState)) {
-            this.coordinator.onSyncRefused({
-                reason: 'unresolved-chromosome',
-                message: `this map has no ${[targetState.chr1Name, targetState.chr2Name].join(' / ')}`,
-                chr1Name: targetState.chr1Name,
-                chr2Name: targetState.chr2Name,
-                genomeId: this.dataset?.genomeId
-            });
+            console.error(`juicebox: the sync pairing rule admitted a pair it should not have -- this map has no ${[targetState.chr1Name, targetState.chr2Name].join(' / ')}`);
             return;
         }
 

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -1280,9 +1280,7 @@ class HICBrowser {
      * The second half of the gate is `canResolveSyncState`, also from
      * `syncGroup.js`: a state naming a chromosome this browser's genome cannot
      * place is skipped rather than carried into `State.sync`, which would throw
-     * on it (#605). Since #632 it is an assert -- pairing already requires
-     * two-way chromosome parity, so it cannot fire unless that rule is wrong.
-     * See the comment there and ADR-0016 decision 5.
+     * on it (#605). An assert since #632 -- see the comment there.
      */
     async syncState(targetState) {
         if (!targetState || !isSynchable(this) || !this.state) {

--- a/js/hicDataset.js
+++ b/js/hicDataset.js
@@ -30,6 +30,7 @@ import {isFile} from "./fileUtils.js"
 import {getUrlMapper} from "./urlMapper.js"
 import Straw from 'hic-straw'
 import {SENTINEL_ZOOM} from './sentinelZoom.js'
+import Genome from './genome.js'
 
 const knownGenomes = {
 
@@ -185,10 +186,17 @@ class Dataset {
      * skipped rather than counted against the pair.
      *
      * The threshold mirrors `matchGenome`'s own four-chromosome line, relaxed to
-     * the smaller table so that a subset map still pairs when every real
-     * chromosome it carries is accounted for. Pairing a subset is deliberate:
-     * `canResolveSyncState` (`syncGroup.js`) is what declines the individual
-     * states it cannot place, and it is a per-state question, not a per-pair one.
+     * the smaller table so that a subset map still counts as the same assembly
+     * when every real chromosome it carries is accounted for.
+     *
+     * That is the *assembly* answer, and it is right for the control-map load.
+     * It is no longer the sync answer. #627 argued here that pairing a subset
+     * was deliberate, leaving `canResolveSyncState` to decline states one at a
+     * time -- which made a subset panel follow its peer across chr1, stall at
+     * chr8 and resume on the way back. ADR-0016 reverses that: sync pairs on
+     * `canSyncWith`, which adds two-way chromosome parity, so a subset map does
+     * not pair with a whole-genome one. Do not loosen `canSyncWith` back to
+     * this rule; the ADR records why at length.
      *
      * `All` is excluded. It is a zoom rung, not a chromosome (ADR-0010), and its
      * size is in kb besides, so comparing it compares two different units.
@@ -307,6 +315,46 @@ class Dataset {
             ((id1 === "mm10" || id1 === "GRCm38") && (id2 === "mm10" || id2 === "GRCm38")) ||
             this.compareChromosomes(d2)
     }
+
+    /**
+     * Can a panel showing this map and a panel showing the other follow each
+     * other? The sync-pairing question, where `isCompatible` above is the
+     * control-map one. ADR-0016 decision 2.
+     *
+     * Same assembly -- exactly `isCompatible` -- **and** two-way chromosome
+     * parity: every real chromosome on each side is one the other side can
+     * place. `isCompatible` alone is not enough, because it short-circuits on
+     * hg38/hg19/mm10 without reading the tables, and that is the right answer
+     * for a control map and the wrong one for a sync partner.
+     *
+     * "Can place" is `Genome.getChromosome` over the other map's own table --
+     * the lookup `State.sync` dereferences, built from the table the way a load
+     * builds `browser.genome` (`dataLoader.js`). It aliases `1`/`chr1`,
+     * `MT`/`chrM` and the dMel `arm_` names, and matches case-insensitively.
+     * Never compare name sets instead: that is stricter than the lookup and
+     * refuses pairs that sync correctly. Decision 3.
+     *
+     * Checked in both directions, so the answer is symmetric and a subset map
+     * does not pair with a whole-genome one (decision 4). `All` is skipped on
+     * both sides (ADR-0010).
+     *
+     * @param {Dataset} other
+     * @returns {boolean}
+     */
+    canSyncWith(other) {
+        return this.isCompatible(other) && placesEveryChromosome(this, other) && placesEveryChromosome(other, this);
+    }
+}
+
+/**
+ * Can `receiver`'s genome lookup place every real chromosome `sender` carries?
+ * One direction of `Dataset.canSyncWith`'s parity.
+ */
+function placesEveryChromosome(receiver, sender) {
+    const genome = new Genome(receiver.genomeId, receiver.chromosomes || []);
+    return (sender.chromosomes || [])
+        .filter(c => 'all' !== c.name.toLowerCase())
+        .every(c => undefined !== genome.getChromosome(c.name));
 }
 
 /**

--- a/js/hicDataset.js
+++ b/js/hicDataset.js
@@ -206,10 +206,8 @@ class Dataset {
      */
     compareChromosomes(otherDataset) {
 
-        const real = chromosomes => (chromosomes || []).filter(c => 'all' !== c.name.toLowerCase());
-
-        const mine = real(this.chromosomes);
-        const theirs = real(otherDataset?.chromosomes);
+        const mine = realChromosomes(this.chromosomes);
+        const theirs = realChromosomes(otherDataset?.chromosomes);
         const theirSizeByName = new Map(theirs.map(c => [c.name.toLowerCase(), c.size]));
 
         let shared = 0;
@@ -329,8 +327,11 @@ class Dataset {
      *
      * "Can place" is `Genome.getChromosome` over the other map's own table --
      * the lookup `State.sync` dereferences, built from the table the way a load
-     * builds `browser.genome` (`dataLoader.js`). It aliases `1`/`chr1`,
-     * `MT`/`chrM` and the dMel `arm_` names, and matches case-insensitively.
+     * builds `browser.genome` (`dataLoader.js`). It aliases `1`/`chr1` and
+     * `MT`/`chrM`, and matches case-insensitively. Its dMel `arm_` aliasing runs
+     * one way only (`arm_2L` places `chr2L`, not the reverse), so an `arm_`
+     * table does not pair with a `chr` one -- nor did it before, since
+     * `isCompatible` refuses that pair for dm6 on its own.
      * Never compare name sets instead: that is stricter than the lookup and
      * refuses pairs that sync correctly. Decision 3.
      *
@@ -352,9 +353,12 @@ class Dataset {
  */
 function placesEveryChromosome(receiver, sender) {
     const genome = new Genome(receiver.genomeId, receiver.chromosomes || []);
-    return (sender.chromosomes || [])
-        .filter(c => 'all' !== c.name.toLowerCase())
-        .every(c => undefined !== genome.getChromosome(c.name));
+    return realChromosomes(sender.chromosomes).every(c => undefined !== genome.getChromosome(c.name));
+}
+
+/** A chromosome table without `All`, which is a zoom rung and not a chromosome (ADR-0010). */
+function realChromosomes(chromosomes) {
+    return (chromosomes || []).filter(c => 'all' !== c.name.toLowerCase());
 }
 
 /**

--- a/js/syncGroup.js
+++ b/js/syncGroup.js
@@ -23,9 +23,15 @@ function isSynchable(browser) {
  * later be one call over a concatenated array.
  *
  * A browser joins the group only if it has not opted out (`synchable === false`)
- * and has a dataset to sync. Each surviving combination is tested once rather
- * than in both orders, which `Dataset.isCompatible` permits: it compares genome
- * ids and chromosome sizes, so it is symmetric.
+ * and has a dataset to sync. Two such browsers pair when `Dataset.canSyncWith`
+ * says their maps can follow each other -- same assembly and two-way chromosome
+ * parity (ADR-0016 decisions 2-4). Not `isCompatible`: that is the control-map
+ * question, and it pairs a subset map with a whole-genome one.
+ *
+ * Each surviving combination is tested once rather than in both orders. That
+ * relies on `canSyncWith` being symmetric, which it is by construction: parity
+ * is checked in both directions. It is an equivalence relation besides, so the
+ * pairs this returns are the complete graphs of disjoint groups -- a partition.
  *
  * @param {Array} browsers
  * @returns {Array<Array>} each compatible pair once, as `[a, b]`
@@ -38,7 +44,7 @@ function pairSynchable(browsers) {
     for (let i = 0; i < synchableBrowsers.length; i++) {
         for (let j = i + 1; j < synchableBrowsers.length; j++) {
             const [a, b] = [synchableBrowsers[i], synchableBrowsers[j]]
-            if (a !== b && a.dataset.isCompatible(b.dataset)) {
+            if (a !== b && a.dataset.canSyncWith(b.dataset)) {
                 pairs.push([a, b])
             }
         }
@@ -50,11 +56,14 @@ function pairSynchable(browsers) {
 /**
  * Can this genome place both chromosomes a sync state names?
  *
- * Deliberately *not* part of `isSynchable`. Membership is a property of the two
- * browsers -- have they opted out, do they have maps -- and holds across every
- * state they exchange; this is a property of one particular state, and a pair
- * that legitimately syncs can still fail on a single publication. Folding it
- * into the membership rule would change who pairs, not just who syncs.
+ * A defensive assert since #632, not a decision. Pairing now requires two-way
+ * chromosome parity (`Dataset.canSyncWith`, ADR-0016), and every state a peer
+ * publishes names chromosomes from the peer's own table, so a paired browser can
+ * place it by construction. Unreachable, then -- and kept, for two reasons: it
+ * is the guard #605 added against a real TypeError, and an unreachable guard
+ * that fires is the cheapest detector of a bug in the pairing rule. That is why
+ * `HICBrowser.syncState` answers it with `console.error` rather than a message
+ * to the host: the user cannot cause it, so only we can.
  *
  * Asked of the **genome** because the genome is what `State.sync` consumes: it
  * dereferences `genome.getChromosome(name).index`, and a name it cannot resolve
@@ -64,12 +73,14 @@ function pairSynchable(browsers) {
  * guarding: the genome aliases `1` to `chr1` and `MT` to `chrM`, and matches
  * case-insensitively. Guarding with the stricter expression would refuse peer
  * states that sync correctly today, trading a rare throw for a routine false
- * negative. What this admits is exactly what `State.sync` can use.
+ * negative. What this admits is exactly what `State.sync` can use -- and it is
+ * the same lookup `canSyncWith` decides parity with, which is what makes this
+ * unreachable rather than merely unlikely.
  *
- * Reachable because `Dataset.isCompatible` short-circuits to `true` on a known
- * genome-id pair without comparing chromosomes at all, so a subset `.hic`
- * labelled `hg38` pairs with a whole-genome one and is then published names it
- * does not have.
+ * It was reachable until #632, because pairing asked `Dataset.isCompatible`,
+ * which short-circuits to `true` on a known genome-id pair without comparing
+ * chromosomes at all: a subset `.hic` labelled `hg38` paired with a whole-genome
+ * one and was then published names it did not have.
  *
  * @param {Object} genome - the receiving browser's genome
  * @param {Object} syncState - as `State.getSyncState` publishes it

--- a/test/testBrowserRegistry.js
+++ b/test/testBrowserRegistry.js
@@ -65,7 +65,8 @@ function fakeBrowser(name, {dataset, synchable} = {}) {
 function fakeDataset(genomeId) {
     return {
         genomeId,
-        isCompatible: other => other.genomeId === genomeId
+        isCompatible: other => other.genomeId === genomeId,
+        canSyncWith: other => other.genomeId === genomeId
     }
 }
 

--- a/test/testBrowserTargeting.js
+++ b/test/testBrowserTargeting.js
@@ -53,9 +53,9 @@ function fakeBrowser(name, {genomeId} = {}) {
         }
     }
     if (genomeId !== undefined) {
-        // `isCompatible` because the registry recomputes the sync group
-        // whenever a browser arrives or leaves -- #635.
-        browser.dataset = {genomeId, isCompatible: other => other.genomeId === genomeId}
+        // `canSyncWith` because the registry recomputes the sync group
+        // whenever a browser arrives or leaves -- #635, #636.
+        browser.dataset = {genomeId, canSyncWith: other => other.genomeId === genomeId}
         browser.genome = {id: genomeId}
     }
     return browser

--- a/test/testCanSyncWith.js
+++ b/test/testCanSyncWith.js
@@ -1,5 +1,6 @@
 import {describe, it, expect} from 'vitest'
 import Dataset from '../js/hicDataset.js'
+import {HG19, HG38, chromosomeTable, ensemblNames} from './utils/servedMaps.js'
 
 /**
  * The two predicates ADR-0016 decision 2 separates. `isCompatible` asks "same
@@ -13,18 +14,10 @@ import Dataset from '../js/hicDataset.js'
  */
 
 function dataset(genomeId, rows) {
-    const named = rows.map(([name, size], i) => ({index: i + 1, name, size}))
-    const all = {index: 0, name: 'All', size: named.reduce((sum, c) => sum + c.size, 0)}
-    return Object.assign(Object.create(Dataset.prototype), {genomeId, chromosomes: [all, ...named]})
+    return Object.assign(Object.create(Dataset.prototype), {genomeId, chromosomes: chromosomeTable(rows)})
 }
 
-const HG38 = [
-    ['chr1', 248956422], ['chr2', 242193529], ['chr3', 198295559], ['chr4', 190214555],
-    ['chr5', 181538259], ['chrX', 156040895], ['chrM', 16569],
-]
-
-/** hg38 as another pipeline names it: no `chr` prefix, `MT` for the mitochondrion. */
-const HG38_ENSEMBL = HG38.map(([name, size]) => ['chrM' === name ? 'MT' : name.substring(3), size])
+const HG38_ENSEMBL = ensemblNames(HG38)
 
 /** Both argument orders, so every row of the table also asserts symmetry. */
 function bothWays(a, b) {
@@ -83,11 +76,10 @@ describe('Dataset.canSyncWith', () => {
     })
 
     it('refuses a different assembly even when every name is shared', () => {
-        const HG19 = [
-            ['chr1', 249250621], ['chr2', 243199373], ['chr3', 198022430], ['chr4', 191154276],
-            ['chr5', 180915260], ['chrX', 155270560], ['chrM', 16571],
-        ]
-        expect(bothWays(dataset('hg38', HG38), dataset('hg19', HG19))).toBe(false)
+        // hg19 at hg19's sizes, over exactly hg38's names.
+        const hg19Sizes = new Map([...HG19, ['chrM', 16571]])
+        const sameNames = HG38.map(([name]) => [name, hg19Sizes.get(name)])
+        expect(bothWays(dataset('hg38', HG38), dataset('hg19', sameNames))).toBe(false)
     })
 
     it('is not satisfied by the hg38/GRCh38 genome-id short-circuit alone', () => {

--- a/test/testCanSyncWith.js
+++ b/test/testCanSyncWith.js
@@ -1,0 +1,132 @@
+import {describe, it, expect} from 'vitest'
+import Dataset from '../js/hicDataset.js'
+
+/**
+ * The two predicates ADR-0016 decision 2 separates. `isCompatible` asks "same
+ * assembly?" and is what the control-map load wants; `canSyncWith` asks "can
+ * these two panels follow each other?" and is what pairing wants: the same
+ * assembly **and** two-way chromosome parity.
+ *
+ * Real `Dataset` instances, on the real prototype, because the question is
+ * exactly which lookup parity uses: `Genome.getChromosome`'s aliasing,
+ * case-insensitive one (decision 3), not a comparison of name sets.
+ */
+
+function dataset(genomeId, rows) {
+    const named = rows.map(([name, size], i) => ({index: i + 1, name, size}))
+    const all = {index: 0, name: 'All', size: named.reduce((sum, c) => sum + c.size, 0)}
+    return Object.assign(Object.create(Dataset.prototype), {genomeId, chromosomes: [all, ...named]})
+}
+
+const HG38 = [
+    ['chr1', 248956422], ['chr2', 242193529], ['chr3', 198295559], ['chr4', 190214555],
+    ['chr5', 181538259], ['chrX', 156040895], ['chrM', 16569],
+]
+
+/** hg38 as another pipeline names it: no `chr` prefix, `MT` for the mitochondrion. */
+const HG38_ENSEMBL = HG38.map(([name, size]) => ['chrM' === name ? 'MT' : name.substring(3), size])
+
+/** Both argument orders, so every row of the table also asserts symmetry. */
+function bothWays(a, b) {
+    const answers = [a.canSyncWith(b), b.canSyncWith(a)]
+    expect(answers[0]).toBe(answers[1])
+    return answers[0]
+}
+
+describe('Dataset.canSyncWith', () => {
+
+    it('pairs two identical maps', () => {
+        expect(bothWays(dataset('hg38', HG38), dataset('hg38', HG38))).toBe(true)
+    })
+
+    it('pairs names that differ only by the chr prefix, and MT with chrM', () => {
+        // Both directions of `MT`/`chrM` have to resolve. The `MT` side's
+        // alias for `chrM` was misspelled `chrmM` in `genome.js` until parity
+        // needed it.
+        expect(bothWays(dataset('hg38', HG38), dataset('hg38', HG38_ENSEMBL))).toBe(true)
+    })
+
+    it('pairs names that differ only in case', () => {
+        const shouting = HG38.map(([name, size]) => [name.toUpperCase(), size])
+        expect(bothWays(dataset('hg38', HG38), dataset('hg38', shouting))).toBe(true)
+    })
+
+    it('ignores All on both sides', () => {
+        // ADR-0010: a zoom rung, not a chromosome. One map calling it `ALL`
+        // and the other lacking it would otherwise be a coverage mismatch.
+        const a = dataset('hg38', HG38)
+        const b = dataset('hg38', HG38)
+        b.chromosomes = b.chromosomes.slice(1)
+        a.chromosomes[0] = {...a.chromosomes[0], name: 'ALL'}
+        expect(bothWays(a, b)).toBe(true)
+    })
+
+    it('pairs the same chromosomes listed in another order', () => {
+        expect(bothWays(dataset('hg38', HG38), dataset('hg38', [...HG38].reverse()))).toBe(true)
+    })
+
+    it('pairs two maps that carry the same extra scaffold, listed in different places', () => {
+        const scaffold = ['chrUn_KI270302v1', 2274]
+        expect(bothWays(dataset('hg38', [...HG38, scaffold]), dataset('hg38', [scaffold, ...HG38]))).toBe(true)
+    })
+
+    it('refuses a map carrying one extra scaffold the other cannot place', () => {
+        // The other panel's lookup has nowhere to put it, so a state naming it
+        // could not cross -- and parity is two-way, so neither order pairs.
+        // Pairing it would bring back the half-sync ADR-0016 retires.
+        const scaffolded = [...HG38, ['chrUn_KI270302v1', 2274]]
+        expect(bothWays(dataset('hg38', HG38), dataset('hg38', scaffolded))).toBe(false)
+    })
+
+    it('refuses a chr1-only subset against a whole-genome map, in either order', () => {
+        expect(bothWays(dataset('hg38', HG38), dataset('hg38', HG38.slice(0, 1)))).toBe(false)
+    })
+
+    it('refuses a different assembly even when every name is shared', () => {
+        const HG19 = [
+            ['chr1', 249250621], ['chr2', 243199373], ['chr3', 198022430], ['chr4', 191154276],
+            ['chr5', 180915260], ['chrX', 155270560], ['chrM', 16571],
+        ]
+        expect(bothWays(dataset('hg38', HG38), dataset('hg19', HG19))).toBe(false)
+    })
+
+    it('is not satisfied by the hg38/GRCh38 genome-id short-circuit alone', () => {
+        // `isCompatible` answers yes on the ids and never looks at the tables.
+        // That is right for a control map and not enough for a sync partner.
+        const whole = dataset('hg38', HG38)
+        const subset = dataset('GRCh38', HG38.slice(0, 1))
+        expect(whole.isCompatible(subset)).toBe(true)
+        expect(bothWays(whole, subset)).toBe(false)
+    })
+
+    it('pairs hg38 with GRCh38 when the tables match', () => {
+        expect(bothWays(dataset('hg38', HG38), dataset('GRCh38', HG38_ENSEMBL))).toBe(true)
+    })
+})
+
+describe('Dataset.isCompatible keeps its answers', () => {
+
+    it('admits a chr1-only control map against a whole-genome map', () => {
+        // The control-map load's question is "same assembly?", and a subset of
+        // the same assembly answers yes. ADR-0016 decision 2.
+        const whole = dataset('hg38', HG38)
+        const subset = dataset('hg38', HG38.slice(0, 1))
+        expect(whole.isCompatible(subset)).toBe(true)
+        expect(subset.isCompatible(whole)).toBe(true)
+    })
+
+    it('short-circuits on the known genome-id pairs', () => {
+        expect(dataset('hg19', HG38).isCompatible(dataset('GRCh37', HG38.slice(0, 1)))).toBe(true)
+        expect(dataset('mm10', HG38).isCompatible(dataset('GRCm38', []))).toBe(true)
+    })
+
+    it('admits an unlisted assembly by the chromosomes the tables share', () => {
+        const scaffolded = [...HG38, ['chrUn_KI270302v1', 2274]]
+        expect(dataset('custom', HG38).isCompatible(dataset('custom', scaffolded))).toBe(true)
+    })
+
+    it('refuses a shared name with a different size', () => {
+        const resized = HG38.map(([name, size]) => [name, size + 1])
+        expect(dataset('custom', HG38).isCompatible(dataset('custom', resized))).toBe(false)
+    })
+})

--- a/test/testDefaultViewOrigin.js
+++ b/test/testDefaultViewOrigin.js
@@ -30,7 +30,8 @@ function stubDataset() {
             { name: 'chr1', size: 1000, index: 1 }
         ],
         datasetType: 'hic',
-        isCompatible: () => false
+        isCompatible: () => false,
+        canSyncWith: () => false
     }
 }
 

--- a/test/testSyncChromosomeGuard.js
+++ b/test/testSyncChromosomeGuard.js
@@ -1,4 +1,4 @@
-import {describe, it, expect, vi} from 'vitest'
+import {describe, it, expect, beforeEach, vi} from 'vitest'
 import {registryForContainer} from '../js/browserRegistry.js'
 import {withContainers} from './utils/browserFixture.js'
 import {withStubbedLoads} from './utils/stubbedLoads.js'
@@ -6,13 +6,23 @@ import Genome from '../js/genome.js'
 import State from '../js/hicState.js'
 
 /**
- * A sync state naming a chromosome the receiver cannot resolve is skipped.
+ * A sync state naming a chromosome the receiver cannot resolve is refused, and
+ * the refusal is an **assert**, not a decision. #632, ADR-0016 decision 5.
  *
- * `Dataset.isCompatible` short-circuits to `true` on a known genome-id pair
- * without comparing chromosomes at all, so a whole-genome hg19 map and a subset
- * hg19 map pair happily. The peer then publishes `chr17` to a browser whose map
- * stops at `chr1`, and `State.sync` dereferences `genome.getChromosome(...)`
- * for its `.index` -- a TypeError on an async path, unhandled. #605.
+ * Until #632 this was reachable by an ordinary user action: pairing asked
+ * `Dataset.isCompatible`, which short-circuits to `true` on a known genome-id
+ * pair, so a whole-genome hg19 map and a subset hg19 map paired, and the peer
+ * went on to publish `chr17` to a browser whose map stops at `chr1`. That
+ * scenario no longer pairs -- `canSyncWith` demands two-way chromosome parity
+ * -- and is pinned as "does not pair" in `testSyncParity.js`. What is left here
+ * is the guard itself, reached the only way it still can be: by handing
+ * `syncState` a state directly.
+ *
+ * The guard stays because `State.sync` dereferences `genome.getChromosome(...)`
+ * for its `.index`, and an unplaceable name there is a TypeError on an async
+ * path (#605). If it ever fires in the wild, the pairing rule admitted a pair it
+ * should not have: so it says so on `console.error`, for us, and tells the host
+ * nothing, since the user cannot have caused it.
  *
  * The guard is asked of the **genome**, not of the dataset. `canBeSynched` --
  * deleted at #566 with the unreachable `config.synchState` rung it guarded --
@@ -23,9 +33,7 @@ import State from '../js/hicState.js'
  * which is what the aliasing case below pins.
  *
  * The rule itself is `canResolveSyncState` in `syncGroup.js`, unit-tested in
- * `testSyncGroup.js`. What is here is the behaviour through two real browsers:
- * that the gate is actually on the path a peer reaches, and that a refusal is a
- * silent no-op rather than a throw.
+ * `testSyncGroup.js`.
  */
 
 const session = (...urls) => ({browsers: urls.map(url => ({url}))})
@@ -52,10 +60,10 @@ async function twoBrowsers(container) {
 }
 
 /**
- * Cut a browser's map down to `All` plus `chr1`, the subset `.hic` labelled with
- * the whole genome's id -- an ordinary artifact, and the reachable case. The
- * genome is rebuilt from the same shortened list, which is how a real load
- * builds it (`dataLoader.js`).
+ * Cut a browser's map down to `All` plus `chr1` behind the registry's back --
+ * no load, so no recompute of membership -- leaving it holding a state it can
+ * no longer be sent by a legitimate peer. The genome is rebuilt from the same
+ * shortened list, which is how a real load builds it (`dataLoader.js`).
  */
 function shrinkToChr1(browser) {
     const subset = {...browser.dataset, chromosomes: browser.dataset.chromosomes.slice(0, 2)}
@@ -68,7 +76,11 @@ describe('syncing a state naming a chromosome the receiver does not have', () =>
     const dom = withContainers()
     withStubbedLoads()
 
-    it('skips the sync rather than throwing', async () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    })
+
+    it('skips the sync rather than throwing, and leaves the state alone', async () => {
         const [a, b] = await twoBrowsers(dom.container)
         shrinkToChr1(b)
         const before = b.state.clone()
@@ -79,15 +91,28 @@ describe('syncing a state naming a chromosome the receiver does not have', () =>
         expect(a.state.chr1).toBe(1)
     })
 
-    it('leaves the coordinator unnotified, as the other guard failures do', async () => {
-        // The skip is silent by decision: it matches `syncState`'s existing
-        // early returns and introduces no new vocabulary for the host.
+    it('reports the broken pairing rule on console.error', async () => {
         const [, b] = await twoBrowsers(dom.container)
         shrinkToChr1(b)
+
+        await b.syncState(published('chr17', 'chr17'))
+
+        expect(console.error).toHaveBeenCalledTimes(1)
+        expect(console.error).toHaveBeenCalledWith(expect.stringContaining('pairing rule'))
+        expect(console.error).toHaveBeenCalledWith(expect.stringContaining('chr17'))
+    })
+
+    it('tells the host nothing: no onSyncRefused, no onLocusChange', async () => {
+        // The user cannot cause this, so it is not addressed to the host. It
+        // used to be `onSyncRefused({reason: 'unresolved-chromosome'})`.
+        const [, b] = await twoBrowsers(dom.container)
+        shrinkToChr1(b)
+        const onSyncRefused = vi.spyOn(b.coordinator, 'onSyncRefused')
         const onLocusChange = vi.spyOn(b.coordinator, 'onLocusChange')
 
         await b.syncState(published('chr17', 'chr17'))
 
+        expect(onSyncRefused).not.toHaveBeenCalled()
         expect(onLocusChange).not.toHaveBeenCalled()
     })
 
@@ -122,6 +147,7 @@ describe('syncing a state naming a chromosome the receiver does not have', () =>
 
     it('leaves an ordinary sync between two full maps alone', async () => {
         const [a, b] = await twoBrowsers(dom.container)
+        expect(console.error).not.toHaveBeenCalled()
 
         await a.setState(new State(2, 2, 5, 7, 9, 1, 'NONE'))
         await b.syncState(a.getSyncState())

--- a/test/testSyncGroup.js
+++ b/test/testSyncGroup.js
@@ -8,14 +8,20 @@ import Genome from '../js/genome.js'
  * `pairSynchable` is the rule alone: given browsers, which of them should sync
  * with which. It reads no module state and touches no DOM, so the browsers here
  * are fabricated objects carrying only what the rule reads -- a `synchable`
- * flag and a `dataset` that can answer `isCompatible`.
+ * flag and a `dataset` that can answer `canSyncWith`, the sync predicate
+ * (ADR-0016 decision 2). `isCompatible` is the control-map predicate and the
+ * rule must not read it: the fake answers it with the opposite of `canSyncWith`
+ * so that a rule reading the wrong one fails here.
  */
 
 function fakeDataset(genomeId) {
     return {
         genomeId,
-        isCompatible(other) {
+        canSyncWith(other) {
             return other.genomeId === genomeId
+        },
+        isCompatible(other) {
+            return other.genomeId !== genomeId
         }
     }
 }
@@ -85,6 +91,28 @@ describe('pairSynchable', () => {
         const empty = fakeBrowser('empty')
 
         expect(pairSynchable([a, other, b, optedOut, empty, c])).toEqual([[a, b], [a, c], [b, c]])
+    })
+
+    it('yields a partition: every browser in exactly one group, each group fully paired', () => {
+        // `canSyncWith` is an equivalence relation, so the pairs are the
+        // complete graphs of disjoint groups -- "which group is this panel in"
+        // has one answer. ADR-0016 decision 4.
+        const browsers = ['hg38', 'dm6', 'hg38', 'mm10', 'dm6', 'hg38']
+            .map((genomeId, i) => fakeBrowser(`${genomeId}-${i}`, {dataset: fakeDataset(genomeId)}))
+
+        const partners = new Map(browsers.map(b => [b, new Set([b])]))
+        for (const [a, b] of pairSynchable(browsers)) {
+            partners.get(a).add(b)
+            partners.get(b).add(a)
+        }
+
+        const groups = new Set([...partners.values()].map(group => [...group].map(b => b.name).sort().join(' ')))
+        expect([...groups].sort()).toEqual(['dm6-1 dm6-4', 'hg38-0 hg38-2 hg38-5', 'mm10-3'])
+        for (const browser of browsers) {
+            for (const peer of partners.get(browser)) {
+                expect(partners.get(peer)).toEqual(partners.get(browser))
+            }
+        }
     })
 })
 

--- a/test/testSyncOnLoad.js
+++ b/test/testSyncOnLoad.js
@@ -18,8 +18,9 @@ import {HG19, WHOLE_HG19, WHOLE_MM10, serveMaps} from './utils/servedMaps.js'
  */
 
 const SUBSET_HG19 = {genomeId: 'hg19', rows: HG19.slice(0, 1)}          // All + chr1 only
-const EXTRA_SCAFFOLD = {genomeId: 'hg19_scaffolds', rows: [...HG19, ['scaffold_7', 12345]]}
-const PLAIN_HG19 = {genomeId: 'hg19_no_alt', rows: HG19}
+const SCAFFOLD = ['scaffold_7', 12345]
+const EXTRA_SCAFFOLD = {genomeId: 'hg19_scaffolds', rows: [...HG19, SCAFFOLD]}
+const PLAIN_HG19 = {genomeId: 'hg19_no_alt', rows: [SCAFFOLD, ...HG19]}   // scaffold first
 /** A map binned no finer than 100kb -- a low-coverage or coarse .hic. */
 const COARSE_HG19 = {genomeId: 'hg19', rows: HG19, resolutions: [2500000, 1000000, 500000, 250000, 100000]}
 
@@ -58,19 +59,19 @@ describe('a second panel loading a map syncs to the first panel', () => {
         expect(b.state.zoom).toBe(5)
     })
 
-    it('syncs when the second map is a chr1-only subset and panel 1 sits on chr1', async () => {
-        const [, b] = await twoPanels(dom.container, WHOLE_HG19, SUBSET_HG19, new State(1, 1, 5, 7, 9, 1, 'NONE'))
-        expect(b.state.chr1).toBe(1)
-        expect(b.state.chr2).toBe(1)
-    })
-
     it('syncs two maps of one assembly whose chromosome tables differ', async () => {
         // #626. Both are hg19, but neither id is one `isCompatible`
-        // short-circuits on and one carries an extra scaffold, so the pair used
-        // to fall to `compareChromosomes`' byte-identical rule and be refused.
+        // short-circuits on and the two list their chromosomes in different
+        // orders, so the pair used to fall to `compareChromosomes`'
+        // byte-identical rule and be refused. Both carry the scaffold: one
+        // carried by only one side is a coverage mismatch, and since #632 that
+        // does not pair (ADR-0016).
         const [a, b] = await twoPanels(dom.container, PLAIN_HG19, EXTRA_SCAFFOLD, MOVED())
-        expect(a.state.chr1).toBe(2)
-        expect(b.state.chr1).toBe(2)
+        // By name: the scaffold leads one table, so the indices differ.
+        const nameAt = (browser, index) => browser.dataset.chromosomes[index].name
+        expect(nameAt(a, a.state.chr1)).toBe('chr1')
+        expect(nameAt(b, b.state.chr1)).toBe('chr1')
+        expect(nameAt(b, b.state.chr2)).toBe('chr1')
         expect(b.state.x).toBe(7)
         expect(b.state.y).toBe(9)
     })
@@ -118,17 +119,18 @@ describe('a panel that cannot follow its sibling says so', () => {
         return [a, b, refusals]
     }
 
-    it('reports the chromosome the second map does not have', async () => {
-        // The guard itself is correct and stays: chr2 cannot be shown on a map
-        // that stops at chr1. What #626 adds is that the host is told.
+    it('reports a subset map beside a whole-genome one as having no peer, once, on load', async () => {
+        // Until #632 these paired, and every state naming a chromosome the
+        // subset lacks was refused one at a time as `'unresolved-chromosome'`.
+        // Now the pair never forms, so the refusal is the load-time one, and
+        // `'unresolved-chromosome'` is not emitted at all.
         const [, b, refusals] = await loadAndWatch(
             dom.container, WHOLE_HG19, SUBSET_HG19, new State(2, 2, 5, 7, 9, 1, 'NONE'))
 
         expect(b.state.chr1).not.toBe(2)
         expect(refusals).toHaveLength(1)
-        expect(refusals[0].reason).toBe('unresolved-chromosome')
-        expect(refusals[0].chr1Name).toBe('chr2')
-        expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('chr2'))
+        expect(refusals[0].reason).toBe('no-compatible-peer')
+        expect(refusals.some(detail => detail.reason === 'unresolved-chromosome')).toBe(false)
     })
 
     it('reports a peer whose map is a different assembly', async () => {
@@ -161,12 +163,12 @@ describe('a panel that cannot follow its sibling says so', () => {
 
         const received = []
         const unsubscribe = browser.coordinator.addCallback('onSyncRefused', detail => received.push(detail))
-        browser.coordinator.onSyncRefused({reason: 'unresolved-chromosome', message: 'no chrZ'})
+        browser.coordinator.onSyncRefused({reason: 'no-compatible-peer', message: 'no peer'})
         unsubscribe()
-        browser.coordinator.onSyncRefused({reason: 'unresolved-chromosome', message: 'ignored'})
+        browser.coordinator.onSyncRefused({reason: 'no-compatible-peer', message: 'ignored'})
 
         expect(received).toHaveLength(1)
-        expect(received[0].reason).toBe('unresolved-chromosome')
+        expect(received[0].reason).toBe('no-compatible-peer')
         expect(received[0].browser).toBe(browser)
     })
 

--- a/test/testSyncOptOut.js
+++ b/test/testSyncOptOut.js
@@ -38,6 +38,7 @@ function stubDataset() {
         bpResolutions: [1000, 100],
         datasetType: 'hic',
         isCompatible: () => true,
+        canSyncWith: () => true,
         getChrIndexFromName: name => CHROMOSOMES.find(c => c.name === name)?.index
     }
 }

--- a/test/testSyncParity.js
+++ b/test/testSyncParity.js
@@ -6,7 +6,7 @@ import {createBrowser} from '../js/createBrowser.js'
 import {withContainers} from './utils/browserFixture.js'
 import State from '../js/hicState.js'
 import BrowserCoordinator from '../js/browserCoordinator.js'
-import {HG19, WHOLE_HG19, serveMaps} from './utils/servedMaps.js'
+import {HG19, HG38 as HG38_ROWS, DM6 as DM6_ROWS, WHOLE_HG19, ensemblNames, serveMaps} from './utils/servedMaps.js'
 
 /**
  * Two panels pair only if they can follow each other everywhere: same assembly
@@ -22,18 +22,13 @@ import {HG19, WHOLE_HG19, serveMaps} from './utils/servedMaps.js'
 const url = name => `https://example.com/${name}.hic`
 
 const SUBSET_HG19 = {genomeId: 'hg19', rows: HG19.slice(0, 1)}          // All + chr1 only
-const HG38 = {genomeId: 'hg38', rows: [
-    ['chr1', 248956422], ['chr2', 242193529], ['chr3', 198295559], ['chr4', 190214555],
-]}
-const DM6 = {genomeId: 'dm6', rows: [
-    ['chr2L', 23513712], ['chr2R', 25286936], ['chr3L', 28110227], ['chr3R', 32079331], ['chrX', 23542271],
-]}
+const HG38 = {genomeId: 'hg38', rows: HG38_ROWS}
+const DM6 = {genomeId: 'dm6', rows: DM6_ROWS}
 
-/** hg19 as another pipeline writes it: no `chr` prefix, and `MT` for the mitochondrion. */
+/** hg19 with a mitochondrion, as UCSC and as Ensembl name it. */
 const HG19_M = [...HG19, ['chrM', 16571]]
 const HG19_UCSC = {genomeId: 'hg19', rows: HG19_M}
-const HG19_ENSEMBL = {genomeId: 'GRCh37', rows: HG19_M.map(([name, size]) =>
-    ['chrM' === name ? 'MT' : name.substring(3), size])}
+const HG19_ENSEMBL = {genomeId: 'GRCh37', rows: ensemblNames(HG19_M)}
 /** hg19 with its names capitalized: `Chr1`, `ChrX`, `ChrM`. */
 const HG19_CAPITALIZED = {genomeId: 'hg19', rows: HG19_M.map(([name, size]) => ['C' + name.substring(1), size])}
 

--- a/test/testSyncParity.js
+++ b/test/testSyncParity.js
@@ -29,11 +29,13 @@ const DM6 = {genomeId: 'dm6', rows: [
     ['chr2L', 23513712], ['chr2R', 25286936], ['chr3L', 28110227], ['chr3R', 32079331], ['chrX', 23542271],
 ]}
 
-/** hg19 as another pipeline writes it: no `chr` prefix, `MT` for the mitochondrion, upper case. */
+/** hg19 as another pipeline writes it: no `chr` prefix, and `MT` for the mitochondrion. */
 const HG19_M = [...HG19, ['chrM', 16571]]
 const HG19_UCSC = {genomeId: 'hg19', rows: HG19_M}
 const HG19_ENSEMBL = {genomeId: 'GRCh37', rows: HG19_M.map(([name, size]) =>
-    ['chrM' === name ? 'MT' : name.substring(3).toUpperCase(), size])}
+    ['chrM' === name ? 'MT' : name.substring(3), size])}
+/** hg19 with its names capitalized: `Chr1`, `ChrX`, `ChrM`. */
+const HG19_CAPITALIZED = {genomeId: 'hg19', rows: HG19_M.map(([name, size]) => ['C' + name.substring(1), size])}
 
 /** Each browser's partners, by panel order, so a failure names who holds whom. */
 function membership(browsers) {
@@ -99,16 +101,18 @@ describe('panels pair only on two-way chromosome parity', () => {
         expect(membership(browsers)).toEqual([[2], [3], [0], [1]])
     })
 
-    it('pairs maps whose names differ by chr prefix, MT/chrM and case, and syncs on load', async () => {
-        serveMaps([HG19_UCSC, HG19_ENSEMBL])
-        const a = await createBrowser(dom.container, {url: url('ucsc')})
-        await a.setState(new State(2, 2, 5, 7, 9, 1, 'NONE'))
-        const b = await createBrowser(dom.container, {url: url('ensembl')})
+    for (const [label, other] of [['chr prefix and MT/chrM', HG19_ENSEMBL], ['case', HG19_CAPITALIZED]]) {
+        it(`pairs maps whose names differ by ${label}, and syncs on load`, async () => {
+            serveMaps([HG19_UCSC, other])
+            const a = await createBrowser(dom.container, {url: url('ucsc')})
+            await a.setState(new State(2, 2, 5, 7, 9, 1, 'NONE'))
+            const b = await createBrowser(dom.container, {url: url('other')})
 
-        expect(membership([a, b])).toEqual([[1], [0]])
-        expect(b.state.chr1).toBe(2)
-        expect(b.state.zoom).toBe(5)
-    })
+            expect(membership([a, b])).toEqual([[1], [0]])
+            expect(b.state.chr1).toBe(2)
+            expect(b.state.zoom).toBe(5)
+        })
+    }
 
     it('brings a panel joining a group on load to its peer\'s current view', async () => {
         serveMaps([WHOLE_HG19, WHOLE_HG19])

--- a/test/testSyncParity.js
+++ b/test/testSyncParity.js
@@ -1,0 +1,135 @@
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest'
+import ContactMatrixView from '../js/contactMatrixView.js'
+import HICBrowser from '../js/hicBrowser.js'
+import DataLoader from '../js/dataLoader.js'
+import {createBrowser} from '../js/createBrowser.js'
+import {withContainers} from './utils/browserFixture.js'
+import State from '../js/hicState.js'
+import BrowserCoordinator from '../js/browserCoordinator.js'
+import {HG19, WHOLE_HG19, serveMaps} from './utils/servedMaps.js'
+
+/**
+ * Two panels pair only if they can follow each other everywhere: same assembly
+ * **and** each can place every chromosome the other carries. #636, ADR-0016
+ * decisions 2-4.
+ *
+ * The real load path, stubbed only at `Dataset.loadDataset`, with datasets on
+ * the real `Dataset.prototype` -- so `isCompatible`, `canSyncWith` and
+ * `compareChromosomes` are the shipping code. Assertions are on who holds whom
+ * in `synchedBrowsers` and on what a host is told, not on how either is stored.
+ */
+
+const url = name => `https://example.com/${name}.hic`
+
+const SUBSET_HG19 = {genomeId: 'hg19', rows: HG19.slice(0, 1)}          // All + chr1 only
+const HG38 = {genomeId: 'hg38', rows: [
+    ['chr1', 248956422], ['chr2', 242193529], ['chr3', 198295559], ['chr4', 190214555],
+]}
+const DM6 = {genomeId: 'dm6', rows: [
+    ['chr2L', 23513712], ['chr2R', 25286936], ['chr3L', 28110227], ['chr3R', 32079331], ['chrX', 23542271],
+]}
+
+/** hg19 as another pipeline writes it: no `chr` prefix, `MT` for the mitochondrion, upper case. */
+const HG19_M = [...HG19, ['chrM', 16571]]
+const HG19_UCSC = {genomeId: 'hg19', rows: HG19_M}
+const HG19_ENSEMBL = {genomeId: 'GRCh37', rows: HG19_M.map(([name, size]) =>
+    ['chrM' === name ? 'MT' : name.substring(3).toUpperCase(), size])}
+
+/** Each browser's partners, by panel order, so a failure names who holds whom. */
+function membership(browsers) {
+    return browsers.map(browser => [...browser.synchedBrowsers].map(peer => browsers.indexOf(peer)).sort())
+}
+
+async function panels(container, maps) {
+    serveMaps(maps)
+    const browsers = []
+    for (const [i] of maps.entries()) {
+        browsers.push(await createBrowser(container, {url: url(`map-${i}`)}))
+    }
+    return browsers
+}
+
+describe('panels pair only on two-way chromosome parity', () => {
+
+    const dom = withContainers()
+
+    beforeEach(() => {
+        vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(DataLoader.prototype, 'loadTracks').mockImplementation(async () => undefined)
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+        vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    })
+
+    afterEach(() => vi.restoreAllMocks())
+
+    it('pairs two identical hg19 maps', async () => {
+        const browsers = await panels(dom.container, [WHOLE_HG19, WHOLE_HG19])
+        expect(membership(browsers)).toEqual([[1], [0]])
+    })
+
+    it('does not pair a whole-genome hg19 map with a chr1-only hg19 map', async () => {
+        // The reversal ADR-0016 records. #627 paired these, and the subset
+        // panel followed across chr1 and stalled beyond it.
+        const browsers = await panels(dom.container, [WHOLE_HG19, SUBSET_HG19])
+        expect(membership(browsers)).toEqual([[], []])
+    })
+
+    it('does not pair them in the other load order either', async () => {
+        const browsers = await panels(dom.container, [SUBSET_HG19, WHOLE_HG19])
+        expect(membership(browsers)).toEqual([[], []])
+    })
+
+    it('leaves a subset panel where it is rather than syncing it on load', async () => {
+        serveMaps([WHOLE_HG19, SUBSET_HG19])
+        const a = await createBrowser(dom.container, {url: url('whole')})
+        await a.setState(new State(1, 1, 5, 7, 9, 1, 'NONE'))
+        const b = await createBrowser(dom.container, {url: url('subset')})
+
+        expect(b.state.zoom).not.toBe(5)
+    })
+
+    it('does not pair hg38 with dm6', async () => {
+        const browsers = await panels(dom.container, [HG38, DM6])
+        expect(membership(browsers)).toEqual([[], []])
+    })
+
+    it('forms two groups from two hg38 and two dm6 maps, with no edge between them', async () => {
+        const browsers = await panels(dom.container, [HG38, DM6, HG38, DM6])
+        expect(membership(browsers)).toEqual([[2], [3], [0], [1]])
+    })
+
+    it('pairs maps whose names differ by chr prefix, MT/chrM and case, and syncs on load', async () => {
+        serveMaps([HG19_UCSC, HG19_ENSEMBL])
+        const a = await createBrowser(dom.container, {url: url('ucsc')})
+        await a.setState(new State(2, 2, 5, 7, 9, 1, 'NONE'))
+        const b = await createBrowser(dom.container, {url: url('ensembl')})
+
+        expect(membership([a, b])).toEqual([[1], [0]])
+        expect(b.state.chr1).toBe(2)
+        expect(b.state.zoom).toBe(5)
+    })
+
+    it('brings a panel joining a group on load to its peer\'s current view', async () => {
+        serveMaps([WHOLE_HG19, WHOLE_HG19])
+        const a = await createBrowser(dom.container, {url: url('a')})
+        await a.setState(new State(3, 4, 6, 11, 13, 1, 'NONE'))
+        const b = await createBrowser(dom.container, {url: url('b')})
+
+        expect([b.state.chr1, b.state.chr2, b.state.zoom, b.state.x, b.state.y]).toEqual([3, 4, 6, 11, 13])
+    })
+
+    it('never refuses a sync while a paired panel pans across every chromosome', async () => {
+        const [a, b] = await panels(dom.container, [HG19_UCSC, HG19_ENSEMBL])
+        const refused = vi.spyOn(BrowserCoordinator.prototype, 'onSyncRefused')
+
+        for (let chr = 0; chr < a.dataset.chromosomes.length; chr++) {
+            await a.setState(new State(chr, chr, 0, 0, 0, 1, 'NONE'))
+            a.syncToOtherBrowsers()
+            await vi.waitFor(() => expect(b.state.chr1).toBe(chr))
+        }
+
+        expect(refused).not.toHaveBeenCalled()
+        expect(console.error).not.toHaveBeenCalled()
+    })
+})

--- a/test/utils/restoreDataset.js
+++ b/test/utils/restoreDataset.js
@@ -166,6 +166,17 @@ function buildDataset(chrs, config) {
         isCompatible(other) {
             return other?.genomeId === this.genomeId
         },
+        // Stands in for `Dataset.canSyncWith`, the sync-pairing predicate
+        // (ADR-0016), and carries the caveat above twice over. The shipping
+        // method is `isCompatible` **and** two-way chromosome parity through
+        // `Genome.getChromosome`; this is the same bare id comparison, and
+        // never reads a chromosome table. So a fixture cut down to `All` +
+        // `chr1` still pairs here with a whole-genome one -- exactly the pair
+        // the shipping rule refuses since #632. A test whose subject is who
+        // pairs with whom builds on the real prototype: `testSyncParity.js`.
+        canSyncWith(other) {
+            return other?.genomeId === this.genomeId
+        },
         wholeGenomeChromosome: chrs[0],
         isWholeGenome(chrIndex) {
             return chrIndex === 0

--- a/test/utils/servedMaps.js
+++ b/test/utils/servedMaps.js
@@ -28,13 +28,33 @@ export const MM10 = [
     ['chr5', 151834684], ['chr6', 149736546], ['chr7', 145441459], ['chr8', 129401213],
 ]
 
+/** hg38, cut to a few autosomes plus `chrX` and `chrM` -- enough to alias. */
+export const HG38 = [
+    ['chr1', 248956422], ['chr2', 242193529], ['chr3', 198295559], ['chr4', 190214555],
+    ['chr5', 181538259], ['chrX', 156040895], ['chrM', 16569],
+]
+
+export const DM6 = [
+    ['chr2L', 23513712], ['chr2R', 25286936], ['chr3L', 28110227], ['chr3R', 32079331], ['chrX', 23542271],
+]
+
 /** A whole-genome map of each assembly -- the ordinary case. */
 export const WHOLE_HG19 = {genomeId: 'hg19', rows: HG19}
 export const WHOLE_MM10 = {genomeId: 'mm10', rows: MM10}
 
+/**
+ * A table as another pipeline names it: no `chr` prefix, and `MT` for the
+ * mitochondrion. Same assembly, different spelling -- what parity has to see
+ * through (ADR-0016 decision 3).
+ */
+export function ensemblNames(rows) {
+    return rows.map(([name, size]) => ['chrM' === name ? 'MT' : name.substring(3), size])
+}
+
 const BP_RESOLUTIONS = [2500000, 1000000, 500000, 250000, 100000, 50000, 25000, 10000, 5000]
 
-function chromosomeTable(rows) {
+/** `rows` as a dataset's chromosome table: `All` at index 0, then each row in order. */
+export function chromosomeTable(rows) {
     const named = rows.map(([name, size], i) => ({index: i + 1, name, size}))
     const all = {index: 0, name: 'All', size: named.reduce((sum, c) => sum + c.size, 0)}
     return [all, ...named]


### PR DESCRIPTION
Closes #636 (part of #632 / spec #634, ADR-0016 decisions 2–5).

## What changes

- **`Dataset.canSyncWith(other)`** — same assembly (exactly `isCompatible`) **and** two-way chromosome parity through `Genome.getChromosome` (aliasing, case-insensitive), `All` excluded. Symmetric by construction.
- **Sync callers move to it:** `pairSynchable` and the sync-on-load peer search. `isCompatible` and the control-map load are unchanged — a chr1-only control map against a whole-genome map stays legal.
- **The reversal:** a subset `.hic` no longer pairs with a whole-genome map of the same assembly, in either load order. Groups are now partitions.
- **`canResolveSyncState` is a defensive assert:** `HICBrowser.syncState` `console.error`s and returns; it no longer calls `onSyncRefused`. `'unresolved-chromosome'` stays in the reason union, annotated as no longer emitted.
- **Docs:** `CONTEXT.md` *Sync group* / *Sync state* rewritten; `compareChromosomes` and `canResolveSyncState` comments point at ADR-0016.

No UI — the isolation mark is the next ticket. ADR-0016 stays *Proposed* until #632 fully lands.

## Worth a look

- **`genome.js` one-character fix:** the `MT` genome's alias for `chrM` was misspelled `chrmM`, so an `MT` map could not place `chrM`. Two-way parity needs that direction for `MT`/`chrM` pairs to keep pairing.
- **Extra scaffold on one side only does not pair** — read strictly from "every real chromosome on each side must be placeable". Maps that both carry it pair in any table order. The #626 case in `testSyncOnLoad` now gives both maps the scaffold.
- **dMel `arm_` names are not covered.** They didn't pair before either (`isCompatible` refuses them for dm6, and `Genome`'s `arm_` aliasing is one-directional). The `canSyncWith` comment says so.
- `testConfigGolden` untouched: its fake is a control dataset, on which `canSyncWith` is never called.

## Tests

- New `test/testCanSyncWith.js` (truth table, symmetry asserted on every row; `isCompatible` answers pinned) and `test/testSyncParity.js` (real load path, stubbed only at `Dataset.loadDataset`).
- `testSyncGroup` gains a partition test; `testSyncChromosomeGuard` now tests the assert directly (`console.error`, no throw, no state change, no `onSyncRefused`).
- Fixtures faking `isCompatible` gain `canSyncWith`.
- Full suite: 67 files, 1201 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9UmXS9G8vg77i28dBja8L