### PR TITLE
Mark panels that cannot join any sync group

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -102,6 +102,15 @@ reported as `onSyncRefused` rather than dropped silently. `js/syncGroup.js`,
 ADR-0016.
 _Avoid_: sync payload, target state.
 
+**Isolation mark** — the quiet mark in a panel's navbar, beside the contact-map
+label, on a panel holding a map that belongs to no sync group; its tooltip says
+why (different assembly, mismatched coverage, or `synchable: false`). It shows
+**isolation, never membership**: a panel with a partner is unmarked, whichever
+group it is in. The **empty room** is exempt — fewer than two mapped panels mark
+nothing. Moves only when the open maps change, never while anyone pans.
+`isolationReasons` in `js/syncGroup.js`, ADR-0016 decisions 7–8.
+_Avoid_: sync badge, unsynced indicator.
+
 **Target set** — the browsers a *load* reaches: the ones the user has aimed at by
 shift-clicking their navbars, plus the current browser. Its members are
 **targeted browsers**. Not a sync group: membership is an explicit gesture, the

--- a/css/juicebox.css
+++ b/css/juicebox.css
@@ -650,6 +650,16 @@
   line-height: var(--nav-bar-label-height);
   background-color: transparent;
 }
+.hic-navbar-container div[id$=hic-nav-bar-map-container] i.hic-isolation-mark {
+  flex: 0 0 auto;
+  margin-left: 6px;
+  margin-right: auto;
+  color: #b5534b;
+  cursor: default;
+}
+.hic-navbar-container div[id$=hic-nav-bar-map-container] i.hic-isolation-mark[hidden] {
+  display: none;
+}
 .hic-navbar-container div[id$=hic-nav-bar-map-container] .hic-nav-bar-button-container {
   height: 100%;
   display: flex;

--- a/css/juicebox.scss
+++ b/css/juicebox.scss
@@ -614,6 +614,25 @@ $default-font-family: 'Open Sans', sans-serif;
       line-height: var(--nav-bar-label-height);
       background-color: transparent;
     }
+    // The isolation mark: this panel cannot join any sync group, and the
+    // tooltip says why (#637, ADR-0016 decision 7). Quiet and permanent, so a
+    // muted rose rather than an alert colour -- and neither the grey of the
+    // selected border nor the blue of the target set (ADR-0015 decision 4b).
+    // `margin-right: auto` keeps it beside the label while the container spaces
+    // the label and the buttons apart; hidden, it is out of the flow entirely,
+    // so the navbar lays out exactly as it does without it.
+    i.hic-isolation-mark {
+      flex: 0 0 auto;
+      margin-left: 6px;
+      margin-right: auto;
+      color: #b5534b;
+      cursor: default;
+    }
+    // Font Awesome's `.fa` sets `display: inline-block`, which outranks the
+    // user agent's `[hidden]` -- without this the hidden mark would still show.
+    i.hic-isolation-mark[hidden] {
+      display: none;
+    }
     .hic-nav-bar-button-container {
       height: 100%;
       display: flex;

--- a/docs/adr/0016-sync-membership-is-static.md
+++ b/docs/adr/0016-sync-membership-is-static.md
@@ -136,8 +136,9 @@ the map label, non-dismissible, reason in the `title`.
 | `synchable: false` | yes — "sync is disabled for this panel" |
 | the only panel open | **no** |
 
-The last row is the empty room, not a refusal, and `dataLoader.js:222` already
-draws exactly this line. Marking it would put a permanent badge on the most common
+The last row is the empty room, not a refusal — the line the load-time refusal
+already drew (#626), and which `isolationReasons` in `js/syncGroup.js` now draws
+for both the mark and that refusal. Marking it would put a permanent badge on the most common
 view in the application and teach every user to ignore the mark before they ever
 saw it mean something.
 

--- a/docs/adr/0016-sync-membership-is-static.md
+++ b/docs/adr/0016-sync-membership-is-static.md
@@ -1,14 +1,13 @@
 # ADR-0016 — Sync membership is static: settled at pair time, never per state
 
-**Status:** Proposed — accept when #632 lands. The decision is made; the code it
-describes is not written yet, and this file should not read as Accepted before it is.
+**Status:** Accepted — #632 landed as #635, #636 and #637.
 
 **Date:** 2026-09-10
 **Related:** #632 (the work), #626 / #627 (the refusal this reverses in part),
 #605 (`canResolveSyncState`, the guard being demoted), ADR-0014 (what crosses a
 sync group), ADR-0015 (targeting is not a sync group — the mechanism this is
 *not*), ADR-0010 (`All` is a zoom rung), ADR-0003 (public API contract),
-`CONTEXT.md` (*Sync group*, *Sync state*), `js/syncGroup.js`, `js/hicDataset.js`
+`CONTEXT.md` (*Sync group*, *Sync state*, *Isolation mark*), `js/syncGroup.js`, `js/hicDataset.js`
 
 ## Context
 

--- a/js/browserCoordinator.js
+++ b/js/browserCoordinator.js
@@ -399,19 +399,20 @@ class BrowserCoordinator {
      * carries never pairs in the first place, and the per-state refusal it used
      * to produce is now a `console.error` assert in `HICBrowser.syncState`.
      *
-     * No widget surface, which is the difference from `onNormalizationSubstituted`
-     * next door. ADR-0012 put a substitution on the normalization selector
-     * because a selector is *already* displaying the value that got substituted;
-     * a refused sync has no such control to contradict, and inventing a badge for
-     * it would be new UI answering a question hosts have not asked yet. The
-     * `console.warn` is the developer-facing half and the callback is the host
-     * facing half; either can grow a surface later without moving this call.
+     * The user-facing half is not here. Static membership is what made a panel
+     * surface affordable -- a mark that cannot flicker -- so since #637 the
+     * panel itself says it is isolated, with a mark the registry paints from
+     * `isolationReasons` (ADR-0016 decision 7). The load-time refusal reads the
+     * same rule and carries the mark's text as its `message`, so the host's log
+     * and the screen cannot disagree. The `console.warn` is the developer-facing
+     * half and the callback is the host-facing half.
      *
      * @param {Object} detail
      * @param {string} detail.reason - `'no-compatible-peer'` or `'unresolved-chromosome'`.
      *   `'unresolved-chromosome'` is no longer emitted since #632; it stays in the
      *   union so host code that branches on it keeps compiling and running.
-     * @param {string} detail.message - The same thing in a sentence
+     * @param {string} detail.message - The same thing in a sentence: since #637,
+     *   the isolation mark's tooltip on the refused panel, word for word.
      */
     onSyncRefused(detail) {
         console.warn(`juicebox: panel not synced -- ${detail.message}`);

--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -1,7 +1,7 @@
 import {AlertDialog} from 'igv-ui'
 import EventBus from './eventBus.js'
 import HICEvent from './hicEvent.js'
-import {pairSynchable} from './syncGroup.js'
+import {pairSynchable, isolationReasons} from './syncGroup.js'
 import {fanOutTracks} from './targetGroup.js'
 import {normalizeSession} from './normalizeSession.js'
 // A cycle, deliberately: `createBrowser.js` resolves its registry from a
@@ -16,9 +16,10 @@ import {createBrowserList} from './createBrowser.js'
  * their sync group. See `CONTEXT.md` and `docs/adr/0004-browser-registry-per-container.md`.
  *
  * A registry never constructs a browser -- `js/createBrowser.js` does that and
- * hands the result over. The registry reads only four things off a browser:
- * `rootElement`, `browserPanelDeleteButton`, `synchedBrowsers` and `dispose()`.
- * That is what makes it constructible in a test. Nor does it tear one down:
+ * hands the result over. The registry reads only five things off a browser:
+ * `rootElement`, `browserPanelDeleteButton`, `synchedBrowsers`,
+ * `setIsolationReason()` and `dispose()` -- plus what the membership rules in
+ * `syncGroup.js` read. That is what makes it constructible in a test. Nor does it tear one down:
  * `delete` and `deleteAll` call `dispose()`, and the browser gives its slot back.
  *
  * One registry owns one container element; `registryForContainer` below is how
@@ -593,6 +594,12 @@ class BrowserRegistry {
      * the result is symmetric whatever the caller passes. It runs wherever the
      * open maps change: a load or a failed one (`dataLoader.js`), a browser
      * arriving (`add`) or leaving (`releaseSlot`), and a restore.
+     *
+     * The isolation marks are painted here too, from the same list, for the
+     * reason the target badges are painted in `#announce`: this is the one
+     * place membership changes, so a panel's mark cannot fall out of step with
+     * its group -- and cannot move while the user pans, since panning never
+     * reaches here. ADR-0016 decisions 7-8, #637.
      */
     sync(browsers = this.browsers) {
 
@@ -606,6 +613,11 @@ class BrowserRegistry {
         for (const [b1, b2] of pairSynchable(browsers)) {
             b1.synchedBrowsers.add(b2)
             b2.synchedBrowsers.add(b1)
+        }
+
+        const reasons = isolationReasons(browsers)
+        for (const browser of browsers) {
+            browser.setIsolationReason(reasons.get(browser))
         }
     }
 

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -36,6 +36,7 @@ import Track2D from './track2D.js'
 
 import {decodeState} from "./sessionCodec.js"
 import {mapTrackConfig} from "./urlMapper.js"
+import {isolationReasons, isSynchable} from "./syncGroup.js"
 
 /**
  * How this module reports a `config.state` that is neither a state token nor a
@@ -221,14 +222,23 @@ class DataLoader {
             if (peer) {
                 await this.browser.syncState(peer.getSyncState());
             } else {
-                // Only worth reporting when there was in fact something to pair
-                // with. A first panel loading into an empty registry finds no
-                // peer and that is not a refusal, it is an empty room. #626.
-                const others = registry.browsers.filter(b => b !== this.browser && b.dataset);
-                if (others.length > 0) {
+                // Reported exactly when the panel wears the isolation mark, and
+                // in its words, so the host's log and the screen agree (#637).
+                // That rule is what stays quiet in the empty room -- a first
+                // panel loading into an empty registry finds no peer and that is
+                // not a refusal (#626) -- and for a panel the host opted out,
+                // which the host needs no telling about even though the person
+                // looking at the screen does.
+                //
+                // Asked over the registry *and* this browser: `createBrowser`
+                // loads before it registers, so a newcomer is not in the list yet.
+                const browsers = registry.browsers.includes(this.browser) ? registry.browsers : [...registry.browsers, this.browser];
+                const reason = isolationReasons(browsers).get(this.browser);
+                if (undefined !== reason && isSynchable(this.browser)) {
+                    const others = registry.browsers.filter(b => b !== this.browser && b.dataset);
                     this.browser.coordinator.onSyncRefused({
                         reason: 'no-compatible-peer',
-                        message: `no open panel holds a compatible map (this is ${this.browser.dataset.genomeId}, the others are ${others.map(b => b.dataset.genomeId).join(', ')})`,
+                        message: reason,
                         genomeId: this.browser.dataset.genomeId,
                         peerGenomeIds: others.map(b => b.dataset.genomeId)
                     });

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -209,14 +209,16 @@ class DataLoader {
 
             registry.sync(); // Sync browsers to ensure all browsers are updated with the new dataset
 
-            // Find a browser to sync with, if any. The opt-out is `syncState`'s
-            // own guard, as it was before #562 -- this filter has never looked
-            // at `synchable`. `canSyncWith`, the pairing predicate, not the
-            // control-map one below: a peer this panel could not pair with is
-            // not one whose view it should adopt. ADR-0016 decision 2.
+            // Find a browser to sync with, if any: one this panel would pair
+            // with, so the pairing rule's two questions -- `isSynchable` and
+            // `canSyncWith` -- and not the control-map predicate below. Until
+            // #637 this filter ignored the *peer's* `synchable`, so a newcomer
+            // adopted the view of an opted-out panel it is in no group with,
+            // and wore the isolation mark while the host heard nothing. This
+            // panel's own opt-out is `syncState`'s guard. ADR-0016 decision 2.
             const peer = registry.browsers.find(
                 b => b !== this.browser &&
-                     b.dataset &&
+                     isSynchable(b) &&
                      b.dataset.canSyncWith(this.browser.dataset)
             );
             if (peer) {
@@ -235,7 +237,9 @@ class DataLoader {
                 const browsers = registry.browsers.includes(this.browser) ? registry.browsers : [...registry.browsers, this.browser];
                 const reason = isolationReasons(browsers).get(this.browser);
                 if (undefined !== reason && isSynchable(this.browser)) {
-                    const others = registry.browsers.filter(b => b !== this.browser && b.dataset);
+                    // The panels the message is about: the synchable company,
+                    // one id per panel. Opted-out panels are not in it.
+                    const others = registry.browsers.filter(b => b !== this.browser && isSynchable(b));
                     this.browser.coordinator.onSyncRefused({
                         reason: 'no-compatible-peer',
                         message: reason,

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -1314,6 +1314,23 @@ class HICBrowser {
         this.coordinator.onLocusChange(eventData);
     }
 
+    /**
+     * Show why this panel cannot join any sync group, or -- given `undefined`
+     * -- that it can. The isolation mark beside the contact-map label; the
+     * reason is its tooltip. ADR-0016 decisions 7-8, #637.
+     *
+     * Internal: the registry calls it right after recomputing membership, with
+     * what `isolationReasons` in `syncGroup.js` decided, and nothing else does.
+     * That is what keeps the mark still while the user pans -- it moves only
+     * when the open maps do.
+     *
+     * @param {string|undefined} reason
+     */
+    setIsolationReason(reason) {
+        this.isolationMark.hidden = undefined === reason;
+        this.isolationMark.title = reason ?? '';
+    }
+
     setNormalization(normalization) {
         if (this.#state) {
             this.#state.normalization = normalization;

--- a/js/hicDataset.js
+++ b/js/hicDataset.js
@@ -343,17 +343,25 @@ class Dataset {
      * @returns {boolean}
      */
     canSyncWith(other) {
-        return this.isCompatible(other) && placesEveryChromosome(this, other) && placesEveryChromosome(other, this);
+        return this.isCompatible(other) && 0 === this.missingChromosomes(other).length && 0 === other.missingChromosomes(this).length;
     }
-}
 
-/**
- * Can `receiver`'s genome lookup place every real chromosome `sender` carries?
- * One direction of `Dataset.canSyncWith`'s parity.
- */
-function placesEveryChromosome(receiver, sender) {
-    const genome = new Genome(receiver.genomeId, receiver.chromosomes || []);
-    return realChromosomes(sender.chromosomes).every(c => undefined !== genome.getChromosome(c.name));
+    /**
+     * The real chromosomes `other` carries that this map cannot place, by
+     * name, in `other`'s table order. One direction of `canSyncWith`'s parity,
+     * and the names the isolation mark gives when that parity fails (#637) --
+     * so the tooltip and the pairing cannot disagree about what is missing.
+     *
+     * Placed by this map's genome lookup, as `canSyncWith` documents: an alias
+     * or a difference of case is not a missing chromosome. `All` is never one.
+     *
+     * @param {Dataset} other
+     * @returns {Array<string>}
+     */
+    missingChromosomes(other) {
+        const genome = new Genome(this.genomeId, this.chromosomes || []);
+        return realChromosomes(other.chromosomes).filter(c => undefined === genome.getChromosome(c.name)).map(c => c.name);
+    }
 }
 
 /** A chromosome table without `All`, which is a zoom rung and not a chromosome (ADR-0010). */

--- a/js/layoutController.js
+++ b/js/layoutController.js
@@ -306,6 +306,7 @@ function createNavBar(browser, root) {
     const htmlContactMapHicNavBarMapContainer =
         `<div id="${browser.id}-contact-map-hic-nav-bar-map-container">
             <div id="${browser.id}-contact-map-hic-nav-bar-map-label"></div>
+            <i class="fa fa-chain-broken hic-isolation-mark" hidden></i>
              <div class="hic-nav-bar-button-container">
                 <i class="fa fa-bars fa-lg" title="Present menu"></i>
                 <i class="fa fa-minus-circle fa-lg" title="Delete browser panel" style="display: none;"></i>
@@ -315,6 +316,12 @@ function createNavBar(browser, root) {
     hicNavbarContainer.appendChild(createDOMFromHTMLString(htmlContactMapHicNavBarMapContainer));
 
     browser.contactMapLabel = hicNavbarContainer.querySelector(`div[id$='contact-map-hic-nav-bar-map-label']`);
+
+    // Shown only while this panel cannot join any sync group, with the reason
+    // as its tooltip; the registry sets it (`HICBrowser.setIsolationReason`).
+    // A sibling of the label rather than a child, because a load writes the
+    // label's `textContent`. ADR-0016 decision 7, #637.
+    browser.isolationMark = hicNavbarContainer.querySelector('.hic-isolation-mark');
     browser.menuPresentDismiss = hicNavbarContainer.querySelector('.fa-bars');
     browser.menuPresentDismiss.addEventListener('click', e => browser.toggleMenu());
 

--- a/js/publicApi.js
+++ b/js/publicApi.js
@@ -97,6 +97,15 @@ export const NAMESPACE_SURFACE = [
  * Seven more are assigned in the constructor rather than declared on the
  * prototype, so they are invisible to any check that reflects on the class
  * instead of building an instance.
+ *
+ * Deliberately *not* declared, and new in #637: `isolationMark`, the navbar
+ * element, and `setIsolationReason`, which the registry calls to paint it after
+ * recomputing membership. The mark is library chrome and needs no host
+ * (ADR-0016 decision 9); a host that wants the reason has `onSyncRefused`,
+ * whose `message` is the same text. Nor is `dataset.missingChromosomes`, the
+ * lookup behind the mark's coverage wording, although `dataset` is declared.
+ * Absence from this file is not permission, and naming them here is what makes
+ * that decision visible.
  */
 export const BROWSER_SURFACE = [
     // Delegating loaders and lookups -- no internal callers, hosts only

--- a/js/syncGroup.js
+++ b/js/syncGroup.js
@@ -54,6 +54,97 @@ function pairSynchable(browsers) {
 }
 
 /**
+ * Which browsers cannot join any sync group, and why -- the isolation mark's
+ * rule, as a pure function beside the pairing rule it explains. ADR-0016
+ * decisions 7-8, #637.
+ *
+ * Reads the same things `pairSynchable` does -- `synchable`, `dataset`, and the
+ * dataset's own predicates -- and no DOM or module state, so what a panel shows
+ * is a function of the open maps and nothing else. That is what keeps the mark
+ * still while the user pans.
+ *
+ * It reports **isolation, never membership**: a panel with a partner is never
+ * in the result, whichever group that partner is in. And it reports nothing in
+ * the **empty room** -- fewer than two mapped panels -- because a lone map is
+ * the most common view there is, and a badge on it would teach every user to
+ * ignore the mark before it ever meant something.
+ *
+ * A synchable panel whose only mapped company has opted out is not marked
+ * either. It *is* partnerless, but the opted-out panels' own marks already say
+ * why nothing moves together, and marking both sides would say it twice.
+ *
+ * @param {Array} browsers
+ * @returns {Map<Object, string>} the reason text, for each browser to be marked
+ */
+function isolationReasons(browsers) {
+
+    const mapped = browsers.filter(browser => browser.dataset !== undefined)
+    const reasons = new Map()
+
+    if (mapped.length < 2) {
+        return reasons
+    }
+
+    const synchable = mapped.filter(isSynchable)
+
+    for (const browser of mapped) {
+
+        if (browser.synchable === false) {
+            reasons.set(browser, 'sync is disabled for this panel')
+            continue
+        }
+
+        const others = synchable.filter(other => other !== browser)
+        if (0 === others.length || others.some(other => browser.dataset.canSyncWith(other.dataset))) {
+            continue
+        }
+
+        reasons.set(browser, partnerlessReason(browser.dataset, others.map(other => other.dataset)))
+    }
+
+    return reasons
+}
+
+/**
+ * Why a synchable map pairs with none of `others`: coverage, if any of them is
+ * the same assembly, and the assembly otherwise.
+ *
+ * Coverage is read through `missingChromosomes`, the lookup `canSyncWith`
+ * decides parity with, so the names in the tooltip are exactly the ones that
+ * refused the pair -- `1` and `chr1` are never reported as a difference.
+ */
+function partnerlessReason(dataset, others) {
+
+    const sameAssembly = others.filter(other => dataset.isCompatible(other))
+
+    if (sameAssembly.length > 0) {
+
+        const lacking = union(sameAssembly.map(other => dataset.missingChromosomes(other)))
+        if (lacking.length > 0) {
+            return `this map has no ${firstNames(lacking)} — the other panels do`
+        }
+
+        const surplus = union(sameAssembly.map(other => other.missingChromosomes(dataset)))
+        if (surplus.length > 0) {
+            return `the other panels have no ${firstNames(surplus)} — this map does`
+        }
+    }
+
+    const genomeIds = [...new Set(others.map(other => other.genomeId))]
+    return `no other panel holds a compatible map (this is ${dataset.genomeId}; the others are ${genomeIds.join(', ')})`
+}
+
+/** Names from several lists, each once, in the order they are first met. */
+function union(lists) {
+    return [...new Set(lists.flat())]
+}
+
+/** The first three names, and an ellipsis when there are more. */
+function firstNames(names) {
+    return names.length > 3 ? `${names.slice(0, 3).join(', ')}, …` : names.join(', ')
+}
+
+/**
  * Can this genome place both chromosomes a sync state names?
  *
  * A defensive assert since #632, not a decision. Pairing now requires two-way
@@ -91,4 +182,4 @@ function canResolveSyncState(genome, syncState) {
     return resolves(syncState.chr1Name) && resolves(syncState.chr2Name)
 }
 
-export {pairSynchable, isSynchable, canResolveSyncState}
+export {pairSynchable, isSynchable, isolationReasons, canResolveSyncState}

--- a/js/syncGroup.js
+++ b/js/syncGroup.js
@@ -5,8 +5,10 @@
  * until #562 -- here, in `HICBrowser.syncState`, and in
  * `StateManager.canBeSynched` -- and its readers now share this one expression
  * rather than each restating it. The third reader, `canBeSynched`, went with
- * the `config.synchState` rung it was the only production caller of (#566);
- * `HICBrowser.syncState` and `pairSynchable` below are what is left.
+ * the `config.synchState` rung it was the only production caller of (#566).
+ * Its readers now are `HICBrowser.syncState`, the load-time peer search in
+ * `dataLoader.js`, and the two rules below -- `pairSynchable` and
+ * `isolationReasons` (#637).
  *
  * @param {Object} browser
  * @returns {boolean}
@@ -89,7 +91,8 @@ function isolationReasons(browsers) {
 
     for (const browser of mapped) {
 
-        if (browser.synchable === false) {
+        // Among mapped browsers, not synchable means opted out.
+        if (!isSynchable(browser)) {
             reasons.set(browser, 'sync is disabled for this panel')
             continue
         }

--- a/test/testBrowserRegistry.js
+++ b/test/testBrowserRegistry.js
@@ -41,6 +41,10 @@ function fakeBrowser(name, {dataset, synchable} = {}) {
         rootElement: fakeElement(),
         browserPanelDeleteButton: {style: {display: 'none'}},
         synchedBrowsers: new Set(),
+        isolationReason: undefined,
+        setIsolationReason(reason) {
+            this.isolationReason = reason
+        },
         unsyncSelfCalls: 0,
         unsyncSelf() {
             this.unsyncSelfCalls++

--- a/test/testBrowserTargeting.js
+++ b/test/testBrowserTargeting.js
@@ -38,6 +38,7 @@ function fakeBrowser(name, {genomeId} = {}) {
         rootElement: fakeElement(),
         browserPanelDeleteButton: {style: {display: 'none'}},
         synchedBrowsers: new Set(),
+        setIsolationReason: () => undefined,
         loadedConfigs: [],
         failing: false,
         unsyncSelf() {},
@@ -54,8 +55,10 @@ function fakeBrowser(name, {genomeId} = {}) {
     }
     if (genomeId !== undefined) {
         // `canSyncWith` because the registry recomputes the sync group
-        // whenever a browser arrives or leaves -- #635, #636.
-        browser.dataset = {genomeId, canSyncWith: other => other.genomeId === genomeId}
+        // whenever a browser arrives or leaves -- #635, #636 -- and
+        // `isCompatible` because it repaints the isolation marks then, which
+        // asks a partnerless panel why (#637).
+        browser.dataset = {genomeId, canSyncWith: other => other.genomeId === genomeId, isCompatible: other => other.genomeId === genomeId}
         browser.genome = {id: genomeId}
     }
     return browser

--- a/test/testCanSyncWith.js
+++ b/test/testCanSyncWith.js
@@ -122,3 +122,31 @@ describe('Dataset.isCompatible keeps its answers', () => {
         expect(dataset('custom', HG38).isCompatible(dataset('custom', resized))).toBe(false)
     })
 })
+
+/**
+ * The names behind a failed parity check, for the isolation mark's tooltip
+ * (#637). The same lookup `canSyncWith` decides with, so a spelling difference
+ * is never reported as a missing chromosome.
+ */
+describe('Dataset.missingChromosomes', () => {
+
+    it('names what the other map carries and this one cannot place, in the other\'s order', () => {
+        const subset = dataset('hg38', HG38.slice(0, 2))
+        expect(subset.missingChromosomes(dataset('hg38', [...HG38].reverse()))).toEqual(['chrM', 'chrX', 'chr5', 'chr4', 'chr3'])
+    })
+
+    it('is empty when this map is the superset', () => {
+        expect(dataset('hg38', HG38).missingChromosomes(dataset('hg38', HG38.slice(0, 1)))).toEqual([])
+    })
+
+    it('does not count a name this map places through an alias or another case', () => {
+        expect(dataset('hg38', HG38).missingChromosomes(dataset('hg38', HG38_ENSEMBL))).toEqual([])
+        expect(dataset('hg38', HG38).missingChromosomes(dataset('hg38', HG38.map(([n, s]) => [n.toUpperCase(), s])))).toEqual([])
+    })
+
+    it('never names All', () => {
+        const noAll = dataset('hg38', HG38.slice(0, 1))
+        noAll.chromosomes = noAll.chromosomes.slice(1)
+        expect(noAll.missingChromosomes(dataset('hg38', HG38.slice(0, 1)))).toEqual([])
+    })
+})

--- a/test/testEmbedScoping.js
+++ b/test/testEmbedScoping.js
@@ -256,6 +256,7 @@ function fakeBrowser(name, registry) {
         rootElement: {classList: {add: () => undefined, remove: () => undefined}},
         browserPanelDeleteButton: {style: {display: 'none'}},
         synchedBrowsers: new Set(),
+        setIsolationReason: () => undefined,
         unsyncSelf: () => undefined,
         toJSON: () => ({name})
     }

--- a/test/testIsolationMark.js
+++ b/test/testIsolationMark.js
@@ -1,0 +1,248 @@
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest'
+import ContactMatrixView from '../js/contactMatrixView.js'
+import HICBrowser from '../js/hicBrowser.js'
+import DataLoader from '../js/dataLoader.js'
+import BrowserCoordinator from '../js/browserCoordinator.js'
+import State from '../js/hicState.js'
+import {createBrowser} from '../js/createBrowser.js'
+import {registryForContainer} from '../js/browserRegistry.js'
+import {withContainers} from './utils/browserFixture.js'
+import {HG19, HG38 as HG38_ROWS, DM6 as DM6_ROWS, WHOLE_HG19, WHOLE_MM10, serveMaps} from './utils/servedMaps.js'
+
+/**
+ * A panel that cannot join any sync group says so, on the panel: a quiet mark
+ * beside the contact-map label, the reason in its `title`. #637, ADR-0016
+ * decisions 7-9.
+ *
+ * The real load path, stubbed only at `Dataset.loadDataset`, and assertions on
+ * the mark as a user meets it -- whether it shows, and what its tooltip says --
+ * rather than on how the registry decided. The rule itself is tabled in
+ * `test/testSyncGroup.js`.
+ */
+
+const url = name => `https://example.com/${name}.hic`
+
+const SUBSET_HG19 = {genomeId: 'hg19', rows: HG19.slice(0, 1)}
+const HG38 = {genomeId: 'hg38', rows: HG38_ROWS}
+const DM6 = {genomeId: 'dm6', rows: DM6_ROWS}
+
+const WHOLE_REASON = 'the other panels have no chr2, chr3, chr4, … — this map does'
+const SUBSET_REASON = 'this map has no chr2, chr3, chr4, … — the other panels do'
+const DISABLED = 'sync is disabled for this panel'
+const assembly = (mine, theirs) => `no other panel holds a compatible map (this is ${mine}; the others are ${theirs})`
+
+/** What each panel's mark says, `null` for a hidden one, in panel order. */
+function marks(browsers) {
+    return browsers.map(browser => browser.isolationMark.hidden ? null : browser.isolationMark.title)
+}
+
+async function panels(container, maps) {
+    serveMaps(maps)
+    const browsers = []
+    for (const [i] of maps.entries()) {
+        browsers.push(await createBrowser(container, {url: url(`map-${i}`)}))
+    }
+    return browsers
+}
+
+describe('the isolation mark', () => {
+
+    const dom = withContainers()
+
+    beforeEach(() => {
+        vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(DataLoader.prototype, 'loadTracks').mockImplementation(async () => undefined)
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    })
+
+    afterEach(() => vi.restoreAllMocks())
+
+    describe('where it sits', () => {
+
+        it('is in the navbar, immediately after the contact-map label, and hidden to begin with', async () => {
+            const [browser] = await panels(dom.container, [WHOLE_HG19])
+
+            expect(browser.contactMapLabel.nextElementSibling).toBe(browser.isolationMark)
+            expect(browser.isolationMark.hidden).toBe(true)
+        })
+
+        it('is out of the flow while hidden, so the navbar lays out as it did without it', async () => {
+            // Tests do no layout (ADR-0013), so this pins the mechanism: the
+            // `hidden` attribute, which the stylesheet keeps meaning
+            // `display: none` -- nothing that reserves a box.
+            const [browser] = await panels(dom.container, [WHOLE_HG19])
+
+            expect(browser.isolationMark.hasAttribute('hidden')).toBe(true)
+            expect(browser.isolationMark.style.visibility).toBe('')
+        })
+    })
+
+    describe('follows the open maps', () => {
+
+        it('marks neither of two identical hg19 maps', async () => {
+            expect(marks(await panels(dom.container, [WHOLE_HG19, WHOLE_HG19]))).toEqual([null, null])
+        })
+
+        it('marks a whole-genome and a chr1-only hg19 map, each with its own coverage reason', async () => {
+            expect(marks(await panels(dom.container, [WHOLE_HG19, SUBSET_HG19]))).toEqual([WHOLE_REASON, SUBSET_REASON])
+        })
+
+        it('marks hg38 and dm6 with the assembly reason', async () => {
+            expect(marks(await panels(dom.container, [HG38, DM6]))).toEqual([assembly('hg38', 'dm6'), assembly('dm6', 'hg38')])
+        })
+
+        it('does not mark a single panel', async () => {
+            expect(marks(await panels(dom.container, [WHOLE_HG19]))).toEqual([null])
+        })
+
+        it('does not mark one mapped panel beside an empty one', async () => {
+            serveMaps([WHOLE_HG19])
+            const a = await createBrowser(dom.container, {url: url('a')})
+            const empty = await createBrowser(dom.container, {})
+
+            expect(empty.dataset).toBeUndefined()
+            expect(marks([a, empty])).toEqual([null, null])
+        })
+
+        it('marks only the opted-out one of a synchable panel and an opted-out one', async () => {
+            serveMaps([WHOLE_HG19, WHOLE_HG19])
+            const a = await createBrowser(dom.container, {url: url('a')})
+            const off = await createBrowser(dom.container, {url: url('off'), synchable: false})
+
+            expect(marks([a, off])).toEqual([null, DISABLED])
+        })
+
+        it('marks none of two hg38 and two dm6 maps -- isolation, never membership', async () => {
+            expect(marks(await panels(dom.container, [HG38, DM6, HG38, DM6]))).toEqual([null, null, null, null])
+        })
+
+        it('marks a paired panel that loads an incompatible map', async () => {
+            const [a, b] = await panels(dom.container, [WHOLE_HG19, WHOLE_HG19])
+            expect(marks([a, b])).toEqual([null, null])
+
+            serveMaps([WHOLE_MM10])
+            await b.loadHicFile({url: url('mouse')})
+
+            expect(marks([a, b])).toEqual([assembly('hg19', 'mm10'), assembly('mm10', 'hg19')])
+        })
+
+        it('clears an isolated panel\'s mark, and pairs it, when it loads a compatible map', async () => {
+            const [a, b] = await panels(dom.container, [WHOLE_HG19, WHOLE_MM10])
+            expect(marks([a, b])).toEqual([assembly('hg19', 'mm10'), assembly('mm10', 'hg19')])
+
+            serveMaps([WHOLE_HG19])
+            await b.loadHicFile({url: url('human')})
+
+            expect(marks([a, b])).toEqual([null, null])
+            expect([...b.synchedBrowsers]).toEqual([a])
+        })
+
+        it('leaves the survivors unmarked when deleting a partner leaves them a partner still', async () => {
+            const [a, b, c, d] = await panels(dom.container, [WHOLE_HG19, WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
+
+            a.registry.delete(b)
+
+            expect(marks([a, c, d])).toEqual([null, null, assembly('mm10', 'hg19')])
+        })
+
+        it('clears the survivor\'s mark when deleting the other panel leaves it alone in the room', async () => {
+            const [a, b] = await panels(dom.container, [WHOLE_HG19, WHOLE_MM10])
+            expect(marks([a, b])).toEqual([assembly('hg19', 'mm10'), assembly('mm10', 'hg19')])
+
+            a.registry.delete(b)
+
+            expect(marks([a])).toEqual([null])
+        })
+
+        it('marks the survivor when deleting its partner leaves it beside an incompatible map', async () => {
+            const [a, b, c] = await panels(dom.container, [WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
+
+            a.registry.delete(b)
+
+            expect(marks([a, c])).toEqual([assembly('hg19', 'mm10'), assembly('mm10', 'hg19')])
+        })
+
+        it('marks every mapped panel of a restored session that does not sync datasets', async () => {
+            serveMaps([WHOLE_HG19, WHOLE_HG19, WHOLE_MM10])
+            const registry = registryForContainer(dom.container)
+
+            await registry.restoreSession({syncDatasets: false, browsers: [{url: url('a')}, {url: url('b')}, {url: url('c')}]})
+
+            expect(marks(registry.browsers)).toEqual([DISABLED, DISABLED, DISABLED])
+        })
+    })
+
+    describe('agrees with the host log', () => {
+
+        it('gives the no-compatible-peer refusal the mark\'s own text as its message', async () => {
+            serveMaps([WHOLE_HG19, SUBSET_HG19])
+            await createBrowser(dom.container, {url: url('whole')})
+            const refused = vi.spyOn(BrowserCoordinator.prototype, 'onSyncRefused')
+            const b = await createBrowser(dom.container, {url: url('subset')})
+
+            expect(refused).toHaveBeenCalledTimes(1)
+            expect(refused.mock.calls[0][0].reason).toBe('no-compatible-peer')
+            expect(refused.mock.calls[0][0].message).toBe(b.isolationMark.title)
+            expect(b.isolationMark.hidden).toBe(false)
+        })
+
+        it('keeps the refusal\'s payload shape', async () => {
+            serveMaps([WHOLE_HG19, WHOLE_MM10])
+            await createBrowser(dom.container, {url: url('human')})
+            const refused = vi.spyOn(BrowserCoordinator.prototype, 'onSyncRefused')
+            await createBrowser(dom.container, {url: url('mouse')})
+
+            expect(refused.mock.calls[0][0]).toEqual({
+                reason: 'no-compatible-peer',
+                message: assembly('mm10', 'hg19'),
+                genomeId: 'mm10',
+                peerGenomeIds: ['hg19'],
+            })
+        })
+
+        it('says nothing on load for a panel the host opted out', async () => {
+            serveMaps([WHOLE_HG19, WHOLE_MM10])
+            await createBrowser(dom.container, {url: url('human')})
+            const refused = vi.spyOn(BrowserCoordinator.prototype, 'onSyncRefused')
+            const off = await createBrowser(dom.container, {url: url('mouse'), synchable: false})
+
+            expect(refused).not.toHaveBeenCalled()
+            expect(off.isolationMark.title).toBe(DISABLED)
+        })
+    })
+
+    describe('stays still while the user moves', () => {
+
+        it('is not touched by panning, zooming or changing chromosome, in any panel', async () => {
+            const browsers = await panels(dom.container, [WHOLE_HG19, SUBSET_HG19, WHOLE_HG19])
+            const [a] = browsers
+            const before = marks(browsers)
+
+            // Collected in the callback rather than read from `takeRecords`:
+            // the awaits below deliver pending records, emptying that queue.
+            const mutations = []
+            const observer = new dom.window.MutationObserver(records => mutations.push(...records))
+            for (const browser of browsers) {
+                observer.observe(browser.isolationMark, {attributes: true})
+            }
+
+            for (const state of [
+                new State(1, 1, 3, 10, 10, 1, 'NONE'),   // chr1
+                new State(1, 1, 3, 40, 25, 1, 'NONE'),   // pan
+                new State(1, 1, 6, 40, 25, 1, 'NONE'),   // zoom
+                new State(8, 9, 2, 0, 0, 1, 'NONE'),     // another chromosome pair
+                new State(0, 0, 0, 0, 0, 1, 'NONE'),     // whole genome
+            ]) {
+                await a.setState(state)
+                a.syncToOtherBrowsers()
+            }
+            await vi.waitFor(() => expect(browsers[2].state.chr1).toBe(0))
+
+            mutations.push(...observer.takeRecords())
+            expect(mutations.map(record => record.attributeName)).toEqual([])
+            expect(marks(browsers)).toEqual(before)
+            observer.disconnect()
+        })
+    })
+})

--- a/test/testIsolationMark.js
+++ b/test/testIsolationMark.js
@@ -210,6 +210,38 @@ describe('the isolation mark', () => {
             expect(refused).not.toHaveBeenCalled()
             expect(off.isolationMark.title).toBe(DISABLED)
         })
+
+        it('reports a marked newcomer whose only compatible company is opted out, and leaves its view alone', async () => {
+            // The opted-out panel is not a peer: it is in no group, so a panel
+            // that adopted its view would be following a panel it does not
+            // follow. Until this, the load's peer search ignored `synchable`
+            // and found it -- the newcomer took its view, wore the mark, and
+            // the host heard nothing.
+            serveMaps([WHOLE_HG19, WHOLE_MM10, WHOLE_HG19])
+            const off = await createBrowser(dom.container, {url: url('off'), synchable: false})
+            await off.setState(new State(2, 2, 5, 7, 9, 1, 'NONE'))
+            await createBrowser(dom.container, {url: url('mouse')})
+            const refused = vi.spyOn(BrowserCoordinator.prototype, 'onSyncRefused')
+            const b = await createBrowser(dom.container, {url: url('human')})
+
+            expect(b.isolationMark.title).toBe(assembly('hg19', 'mm10'))
+            expect(refused).toHaveBeenCalledTimes(1)
+            expect(refused.mock.calls[0][0].message).toBe(b.isolationMark.title)
+            expect(b.state.zoom).not.toBe(5)
+        })
+
+        it('names in peerGenomeIds exactly the panels the message is about', async () => {
+            // The opted-out mouse panel is in the room but not in the message,
+            // so it is not in the ids either.
+            serveMaps([WHOLE_MM10, DM6, WHOLE_HG19])
+            await createBrowser(dom.container, {url: url('off'), synchable: false})
+            await createBrowser(dom.container, {url: url('fly')})
+            const refused = vi.spyOn(BrowserCoordinator.prototype, 'onSyncRefused')
+            await createBrowser(dom.container, {url: url('human')})
+
+            expect(refused.mock.calls[0][0].message).toBe(assembly('hg19', 'dm6'))
+            expect(refused.mock.calls[0][0].peerGenomeIds).toEqual(['dm6'])
+        })
     })
 
     describe('stays still while the user moves', () => {

--- a/test/testRegistryLookup.js
+++ b/test/testRegistryLookup.js
@@ -62,6 +62,7 @@ function fakeBrowser(name, registry) {
         },
         browserPanelDeleteButton: {style: {display: 'none'}},
         synchedBrowsers: new Set(),
+        setIsolationReason: () => undefined,
         unsyncSelf: () => {
         }
     }

--- a/test/testRegistrySession.js
+++ b/test/testRegistrySession.js
@@ -36,6 +36,7 @@ function fakeBrowser(name, registry) {
         rootElement,
         browserPanelDeleteButton: {style: {display: 'none'}},
         synchedBrowsers: new Set(),
+        setIsolationReason: () => undefined,
         unsyncSelf: () => undefined,
         // Since #493 a restore's opening `deleteAll()` asks each browser to
         // dispose itself; what the registry sees of that is the DOM going and

--- a/test/testSyncGroup.js
+++ b/test/testSyncGroup.js
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest'
-import {pairSynchable, canResolveSyncState} from '../js/syncGroup.js'
+import {pairSynchable, canResolveSyncState, isolationReasons} from '../js/syncGroup.js'
 import Genome from '../js/genome.js'
 
 /**
@@ -168,5 +168,140 @@ describe('canResolveSyncState', () => {
 
     it('refuses a state whose names are missing altogether', () => {
         expect(canResolveSyncState(genome(), state(undefined, undefined))).toBe(false)
+    })
+})
+
+/**
+ * Which panels wear the isolation mark, and what its tooltip says. #637,
+ * ADR-0016 decisions 7-8.
+ *
+ * Pure, like `pairSynchable`, so the browsers are fabricated again. The fake
+ * dataset is an assembly plus a list of chromosome names, and answers the three
+ * questions the rule asks of a real one: `isCompatible` (same assembly),
+ * `canSyncWith` (same assembly and the same chromosomes) and
+ * `missingChromosomes` (what the other carries that this cannot place).
+ */
+describe('isolationReasons', () => {
+
+    function coverage(genomeId, names) {
+        return {
+            genomeId,
+            names,
+            isCompatible: other => other.genomeId === genomeId,
+            canSyncWith(other) {
+                return other.genomeId === genomeId &&
+                    0 === this.missingChromosomes(other).length &&
+                    0 === other.missingChromosomes(this).length
+            },
+            missingChromosomes: other => other.names.filter(name => !names.includes(name))
+        }
+    }
+
+    const WHOLE = ['chr1', 'chr2', 'chr3', 'chr4', 'chr5']
+    const whole = (genomeId = 'hg19') => coverage(genomeId, WHOLE)
+    const chr1Only = (genomeId = 'hg19') => coverage(genomeId, ['chr1'])
+
+    /** The reasons as `{name: reason}`, so a failure says who got what. */
+    function reasons(browsers) {
+        return Object.fromEntries([...isolationReasons(browsers)].map(([browser, reason]) => [browser.name, reason]))
+    }
+
+    it('marks nobody when no panel holds a map', () => {
+        expect(reasons([fakeBrowser('a'), fakeBrowser('b')])).toEqual({})
+    })
+
+    it('marks nobody in the empty room: one mapped panel, alone', () => {
+        expect(reasons([fakeBrowser('a', {dataset: whole()})])).toEqual({})
+    })
+
+    it('marks nobody in the empty room: one mapped panel beside empty ones', () => {
+        const browsers = [fakeBrowser('a', {dataset: whole()}), fakeBrowser('empty')]
+        expect(reasons(browsers)).toEqual({})
+    })
+
+    it('does not mark an opted-out panel alone in the empty room either', () => {
+        const browsers = [fakeBrowser('a', {dataset: whole(), synchable: false}), fakeBrowser('empty')]
+        expect(reasons(browsers)).toEqual({})
+    })
+
+    it('marks nobody when every mapped panel has a partner', () => {
+        const browsers = [
+            fakeBrowser('a', {dataset: whole('hg38')}), fakeBrowser('b', {dataset: whole('dm6')}),
+            fakeBrowser('c', {dataset: whole('hg38')}), fakeBrowser('d', {dataset: whole('dm6')}),
+        ]
+        expect(reasons(browsers)).toEqual({})
+    })
+
+    it('never marks a panel without a map', () => {
+        const browsers = [fakeBrowser('a', {dataset: whole('hg38')}), fakeBrowser('b', {dataset: whole('dm6')}), fakeBrowser('empty')]
+        expect(reasons(browsers)).not.toHaveProperty('empty')
+    })
+
+    it('marks an opted-out panel as disabled, whatever it could have paired with', () => {
+        const browsers = [fakeBrowser('a', {dataset: whole()}), fakeBrowser('b', {dataset: whole()}), fakeBrowser('off', {dataset: whole(), synchable: false})]
+        expect(reasons(browsers)).toEqual({off: 'sync is disabled for this panel'})
+    })
+
+    it('leaves a synchable panel whose only company is opted out unmarked', () => {
+        // The opted-out panel's own mark already accounts for the stillness.
+        const browsers = [fakeBrowser('a', {dataset: whole()}), fakeBrowser('off', {dataset: whole('dm6'), synchable: false})]
+        expect(reasons(browsers)).toEqual({off: 'sync is disabled for this panel'})
+    })
+
+    it('marks every panel when all of them are opted out', () => {
+        const browsers = [fakeBrowser('a', {dataset: whole(), synchable: false}), fakeBrowser('b', {dataset: whole(), synchable: false})]
+        expect(reasons(browsers)).toEqual({a: 'sync is disabled for this panel', b: 'sync is disabled for this panel'})
+    })
+
+    it('blames coverage on both sides of a subset and a whole-genome map of one assembly', () => {
+        const browsers = [fakeBrowser('whole', {dataset: whole()}), fakeBrowser('subset', {dataset: chr1Only()})]
+        expect(reasons(browsers)).toEqual({
+            whole: 'the other panels have no chr2, chr3, chr4, … — this map does',
+            subset: 'this map has no chr2, chr3, chr4, … — the other panels do',
+        })
+    })
+
+    it('names every missing chromosome, without an ellipsis, when there are three or fewer', () => {
+        const browsers = [fakeBrowser('a', {dataset: coverage('hg19', ['chr1', 'chr2', 'chr3'])}), fakeBrowser('b', {dataset: chr1Only()})]
+        expect(reasons(browsers)).toEqual({
+            a: 'the other panels have no chr2, chr3 — this map does',
+            b: 'this map has no chr2, chr3 — the other panels do',
+        })
+    })
+
+    it('takes the union of what the same-assembly peers carry, in the table order of whichever carries it', () => {
+        const browsers = [
+            fakeBrowser('subset', {dataset: chr1Only()}),
+            fakeBrowser('p', {dataset: coverage('hg19', ['chr1', 'chr7'])}),
+            fakeBrowser('q', {dataset: coverage('hg19', ['chr7', 'chr1', 'chr2', 'chr9'])}),
+        ]
+        expect(reasons(browsers).subset).toBe('this map has no chr7, chr2, chr9 — the other panels do')
+    })
+
+    it('blames the assembly when no peer is the same assembly, naming each other genome once', () => {
+        const browsers = [
+            fakeBrowser('fly', {dataset: whole('dm6')}),
+            fakeBrowser('a', {dataset: whole('hg38')}), fakeBrowser('b', {dataset: whole('hg38')}),
+            fakeBrowser('m', {dataset: whole('mm10')}), fakeBrowser('n', {dataset: whole('mm10')}),
+        ]
+        expect(reasons(browsers)).toEqual({fly: 'no other panel holds a compatible map (this is dm6; the others are hg38, mm10)'})
+    })
+
+    it('blames the assembly on both sides of an hg38 and a dm6 map', () => {
+        const browsers = [fakeBrowser('human', {dataset: whole('hg38')}), fakeBrowser('fly', {dataset: whole('dm6')})]
+        expect(reasons(browsers)).toEqual({
+            human: 'no other panel holds a compatible map (this is hg38; the others are dm6)',
+            fly: 'no other panel holds a compatible map (this is dm6; the others are hg38)',
+        })
+    })
+
+    it('blames coverage, not the assembly, when any partnerless peer is the same assembly', () => {
+        const browsers = [fakeBrowser('subset', {dataset: chr1Only('hg38')}), fakeBrowser('whole', {dataset: whole('hg38')}), fakeBrowser('fly', {dataset: whole('dm6')})]
+        expect(reasons(browsers).subset).toBe('this map has no chr2, chr3, chr4, … — the other panels do')
+    })
+
+    it('leaves out opted-out panels when naming the other genomes', () => {
+        const browsers = [fakeBrowser('human', {dataset: whole('hg38')}), fakeBrowser('fly', {dataset: whole('dm6')}), fakeBrowser('off', {dataset: whole('mm10'), synchable: false})]
+        expect(reasons(browsers).human).toBe('no other panel holds a compatible map (this is hg38; the others are dm6)')
     })
 })


### PR DESCRIPTION
Closes #637. Part of #634 / #632; ADR-0016 decisions 7–9.

## What

A panel that holds a map but belongs to no sync group now shows a quiet, permanent mark (a broken-chain glyph) beside its contact-map label. The tooltip gives the reason:

| condition | tooltip |
| --- | --- |
| different assembly | `no other panel holds a compatible map (this is dm6; the others are hg38)` |
| this map lacks chromosomes the same-assembly peers carry | `this map has no chr2, chr3, chr4, … — the other panels do` |
| this map is the superset | `the other panels have no chr2, chr3, chr4, … — this map does` |
| `synchable: false` | `sync is disabled for this panel` |
| fewer than two mapped panels (the empty room) | no mark |

It shows isolation, never group membership. It only changes when the set of open maps changes, never on pan, zoom or chromosome change.

## How

- **`isolationReasons`** (`js/syncGroup.js`) is a pure function next to `pairSynchable`. It takes a list of browsers and returns a `Map` from each browser that should be marked to its reason.
- **`Dataset.missingChromosomes(other)`** returns the chromosome names `other` carries that this map can't place, using the same genome lookup as the pairing check. `canSyncWith` now uses it too, so the tooltip names exactly the chromosomes that blocked the pair. `1` vs `chr1` is never reported as a difference.
- **`registry.sync()`** paints the marks right after it recomputes membership, through `HICBrowser.setIsolationReason`. This is the same approach it uses for the targeting badges.
- **The `no-compatible-peer` refusal** now reads the same rule, and its `message` is the mark's tooltip text. The callback name, registration and payload shape are unchanged.
- **Style:** the mark is styled in `css/juicebox.scss`. It is muted rose, distinct from the grey selected border and the blue target outline. `margin-right: auto` keeps it beside the label. A `[hidden]` rule overrides Font Awesome's `display: inline-block`, so a hidden mark takes up no space.
- **Docs:** `CONTEXT.md` has a new *Isolation mark* entry, ADR-0016 is now Accepted, and `publicApi.js` names the new members as deliberately not part of the host API.

## Differences from the issue text

- **The warning to hosts now fires exactly when the mark shows.** The issue asks for both "fires under the same condition as today" and "`message` equals the mark's `title`", which conflict in two corner cases. I followed the mark:
  - A synchable panel whose only company is an **opted-out, incompatible** panel used to get the warning. It no longer does, because the panel isn't marked; the opted-out panel's own mark already explains why nothing moves together.
  - The load-time peer search used to ignore the *peer's* `synchable`. So a new panel next to an **opted-out, compatible** panel took that panel's view and got marked, but the host was never warned. The search now requires the peer to be synchable. The new panel no longer adopts an opted-out panel's view on load, and it now gets the warning.
- **`peerGenomeIds` lists the same panels as the message**: the other synchable panels, one id per panel. Opted-out panels are no longer included.
- **The rule asks the dataset one extra question**, `missingChromosomes`, besides the two predicates the issue lists. The coverage wording needs chromosome names, and asking the parity lookup keeps the tooltip and the pairing in agreement.
- **The style rule sits with the navbar-label rules**, not physically next to the targeting badges. Its comment points to ADR-0015 decision 4b.

## Tests

- `test/testSyncGroup.js` tests the pure rule over fake browsers. It covers every case in the table above, both empty-room cases, a synchable panel whose only company is opted out, the three-name truncation, the union across peers, and genome-id dedup.
- `test/testIsolationMark.js` runs the real load path, stubbed only at `Dataset.loadDataset`, and covers every seam case in the issue. The "never toggles on pan" test uses a `MutationObserver` on the marks. I checked it fails if `setState` re-runs `registry.sync()`.
- `test/testCanSyncWith.js` covers `missingChromosomes`: table order, aliases, case, and `All`.
- The full suite passes: 1242 tests.

Not checked in a real browser (ADR-0013), so the look of the mark and "hidden doesn't shift the navbar" are worth a glance on the dev page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fXnazGmJp1BqY9AZ6fcN1