### PR TITLE
Bump version to 4.4.0

### DIFF
--- a/docs/adr/0003-public-api-contract.md
+++ b/docs/adr/0003-public-api-contract.md
@@ -425,3 +425,50 @@ mechanism earned its declaration is worth asking out loud.
 named in `js/publicApi.js` and pinned by `test/testTargetGroup.js`, which is the
 `#471` lesson applied in advance: a host branching on a spelling nobody declared
 is the failure, so the spellings are declared.
+
+## Re-measurement — 2026-09-10, for the v4.4.0 release
+
+Appended, not revised. The tables above stay as the measurement they were.
+
+Measured against `juicebox.js` at `bump-version-4.4.0`, `juicebox-web` `master`
+(pinned to `#v4.3.0`) and `spacewalk` at `bump-juicebox-4.3.0` — the branch of
+its still-open v4.3.0 bump PR (spacewalk #91), whose only difference from `main`
+is the pin.
+
+**Result: nothing undeclared in use, in either consumer.** Third release running.
+
+### The v4.3.0 re-check: two of the four target-set names now have a caller
+
+The previous section asked that the four target-set names be re-checked here.
+juicebox-web's track menu landed (juicebox-web #81, *Send track loads to every
+targeted browser*) and calls **`loadTracksIntoTargets`** and
+**`targetedBrowsers`** from `js/trackLoad.js`. Those two are now ordinary members
+with a caller, and the question of whether the mechanism earned its declaration
+is answered.
+
+The other two — **`toggleTarget`** and the **`BrowserTargetChange`** event —
+still have no consumer caller. That is not the same reading as before. The
+gesture that toggles a target is library chrome, so a host never needs to call
+`toggleTarget` to get a target set (`js/layoutController.js` calls it); and
+juicebox-web reads the set at the moment a gesture needs it rather than
+subscribing to changes. Both are host-optional surface, and zero
+call sites is a stable reading for them, not a pending one.
+
+### The new declared name: `onSyncRefused`
+
+v4.4.0 adds one name to `COORDINATOR_CALLBACKS`, `onSyncRefused` (#626,
+ADR-0016). **No consumer registers it**, which is expected: it is new, and a
+host only needs it to put the refusal reason into its own UI — the library's own
+isolation mark (#637) already shows it on the panel. As with the target set in
+v4.3.0, zero call sites is the expected reading and is not evidence it is dead.
+
+`js/publicApi.js` also names, as deliberately *undeclared*, `isolationMark`,
+`setIsolationReason` and `dataset.missingChromosomes`. The measurement finds no
+consumer reaching for any of the three.
+
+### Consequence
+
+**Nothing was required of the release.** The payload's two `reason` spellings,
+`'no-compatible-peer'` and `'unresolved-chromosome'`, are declared above,
+including the one no longer emitted since #632, so a host that branches on
+either keeps working.

--- a/js/version.js
+++ b/js/version.js
@@ -1,2 +1,2 @@
-const version = "4.3.0"
+const version = "4.4.0"
 export {version}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juicebox.js",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juicebox.js",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "license": "MIT",
       "devDependencies": {
         "@vitest/ui": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juicebox.js",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "type": "module",
   "main": "./dist/juicebox.esm.js",
   "module": "./dist/juicebox.esm.js",


### PR DESCRIPTION
Release bump for **v4.4.0 — Sync Says Why**.

## Semver

**Minor.** `js/publicApi.js` gains one declared name, `onSyncRefused` in `COORDINATOR_CALLBACKS`, and loses none. The rest of its diff is a comment naming `isolationMark`, `setIsolationReason` and `dataset.missingChromosomes` as deliberately *undeclared*. Nothing a v4.3.0 host calls has changed meaning or spelling.

Not patch: `onSyncRefused` is new surface, and sync membership changes in a way a user sees. It is now settled once, at pair time, and no longer flickers as a panel pans (ADR-0016). Panels pair only on two-way chromosome parity, and a panel that cannot join any sync group shows an isolation mark saying why.

Not major: the one behavior loss is the intermittent partial sync ADR-0016 calls the bug. It is reported rather than silent, and no declared surface is removed.

## Verification (ceremony step 2)

- `npm run build`: clean
- `npm run test:run`: **68 files, 1242 tests, all passing**
- `npm run measure-consumers`: **nothing undeclared in use** in either consumer
- `npm pack --dry-run`: every `exports` target present in the tarball. `exports` is unchanged since v4.3.0, so this is a precaution.

## ADR-0003

Appended a dated re-measurement section:

- **The v4.3.0 re-check is answered.** juicebox-web (#81) now calls `loadTracksIntoTargets` and `targetedBrowsers`. `toggleTarget` and `BrowserTargetChange` still have no host caller, and that is expected to last: the toggle is library chrome, and juicebox-web reads the target set on demand instead of subscribing to changes.
- **`onSyncRefused` has no caller yet**, as expected for a new callback. The library's own isolation mark already shows the same reason on the panel.

Tag, release and the two consumer bump PRs follow once this lands. Note: spacewalk's v4.3.0 bump (spacewalk #91) is still open. Its v4.4.0 bump will supersede it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzRZQ16TkNuEPByCpAxczK
