### PR TITLE
Let the target badges win on specificity, not source order (#625)

### DIFF
--- a/css/juicebox.css
+++ b/css/juicebox.css
@@ -1310,20 +1310,26 @@ div[id$=content-container] div[id$=x-scrollbar-container] div[id$=x-axis-scrollb
   border-color: #5f5f5f;
 }
 
+/* The target badges are qualified with `.hic-root` (#625). An anchor also
+   carries `hic-root-selected`, and a host stylesheet loaded after this one may
+   redeclare a bare `.hic-root-selected` -- juicebox-web did. The extra class
+   lets the badges win on specificity, whatever order the host loads styles in.
+   Every element wearing a badge is a `.hic-root`, so the selectors match the
+   same panels as before. A host that wants to restyle a badge must match this
+   specificity too. */
+
 /* The target set (#615): a load reaches these panels. Deliberately a second
    class and a second visual, not the selected border -- a user still needs to
    see at a glance which panel the widgets are reading. */
-.hic-root-targeted {
+.hic-root.hic-root-targeted {
   outline: 3px dashed #3a8ab4;
   outline-offset: -3px;
 }
 
 /* The browser the aim starts from: current *and* explicitly targeted. Blue
    rather than the plain selected grey, so the first shift-click reads as the
-   head of a target set rather than as an ordinary selection. Declared after
-   `.hic-root-selected` -- an anchor carries both classes and equal
-   specificity, so source order decides the color. */
-.hic-root-target-anchor {
+   head of a target set rather than as an ordinary selection. */
+.hic-root.hic-root-target-anchor {
   border-color: #3a8ab4;
 }
 

--- a/css/juicebox.scss
+++ b/css/juicebox.scss
@@ -1193,20 +1193,26 @@ div[id$="content-container"] {
   border-color: #5f5f5f;
 }
 
+/* The target badges are qualified with `.hic-root` (#625). An anchor also
+   carries `hic-root-selected`, and a host stylesheet loaded after this one may
+   redeclare a bare `.hic-root-selected` -- juicebox-web did. The extra class
+   lets the badges win on specificity, whatever order the host loads styles in.
+   Every element wearing a badge is a `.hic-root`, so the selectors match the
+   same panels as before. A host that wants to restyle a badge must match this
+   specificity too. */
+
 /* The target set (#615): a load reaches these panels. Deliberately a second
    class and a second visual, not the selected border -- a user still needs to
    see at a glance which panel the widgets are reading. */
-.hic-root-targeted {
+.hic-root.hic-root-targeted {
   outline: 3px dashed #3a8ab4;
   outline-offset: -3px;
 }
 
 /* The browser the aim starts from: current *and* explicitly targeted. Blue
    rather than the plain selected grey, so the first shift-click reads as the
-   head of a target set rather than as an ordinary selection. Declared after
-   `.hic-root-selected` -- an anchor carries both classes and equal
-   specificity, so source order decides the color. */
-.hic-root-target-anchor {
+   head of a target set rather than as an ordinary selection. */
+.hic-root.hic-root-target-anchor {
   border-color: #3a8ab4;
 }
 .unselect {

--- a/dev/multi-browser-targeting.html
+++ b/dev/multi-browser-targeting.html
@@ -38,18 +38,6 @@
             margin: 8px 0;
         }
 
-        /* The badges the registry drives, exaggerated here so the four states --
-           plainly selected, the anchor of an aim, aimed at, neither -- are obvious
-           at a glance. The library's own rules are in css/juicebox.scss. */
-        .hic-root-targeted {
-            outline: 4px dashed #3a8ab4;
-            outline-offset: -4px;
-        }
-
-        .hic-root-target-anchor {
-            border-color: #3a8ab4;
-        }
-
         #panels {
             display: flex;
             flex-wrap: wrap;
@@ -118,6 +106,29 @@
     import hic from '../js/index.js'
     import EventBus from '../js/eventBus.js'
     import {devMapUrl} from '../dev-proxy/map-url.js'
+
+    // Page styles that must land after the library's. Importing js/index.js injects
+    // juicebox.scss at the end of <head>, so rules in the <style> above lose to it on
+    // source order; these are appended once the imports have run.
+    //
+    // - The badges the registry drives, exaggerated so the four states -- plainly
+    //   selected, the anchor of an aim, aimed at, neither -- are obvious at a glance.
+    //   The library qualifies its badges with .hic-root, so this does too.
+    // - A hostile host (#625): juicebox-web's app.scss redeclared .hic-root-selected
+    //   after juicebox.css. The anchor must stay blue anyway; if it turns grey, the
+    //   badge is winning on source order again.
+    const pageStyles = document.createElement('style')
+    pageStyles.textContent = `
+        .hic-root.hic-root-targeted {
+            outline: 4px dashed #3a8ab4;
+            outline-offset: -4px;
+        }
+
+        .hic-root-selected {
+            border-color: #5f5f5f;
+        }
+    `
+    document.head.appendChild(pageStyles)
 
     // Dev-only: routes .hic reads on hosts that answer localhost with a bot challenge
     // (encodeproject.org today) through the dev server's proxy. The mm10 panel below is

--- a/test/testBrowserTargeting.js
+++ b/test/testBrowserTargeting.js
@@ -13,8 +13,10 @@ import EventBus from '../js/eventBus.js'
  * The browsers are fabricated, as in `test/testBrowserRegistry.js`: the
  * registry reads only a handful of members off one, which is what makes it
  * constructible without a document. Per ADR-0013 the shift-click handler and
- * the badge get no automated test; the class the badge is keyed on is asserted
- * here because the registry is what applies it.
+ * the badge's rendering get no automated test; the class the badge is keyed on
+ * is asserted here because the registry is what applies it. Whether the badge
+ * rules survive a host stylesheet is a cascade question, pinned separately in
+ * `test/testTargetBadgeCascade.js`.
  */
 
 function fakeElement() {

--- a/test/testTargetBadgeCascade.js
+++ b/test/testTargetBadgeCascade.js
@@ -26,8 +26,8 @@ const compileScss = file => execFileSync(process.execPath,
     {encoding: 'utf8'})
 
 const libraryStylesheets = {
-    'css/juicebox.scss': () => compileScss(resolve(cssDir, 'juicebox.scss')),
-    'css/juicebox.css': () => readFileSync(resolve(cssDir, 'juicebox.css'), 'utf8'),
+    'css/juicebox.scss': compileScss(resolve(cssDir, 'juicebox.scss')),
+    'css/juicebox.css': readFileSync(resolve(cssDir, 'juicebox.css'), 'utf8'),
 }
 
 // A host stylesheet loaded after juicebox.css. The border rule is what
@@ -39,6 +39,7 @@ const hostileHost = `
 `
 
 const anchorBlue = 'rgb(58, 138, 180)'
+const selectedGrey = 'rgb(95, 95, 95)'
 
 // A fresh document per case: the library stylesheet, then the host's, then a
 // root div wearing the given classes.
@@ -50,21 +51,21 @@ function mount(libraryCss, classes) {
     return window.getComputedStyle(window.document.querySelector('div'))
 }
 
-describe.each(Object.entries(libraryStylesheets))('target badges in %s', (_, load) => {
+describe.each(Object.entries(libraryStylesheets))('target badges in %s', (_, libraryCss) => {
 
     it('keeps the anchor border blue when a host redeclares .hic-root-selected later', () => {
-        const style = mount(load(), 'hic-root hic-root-selected hic-root-target-anchor')
+        const style = mount(libraryCss, 'hic-root hic-root-selected hic-root-target-anchor')
         expect(style.borderTopColor).toBe(anchorBlue)
     })
 
     it('keeps the targeted outline when a host clears the outline on .hic-root-selected later', () => {
-        const style = mount(load(), 'hic-root hic-root-selected hic-root-targeted')
+        const style = mount(libraryCss, 'hic-root hic-root-selected hic-root-targeted')
         // jsdom keeps `outline` as a shorthand and never fills the longhands.
         expect(style.outline).toContain('dashed')
     })
 
     it('still paints a plain selection with the library grey', () => {
-        const style = mount(load(), 'hic-root hic-root-selected')
-        expect(style.borderTopColor).toBe('rgb(95, 95, 95)')
+        const style = mount(libraryCss, 'hic-root hic-root-selected')
+        expect(style.borderTopColor).toBe(selectedGrey)
     })
 })

--- a/test/testTargetBadgeCascade.js
+++ b/test/testTargetBadgeCascade.js
@@ -1,0 +1,70 @@
+/**
+ * The target badges must survive a host stylesheet (#625).
+ *
+ * juicebox.js is embedded, and every host controls its own stylesheet order.
+ * An anchor panel carries both `hic-root-selected` and `hic-root-target-anchor`;
+ * if the anchor rule wins only on source order, a host that redeclares a bare
+ * `.hic-root-selected` after juicebox.css silently turns the anchor grey again.
+ * juicebox-web did exactly that.
+ *
+ * Both shipped forms are checked: css/juicebox.scss (what the build compiles)
+ * and css/juicebox.css (the hand-synced copy dev pages link directly).
+ */
+
+import {describe, it, expect} from 'vitest'
+import {readFileSync} from 'node:fs'
+import {resolve} from 'node:path'
+import {execFileSync} from 'node:child_process'
+import {JSDOM} from 'jsdom'
+
+const cssDir = resolve(__dirname, '../css')
+
+// Compiled out of process: test/setup.js mocks a global `document`, and sass's
+// loader takes that for a browser and fails to start.
+const compileScss = file => execFileSync(process.execPath,
+    [resolve(__dirname, '../node_modules/sass/sass.js'), '--no-source-map', file],
+    {encoding: 'utf8'})
+
+const libraryStylesheets = {
+    'css/juicebox.scss': () => compileScss(resolve(cssDir, 'juicebox.scss')),
+    'css/juicebox.css': () => readFileSync(resolve(cssDir, 'juicebox.css'), 'utf8'),
+}
+
+// A host stylesheet loaded after juicebox.css. The border rule is what
+// juicebox-web's app.scss carried; the outline rule is its twin for the
+// targeted badge.
+const hostileHost = `
+.hic-root-selected { border-color: #5f5f5f; }
+.hic-root-selected { outline: none; }
+`
+
+const anchorBlue = 'rgb(58, 138, 180)'
+
+// A fresh document per case: the library stylesheet, then the host's, then a
+// root div wearing the given classes.
+function mount(libraryCss, classes) {
+    const {window} = new JSDOM(`<!DOCTYPE html><html><head>
+        <style>${libraryCss}</style>
+        <style>${hostileHost}</style>
+    </head><body><div class="${classes}"></div></body></html>`)
+    return window.getComputedStyle(window.document.querySelector('div'))
+}
+
+describe.each(Object.entries(libraryStylesheets))('target badges in %s', (_, load) => {
+
+    it('keeps the anchor border blue when a host redeclares .hic-root-selected later', () => {
+        const style = mount(load(), 'hic-root hic-root-selected hic-root-target-anchor')
+        expect(style.borderTopColor).toBe(anchorBlue)
+    })
+
+    it('keeps the targeted outline when a host clears the outline on .hic-root-selected later', () => {
+        const style = mount(load(), 'hic-root hic-root-selected hic-root-targeted')
+        // jsdom keeps `outline` as a shorthand and never fills the longhands.
+        expect(style.outline).toContain('dashed')
+    })
+
+    it('still paints a plain selection with the library grey', () => {
+        const style = mount(load(), 'hic-root hic-root-selected')
+        expect(style.borderTopColor).toBe('rgb(95, 95, 95)')
+    })
+})


### PR DESCRIPTION
Closes #625.

## What changed

- **Badge selectors qualified with `.hic-root`.** `.hic-root.hic-root-target-anchor` and `.hic-root.hic-root-targeted` are now `(0,2,0)`, so they beat a host's bare `.hic-root-selected` whatever order the host loads its stylesheets in. Changed in both `css/juicebox.scss` and the hand-synced `css/juicebox.css`. Every badged element already carries `hic-root`, so the selectors match the same panels as before. The source-order comment is rewritten.
- **`test/testTargetBadgeCascade.js`.** Builds a jsdom document with the library stylesheet and then a hostile host stylesheet, and checks the computed anchor border and targeted outline. Covers both the compiled scss and the css copy. It fails on master (4 of 6 cases) and passes here.
- **`dev/multi-browser-targeting.html` now plays the hostile host.** Its page styles moved into a `<style>` appended after the imports. Importing `js/index.js` injects `juicebox.scss` at the end of `<head>`, so the page's inline rules had always lost to it. That hid the bug on this page and quietly dropped its exaggerated 4px outline.

## Verification

- Full vitest suite: 69 files, 1248 tests, all passing (run before the review follow-up commit, which only touched test files).
- Chromium via Playwright on the dev page: the anchor's computed border is `rgb(58, 138, 180)` with the fix and `rgb(95, 95, 95)` without it.

## Spacewalk

Spacewalk sets `border-color: transparent` on `.hic-root` under an ID-qualified selector (`src/styles/_juicebox_panel.scss:87`, `src/styles/app.css:235`). That beats every badge, before and after this change. Spacewalk has one panel, so no aim can form there; it looks deliberate and is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012n3qTkreG6wUto4U7cL4gY