### PR TITLE
Move the punch list's consumer pins to v4.4.1

### DIFF
--- a/docs/juicebox-punch-list.md
+++ b/docs/juicebox-punch-list.md
@@ -1,6 +1,6 @@
 # Juicebox.js — Punch List
 
-**As of 2026-09-10, `v4.4.0`.** The architecture review closed at `v4.0.0` with eight of eleven
+**As of 2026-09-11, `v4.4.1`.** The architecture review closed at `v4.0.0` with eight of eleven
 candidates landed. The three left over are open issues, each waiting on a decision:
 [#580](https://github.com/aidenlab/juicebox.js/issues/580),
 [#581](https://github.com/aidenlab/juicebox.js/issues/581) and
@@ -27,8 +27,8 @@ sync-group and targeting work (ADR-0010 to ADR-0016), none of it a review candid
 
 Three repos are involved:
 - `~/JuiceboxDevelopment/juicebox.js`
-- `~/JuiceboxDevelopment/juicebox-web` — pinned `v4.4.0`
-- `~/SpacewalkDevelopment/spacewalk` — pinned `v4.4.0`
+- `~/JuiceboxDevelopment/juicebox-web` — pinned `v4.4.1`
+- `~/SpacewalkDevelopment/spacewalk` — pinned `v4.4.1`
 
 ---
 


### PR DESCRIPTION
Release-time walk of the three living docs for v4.4.1. Only the punch list was stale: its date and the two consumer pins (juicebox-web #83 and spacewalk #93, both merged). The review and the map still hold, because v4.4.1 changed no JS beyond `js/version.js`: `hicBrowser.js` is still 1753 lines and `browserRegistry.js` is still 799.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012n3qTkreG6wUto4U7cL4gY